### PR TITLE
fix: prop knowledge cache invalidates on upgrade; Workspace entry opens Home; index wait matches Storybook 10.5.10

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ npm packages and local source. Other frameworks get the classic panel; see
 ## Requirements
 
 - Node 20 or newer.
-- Storybook 10 or newer. In testing, Storybook 9.1 did not refresh its story index when a new file was written, so a generated story never appeared without a restart; `check` reports the installed version.
+- Storybook 10 or newer; 10.5.10 or newer recommended. In testing, 9.1 did not refresh its story index when a new file was written, and 10.5.5–10.5.6 stopped refreshing it after a while (a restart fixes it); 10.5.10 kept up. `check` reports the installed version.
 - A React + TypeScript design system for the full workspace.
 - An API key for Anthropic, OpenAI or Google Gemini.
 - For verification: `playwright` installed in your project with a browser downloaded (`npx playwright install chromium`). `axe-core` is optional and enables the accessibility check.

--- a/cli/check.ts
+++ b/cli/check.ts
@@ -20,6 +20,13 @@ import { resolveHostTooling, canLaunchBrowser } from '../story-generator/verify/
 import { closeBrowserSession } from '../story-generator/verify/browserSession.js';
 import { describeLaunchFailure } from '../story-generator/verify/verifyStory.js';
 
+/** a < b for dotted versions; prerelease tags ignored. */
+export function semverLt(a: string, b: string): boolean {
+  const pa = a.split('-')[0].split('.').map(Number); const pb = b.split('-')[0].split('.').map(Number);
+  for (let i = 0; i < 3; i++) { const x = pa[i] || 0, y = pb[i] || 0; if (x !== y) return x < y; }
+  return false;
+}
+
 export interface CheckItem {
   id: string;
   ok: boolean | null;
@@ -192,7 +199,11 @@ export async function runChecks(opts: { server?: string; cwd?: string } = {}): P
       id: 'storybook-version',
       ok: sbVersion ? major >= 10 : null,
       detail: sbVersion
-        ? (major >= 10 ? `Storybook ${sbVersion}` : `Storybook ${sbVersion} — new stories are not picked up live before 10; generated stories appear only after a restart`)
+        ? (major >= 10
+            ? (semverLt(sbVersion, '10.5.10')
+                ? `Storybook ${sbVersion} — works, but 10.5.5–10.5.6 stopped indexing new stories after a while in testing (a restart fixes it); 10.5.10 did not`
+                : `Storybook ${sbVersion}`)
+            : `Storybook ${sbVersion} — new stories are not picked up live before 10; generated stories appear only after a restart`)
         : 'Storybook is not installed in this project',
       fix: sbVersion && major < 10 ? 'npx storybook@latest upgrade' : undefined,
     });

--- a/cli/update.ts
+++ b/cli/update.ts
@@ -664,6 +664,7 @@ export async function updateCommand(options: UpdateOptions = {}): Promise<Update
   if (filesToUpdate.length === 0) {
     wireStorybookEntries();
     console.log(chalk.green('\n✅ All files are already up to date!'));
+    console.log(chalk.gray('   If Storybook is running, restart it — and clear node_modules/.vite and node_modules/.cache/storybook first, so Vite does not keep two copies of the old bundle.'))
     result.success = result.errors.length === 0;
     return result;
   }
@@ -751,6 +752,7 @@ export async function updateCommand(options: UpdateOptions = {}): Promise<Update
 
   if (result.success && !options.dryRun) {
     console.log(chalk.green('\n✅ Story UI updated successfully!'));
+  console.log(chalk.gray('   Restart Storybook to pick this up. Clear node_modules/.vite and node_modules/.cache/storybook first — Vite keeps two copies of the old bundle otherwise ("Illegal invocation" in the preview).'));
     console.log(chalk.gray('   Restart Storybook to see the changes.'));
   }
 

--- a/story-generator/knowledge/propExtractor.ts
+++ b/story-generator/knowledge/propExtractor.ts
@@ -1318,7 +1318,7 @@ function collectPropTypes(source: ts.SourceFile, out: Record<string, ComponentFa
  *    exported component rather than a `<Name>Props` convention; a path given
  *    as the package no longer reads node_modules.
  */
-const EXTRACTOR_SCHEMA = 5;
+const EXTRACTOR_SCHEMA = 6 // 6: OverridableStringUnion literals; caches written before it hid MUI's variant/color/size;
 
 /**
  * Keyed on version AND a content fingerprint (`knowledge/cacheKey`).

--- a/story-generator/verify/renderHarness.ts
+++ b/story-generator/verify/renderHarness.ts
@@ -330,7 +330,7 @@ export async function indexIsStale(
     return { stale: false, onDisk, indexed: 0 };
   }
 
-  return { stale: onDisk > indexed, onDisk, indexed };
+  return { stale: onDisk - indexed > 1, onDisk, indexed };
 }
 
 export async function waitForStoryIndexed(

--- a/story-generator/verify/verifyStory.ts
+++ b/story-generator/verify/verifyStory.ts
@@ -266,7 +266,10 @@ export async function verifyStory(options: VerifyStoryOptions): Promise<VerifyRe
 
   // The story has to be in the index before it can be rendered by id. This also
   // separates "generated badly" from "Storybook never noticed the file".
-  const indexed = await waitForStoryIndexed(storybookUrl, storyIdPrefix, Math.min(10000, timeoutMs), 250, title);
+  // Storybook 10.5.10 indexes a new file reliably but not instantly: with a
+  // 10s wait, two of three stories were declared "index behind" and never
+  // verified, then appeared a moment later. 30s, bounded by the budget.
+  const indexed = await waitForStoryIndexed(storybookUrl, storyIdPrefix, Math.min(30000, timeoutMs), 250, title);
   if (!indexed.indexed || !indexed.storyId) {
     // Down, stale watcher, or not picked up yet? Reachability and the counts
     // answer it, and the three need different responses from whoever reads

--- a/templates/StoryUIV2/StoryUIV2.mdx
+++ b/templates/StoryUIV2/StoryUIV2.mdx
@@ -64,6 +64,11 @@ export const Mount = () => {
   useEffect(() => {
     if (!tabRoute) return;
     try {
+      // The sidebar entry means "take me to the workspace", not "resume the
+      // story I had open": clear the remembered story so the page opens on
+      // Home. A reload mid-work still restores the story, because nothing
+      // clears the key on that path.
+      try { sessionStorage.removeItem('story-ui-v2-active'); } catch {}
       const target = `${window.location.origin}/?path=${tabRoute}`;
       if (window.top && window.top.location.href !== target) window.top.location.href = target;
     } catch { /* cross-origin host: fall through to the inline workspace */ }


### PR DESCRIPTION
- MUI's Button offered one editable prop after upgrading: the knowledge cache written by 4.x hid the extractor's newer facts. The schema version is bumped so caches rebuild on upgrade (color/size/variant come back).
- The Workspace sidebar entry now opens Home rather than resuming the last story; a reload mid-work still resumes.
- Storybook 10.5.10 indexes a new file reliably but not within 10s; the wait is 30s and one file ahead is no longer called a stalled watcher.
- check recommends 10.5.10+ (10.5.5–10.5.6 stalled in testing); update tells you to restart Storybook with a cleared Vite cache.

Merging publishes 5.0.2.

https://claude.ai/code/session_0158a8zxX4SKPdxm7DLfgqp4