### PR TITLE
fix: canvas scope matches the catalog; panel waits for the server; deleted titles are free again

### DIFF
--- a/__tests__/canvas-scope-and-versions.test.ts
+++ b/__tests__/canvas-scope-and-versions.test.ts
@@ -1,0 +1,135 @@
+import { describe, it, expect } from 'vitest';
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import { unknownCanvasComponents, voiceCanvasStorySource } from '../mcp-server/routes/canvasGenerate.js';
+import { componentImportLines, jsxCodeToStory } from '../mcp-server/routes/canvasSave.js';
+import { importSpecifierFor, importHomeResolver } from '../story-generator/knowledge/importSpecifier.js';
+import { StoryTracker } from '../story-generator/storyTracker.js';
+
+describe('canvas scope check', () => {
+  const known = ['Button', 'Card', 'Text', 'Badge'];
+
+  it('names the tags the design system does not have', () => {
+    const code = `const Canvas = () => (
+  <Card>
+    <Card.Section><Text>Hi</Text></Card.Section>
+    <BrandBadge tone="new" />
+    <PriceTag>$4</PriceTag>
+    <div className="x"><Button>Go</Button></div>
+  </Card>
+);
+render(<Canvas />);`;
+    expect(unknownCanvasComponents(code, known)).toEqual(['BrandBadge', 'PriceTag']);
+  });
+
+  it('accepts components the canvas defines itself, React builtins and HTML', () => {
+    const code = `const Row = ({ children }) => <div>{children}</div>;
+function Tile() { return <Badge>1</Badge>; }
+const Canvas = () => <React.Fragment><Fragment><Row><Tile /></Row></Fragment></React.Fragment>;
+render(<Canvas />);`;
+    expect(unknownCanvasComponents(code, known)).toEqual([]);
+  });
+
+  it('reports nothing when discovery knows nothing — absent is not zero', () => {
+    // The caller skips the check entirely for an empty catalog; the predicate
+    // itself still answers honestly.
+    expect(unknownCanvasComponents('<Whatever />', [])).toEqual(['Whatever']);
+  });
+});
+
+describe('canvas save import lines', () => {
+  it('groups components by the module discovery places them in', () => {
+    const resolve = (name: string) => ({
+      Button: { specifier: '../../components/Button/Button', defaultExport: false },
+      Card: { specifier: '../../components/Card/Card', defaultExport: false },
+      CardHeader: { specifier: '../../components/Card/Card', defaultExport: false },
+      Avatar: { specifier: '@acme/avatar', defaultExport: true },
+    } as Record<string, { specifier: string; defaultExport: boolean }>)[name];
+    expect(componentImportLines(['Avatar', 'Button', 'Card', 'CardHeader', 'Mystery'], '@acme/ui', resolve)).toEqual([
+      "import { Button } from '../../components/Button/Button';",
+      "import { Card, CardHeader } from '../../components/Card/Card';",
+      "import { Mystery } from '@acme/ui';",
+      "import Avatar from '@acme/avatar';",
+    ]);
+  });
+
+  it('falls back to the base path when no resolver is given', () => {
+    const story = jsxCodeToStory(`const Canvas = () => <Card><Text>Hi</Text></Card>;\nrender(<Canvas />);`, 'Hi', '@mantine/core');
+    expect(story).toContain("import { Card, Text } from '@mantine/core';");
+  });
+});
+
+describe('import specifier precedence', () => {
+  it('prefers the declared path, then discovery, then a local file, then the base path', () => {
+    const dir = fs.realpathSync(fs.mkdtempSync(path.join(os.tmpdir(), 'spec-')));
+    const file = path.join(dir, 'src', 'components', 'Tile.tsx');
+    fs.mkdirSync(path.dirname(file), { recursive: true });
+    fs.writeFileSync(file, 'export const Tile = () => null;');
+    const cwd = process.cwd();
+    process.chdir(dir);
+    try {
+      const config: any = {
+        importPath: '@acme/ui',
+        generatedStoriesPath: './src/stories/generated/',
+        components: [{ name: 'Declared', importPath: '@acme/ui/declared' }],
+      };
+      expect(importSpecifierFor({ name: 'Declared', filePath: file } as any, config)).toBe('@acme/ui/declared');
+      expect(importSpecifierFor({ name: 'Sub', filePath: '', __componentPath: '@acme/ui/sub' } as any, config)).toBe('@acme/ui/sub');
+      expect(importSpecifierFor({ name: 'Tile', filePath: file } as any, config)).toBe('../../components/Tile');
+      expect(importSpecifierFor({ name: 'Button', filePath: '' } as any, config)).toBe('@acme/ui');
+      const resolve = importHomeResolver([{ name: 'Tile', filePath: file } as any], config);
+      expect(resolve('Tile')).toEqual({ specifier: '../../components/Tile', defaultExport: false });
+      expect(resolve('Nope')).toBeUndefined();
+    } finally {
+      process.chdir(cwd);
+    }
+  });
+});
+
+describe('story titles after deletion', () => {
+  it('frees a title whose file is gone instead of versioning past it', () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'tracker-'));
+    const stories = path.join(dir, 'generated');
+    fs.mkdirSync(stories);
+    const tracker = new StoryTracker({ generatedStoriesPath: stories } as any);
+    const mapping = (title: string, fileName: string) => ({
+      title, fileName, storyId: fileName, hash: 'h', prompt: title, createdAt: '', updatedAt: '',
+    });
+    fs.writeFileSync(path.join(stories, 'profile-card.stories.tsx'), '');
+    tracker.registerStory(mapping('Profile Card', 'profile-card.stories.tsx'));
+    expect(tracker.getNextVersionTitle('Profile Card')).toBe('Profile Card v2');
+
+    fs.unlinkSync(path.join(stories, 'profile-card.stories.tsx'));
+    expect(tracker.getNextVersionTitle('Profile Card')).toBe('Profile Card');
+    expect(JSON.parse(fs.readFileSync(path.join(dir, '.story-mappings.json'), 'utf8'))).toEqual([]);
+  });
+});
+
+describe('voice canvas scope', () => {
+  it('imports the catalog from where each component lives and never a path it does not know', () => {
+    const config: any = { importPath: '@acme/ui', generatedStoriesPath: './src/stories/generated/', importStyle: 'individual' };
+    const source = voiceCanvasStorySource(config, [
+      { name: 'Button', filePath: '', __componentPath: '@acme/ui/button' },
+      { name: 'Card', filePath: '', __componentPath: '@acme/ui/card' },
+      { name: 'CardHeader', filePath: '', __componentPath: '@acme/ui/card' },
+      { name: 'Avatar', filePath: '', __componentPath: '@acme/avatar', __defaultExport: true },
+      { name: 'Ghost', filePath: '' },
+      { name: 'not-a-component', filePath: '' },
+    ] as any);
+    expect(source).toContain("import * as __sui0 from '@acme/ui/button';");
+    expect(source).toContain("import * as __sui1 from '@acme/ui/card';");
+    expect(source).toContain('...pick(__sui1, ["Card","CardHeader"], []),');
+    expect(source).toContain('...pick(__sui2, [], ["Avatar"]),');
+    expect(source).not.toContain('Ghost');
+    expect(source).not.toContain('__STORY_UI_CATALOG_IMPORTS__');
+    expect(source).toContain('...catalog,\n  ...designSystem,');
+  });
+
+  it('is stable for the same catalog, so the story file is only rewritten on change', () => {
+    const config: any = { importPath: '@mantine/core', generatedStoriesPath: './src/stories/generated/' };
+    const comps: any = [{ name: 'Button', filePath: '' }, { name: 'Text', filePath: '' }];
+    expect(voiceCanvasStorySource(config, comps)).toBe(voiceCanvasStorySource(config, comps));
+    expect(voiceCanvasStorySource(config, comps)).toContain('...pick(__sui0, ["Button","Text"], []),');
+  });
+});

--- a/cli/update.ts
+++ b/cli/update.ts
@@ -663,6 +663,12 @@ export async function updateCommand(options: UpdateOptions = {}): Promise<Update
 
   if (filesToUpdate.length === 0) {
     wireStorybookEntries();
+    // The version stamp records which release the project was last brought
+    // up to, and a project whose files were already current never got it —
+    // a 5.0.0 project kept reading `_storyUIVersion: '4.17.0'`.
+    if (!options.dryRun && installation.configPath) {
+      updateConfigVersion(installation.configPath, result.newVersion);
+    }
     console.log(chalk.green('\n✅ All files are already up to date!'));
     console.log(chalk.gray('   If Storybook is running, restart it — and clear node_modules/.vite and node_modules/.cache/storybook first, so Vite does not keep two copies of the old bundle.'))
     result.success = result.errors.length === 0;

--- a/mcp-server/routes/canvasGenerate.ts
+++ b/mcp-server/routes/canvasGenerate.ts
@@ -23,13 +23,59 @@ import { promisify } from 'util';
 const execAsync = promisify(exec);
 import { loadUserConfig } from '../../story-generator/configLoader.js';
 import { EnhancedComponentDiscovery } from '../../story-generator/enhancedComponentDiscovery.js';
+import type { DiscoveredComponent } from '../../story-generator/componentDiscovery.js';
+import type { StoryUIConfig } from '../../story-ui.config.js';
+import { importSpecifierFor } from '../../story-generator/knowledge/importSpecifier.js';
 import { buildFrameworkAwarePrompt } from '../../story-generator/promptGenerator.js';
 import { chatCompletionDetailed, chatCompletionStream } from '../../story-generator/llm-providers/story-llm-service.js';
 import { logger } from '../../story-generator/logger.js';
 
 // ── Component discovery cache ─────────────────────────────────
-let _componentCache: { components: any[]; timestamp: number } | null = null;
+let _componentCache: { components: DiscoveredComponent[]; timestamp: number } | null = null;
 const COMPONENT_CACHE_TTL = 300_000; // 5 minutes
+
+/** The design-system catalog the canvas draws from, shared with canvas save. */
+export async function getCanvasComponents(config: StoryUIConfig): Promise<DiscoveredComponent[]> {
+  const now = Date.now();
+  if (_componentCache && now - _componentCache.timestamp < COMPONENT_CACHE_TTL) {
+    return _componentCache.components;
+  }
+  const discovery = new EnhancedComponentDiscovery(config);
+  const components = await discovery.discoverAll();
+  _componentCache = { components, timestamp: now };
+  return components;
+}
+
+// ── Scope check ───────────────────────────────────────────────
+
+/**
+ * JSX tags the canvas uses that neither the design system nor the code itself
+ * defines. The canvas scope is exactly the design-system module plus React,
+ * so any other capitalised tag is a ReferenceError at render — observed as
+ * `BrandBadge is not defined`, painted red where the preview should be, and
+ * then saved as a story importing `BrandBadge` from a package that has no
+ * such export. The sanitizer only ever looked for dangerous APIs; nothing
+ * asked whether the components exist.
+ */
+export function unknownCanvasComponents(code: string, known: Iterable<string>): string[] {
+  const available = new Set(known);
+  for (const m of code.matchAll(/\b(?:const|let|var|function|class)\s+([A-Z][A-Za-z0-9_]*)/g)) available.add(m[1]);
+  for (const m of code.matchAll(/\bimport\s+(?:\{([^}]*)\}|([A-Z][A-Za-z0-9_]*))/g)) {
+    for (const n of (m[1] ?? m[2] ?? '').split(',')) {
+      const local = n.trim().split(/\s+as\s+/).pop()?.trim();
+      if (local) available.add(local);
+    }
+  }
+  for (const builtin of ['React', 'Fragment', 'Canvas', 'Suspense', 'Profiler', 'StrictMode']) available.add(builtin);
+  const unknown = new Set<string>();
+  for (const m of code.matchAll(/<([A-Z][A-Za-z0-9_]*)(?:\.[A-Za-z0-9_]+)*[\s/>]/g)) {
+    if (!available.has(m[1])) unknown.add(m[1]);
+  }
+  return [...unknown];
+}
+
+const describeUnknown = (names: string[], importPath: string): string =>
+  `${names.join(', ')} ${names.length === 1 ? 'is not a component' : 'are not components'} in ${importPath || 'your design system'}.`;
 
 // ── Constants ─────────────────────────────────────────────────
 export const VOICE_CANVAS_STORY_ID = 'generated-voice-canvas--default';
@@ -92,9 +138,12 @@ import type { Meta, StoryObj } from '@storybook/react';
 const meta: Meta = { title: 'Generated/Voice Canvas', tags: ['voice-canvas-internal'] };
 export default meta;
 
+__STORY_UI_CATALOG_IMPORTS__
+
 // Design system components set by .storybook/preview.tsx via:
 //   (window as any).__STORY_UI_DESIGN_SYSTEM__ = YourDesignSystemModule;
-// Works with any React component library (Mantine, Chakra, MUI, shadcn, etc.)
+// Optional: the catalog above already covers every discovered component;
+// this hook adds anything discovery does not know, and wins on a name clash.
 const designSystem = (window as any).__STORY_UI_DESIGN_SYSTEM__ || {};
 
 // Module-level scope — created once, never recreated, so react-live
@@ -108,6 +157,7 @@ const scope = {
   useRef: React.useRef,
   useReducer: React.useReducer,
   useContext: React.useContext,
+  ...catalog,
   ...designSystem,
 };
 
@@ -213,35 +263,67 @@ export class ReactLiveMissingError extends Error {
  * Write the static voice-canvas story template if it doesn't exist yet.
  * Subsequent calls are no-ops — the file never changes after initial creation.
  */
-export function ensureVoiceCanvasStory(storiesDir: string): void {
-  /**
-   * Only when the project can actually compile it.
-   *
-   * This template imports `react-live`. Writing it into a project that does
-   * not have that dependency breaks the whole Storybook with a Vite overlay —
-   * not just this story — because the dev server fails to resolve the import
-   * and stops rendering anything. Observed on a Carbon project: every
-   * generated story was fine, and the workspace was unusable.
-   *
-   * The existing guard checked the FRAMEWORK, which answers a different
-   * question. React projects that have never installed react-live are the
-   * common case, not the exception, so the guard passed exactly where it
-   * needed to fail. Ask for the dependency itself.
-   */
-  if (!reactLiveIsInstalled()) {
-    logger.log('[canvas-generate] Skipping voice-canvas template — react-live is not installed in this project');
-    return;
-  }
-
+export function ensureVoiceCanvasStory(storiesDir: string, source: string): void {
   const resolvedDir = path.resolve(process.cwd(), storiesDir);
   if (!fs.existsSync(resolvedDir)) {
     fs.mkdirSync(resolvedDir, { recursive: true });
   }
   const filePath = path.resolve(resolvedDir, VOICE_CANVAS_STORY_FILE);
-  if (!fs.existsSync(filePath)) {
-    fs.writeFileSync(filePath, VOICE_CANVAS_TEMPLATE, 'utf-8');
-    logger.log('[canvas-generate] Created voice-canvas story template');
+  // Rewritten whenever the catalog changes, so a component added to the
+  // project is in scope on the next command — not on the next fresh install.
+  let current: string | null = null;
+  try { current = fs.readFileSync(filePath, 'utf-8'); } catch { /* absent */ }
+  if (current === source) return;
+  fs.writeFileSync(filePath, source, 'utf-8');
+  logger.log(`[canvas-generate] ${current === null ? 'Created' : 'Updated'} voice-canvas story (${source.split('\n').length} lines)`);
+}
+
+/**
+ * The voice-canvas story, with the catalog in scope.
+ *
+ * The scope used to be whatever `.storybook/preview.tsx` put on
+ * `window.__STORY_UI_DESIGN_SYSTEM__` — the npm module and nothing else —
+ * while the prompt offered every discovered component, local ones included.
+ * A project's own `BrandBadge` was in the catalog, chosen by the model, and
+ * a ReferenceError on the canvas. Now the story imports each discovered
+ * component from where the project says it lives (the same rule the prompt
+ * and the story pipeline use), so what the model is offered is what renders.
+ *
+ * Namespace imports, not named ones: a name discovery got wrong would make a
+ * named import fail at build time and take the whole canvas with it. Through
+ * a namespace a missing export is simply absent from scope, and the scope
+ * check names it.
+ */
+export function voiceCanvasStorySource(config: StoryUIConfig, components: DiscoveredComponent[]): string {
+  const byModule = new Map<string, { named: string[]; defaults: string[] }>();
+  const seen = new Set<string>();
+  for (const component of components) {
+    if (!/^[A-Z][A-Za-z0-9_]*$/.test(component.name) || seen.has(component.name)) continue;
+    if (/\.(vue|svelte)$/.test(component.filePath || '')) continue;
+    const specifier = importSpecifierFor(component, config);
+    if ((component as any).__importPathUnknown === true) continue;
+    if (!specifier || specifier === 'unknown' || /['"\\\n\r]/.test(specifier)) continue;
+    seen.add(component.name);
+    const group = byModule.get(specifier) ?? { named: [], defaults: [] };
+    ((component as any).__defaultExport === true ? group.defaults : group.named).push(component.name);
+    byModule.set(specifier, group);
   }
+  const modules = [...byModule.entries()];
+  const imports = modules.map(([specifier], i) => `import * as __sui${i} from '${specifier}';`);
+  const picks = modules.map(([, g], i) => `  ...pick(__sui${i}, ${JSON.stringify(g.named)}, ${JSON.stringify(g.defaults)}),`);
+  const block = [
+    '// The component catalog, imported from where the project says each one',
+    '// lives — generated from discovery by Story UI; edits are overwritten.',
+    ...imports,
+    'const pick = (ns: Record<string, unknown>, named: string[], defaults: string[]): Record<string, unknown> => ({',
+    '  ...Object.fromEntries(named.filter(n => ns[n] !== undefined).map(n => [n, ns[n]])),',
+    "  ...Object.fromEntries(defaults.filter(() => ns.default !== undefined).map(n => [n, ns.default])),",
+    '});',
+    'const catalog: Record<string, unknown> = {',
+    ...picks,
+    '};',
+  ].join('\n');
+  return VOICE_CANVAS_TEMPLATE.replace('__STORY_UI_CATALOG_IMPORTS__', block);
 }
 
 // ── Code extraction ───────────────────────────────────────────
@@ -376,6 +458,35 @@ export function sanitizeCanvasCode(code: string): string {
   return sanitized;
 }
 
+/**
+ * One correction round when the canvas names components that do not exist —
+ * the same shape as the story pipeline's healing loop, with the catalog as
+ * the instruction. Returns the code and whatever is STILL unknown; the caller
+ * refuses to ship a canvas that will not render rather than let react-live
+ * report the ReferenceError.
+ */
+async function healUnknownComponents(
+  code: string,
+  rawResponse: string,
+  messages: Array<{ role: 'system' | 'user' | 'assistant'; content: string }>,
+  known: string[],
+  importPath: string,
+  llm: { provider: any; model: any },
+): Promise<{ code: string; unknown: string[] }> {
+  const unknown = unknownCanvasComponents(code, known);
+  if (unknown.length === 0 || known.length === 0) return { code, unknown: [] };
+  logger.warn(`[canvas-generate] Unknown components ${unknown.join(', ')} — asking for a correction`);
+  const correction = `${describeUnknown(unknown, importPath)} The canvas can only use the components listed ` +
+    `in "Available Components" above, plus plain HTML elements. Rewrite the canvas without ${unknown.join(', ')}: ` +
+    `build the same thing from components that exist. Return the complete corrected code only.`;
+  const retry = await chatCompletionDetailed(
+    [...messages, { role: 'assistant', content: rawResponse }, { role: 'user', content: correction }],
+    { provider: llm.provider, model: llm.model, maxTokens: 4096, temperature: 0.3 },
+  );
+  const healed = sanitizeCanvasCode(extractCanvasCode(retry.content));
+  return { code: healed, unknown: unknownCanvasComponents(healed, known) };
+}
+
 // ── Handler ───────────────────────────────────────────────────
 
 export async function canvasGenerateHandler(req: Request, res: Response) {
@@ -424,21 +535,14 @@ export async function canvasGenerateHandler(req: Request, res: Response) {
         error: `Voice Canvas is only available for React-based Storybook projects. Current framework: ${config.componentFramework}`,
       });
     }
-    let components: any[];
-    const now = Date.now();
-    if (_componentCache && now - _componentCache.timestamp < COMPONENT_CACHE_TTL) {
-      components = _componentCache.components;
-    } else {
-      const discovery = new EnhancedComponentDiscovery(config);
-      components = await discovery.discoverAll();
-      _componentCache = { components, timestamp: now };
-    }
+    const components = await getCanvasComponents(config);
 
     // Build the system prompt through the SAME adapter-driven pipeline as
     // standard generation (component reference, docs, considerations, custom
     // local components) — the canvas suffix then overrides the output format.
     const baseSystemPrompt = await buildFrameworkAwarePrompt(prompt, config, components, { framework: 'react' });
     const systemPrompt = baseSystemPrompt + '\n' + CANVAS_MODE_SUFFIX;
+    const knownNames = components.map(c => c.name);
 
     // Build the user message — include current canvas code for edit requests
     let userMessage = prompt;
@@ -466,7 +570,7 @@ export async function canvasGenerateHandler(req: Request, res: Response) {
       throw err;
     }
     const storiesDir = config.generatedStoriesPath || './src/stories/generated/';
-    ensureVoiceCanvasStory(storiesDir);
+    ensureVoiceCanvasStory(storiesDir, voiceCanvasStorySource(config, components));
 
     // Streaming mode: emit raw LLM text deltas over SSE so the canvas can show
     // the code being written in real time, then a final `complete` event with
@@ -491,7 +595,13 @@ export async function canvasGenerateHandler(req: Request, res: Response) {
         }
 
         const rawCode = extractCanvasCode(fullResponse);
-        const result = sanitizeCanvasCode(rawCode);
+        const healed = await healUnknownComponents(sanitizeCanvasCode(rawCode), fullResponse, messages, knownNames, config.importPath || '', { provider, model });
+        if (healed.unknown.length > 0) {
+          res.write(`event: error\ndata: ${JSON.stringify({ error: `${describeUnknown(healed.unknown, config.importPath || '')} Try naming a component that exists, or describe the element instead.`, code: 'UNKNOWN_COMPONENTS', components: healed.unknown })}\n\n`);
+          res.end();
+          return;
+        }
+        const result = healed.code;
         logger.log(`[canvas-generate] Streamed ${result.split('\n').length} lines for: "${prompt.slice(0, 60)}"`);
         res.write(`event: complete\ndata: ${JSON.stringify({ canvasCode: result, storyId: VOICE_CANVAS_STORY_ID })}\n\n`);
       } catch (streamError) {
@@ -520,7 +630,15 @@ export async function canvasGenerateHandler(req: Request, res: Response) {
     // injection, prototype pollution, etc.) before the code reaches the
     // client where react-live would execute it as arbitrary JS.
     const rawCode = extractCanvasCode(response.content);
-    const result = sanitizeCanvasCode(rawCode);
+    const healed = await healUnknownComponents(sanitizeCanvasCode(rawCode), response.content, messages, knownNames, config.importPath || '', { provider, model });
+    if (healed.unknown.length > 0) {
+      return res.status(422).json({
+        error: `${describeUnknown(healed.unknown, config.importPath || '')} Try naming a component that exists, or describe the element instead.`,
+        code: 'UNKNOWN_COMPONENTS',
+        components: healed.unknown,
+      });
+    }
+    const result = healed.code;
 
     logger.log(`[canvas-generate] Generated ${result.split('\n').length} lines for: "${prompt.slice(0, 60)}"`);
 

--- a/mcp-server/routes/canvasSave.ts
+++ b/mcp-server/routes/canvasSave.ts
@@ -15,6 +15,8 @@ import path from 'path';
 import { loadUserConfig } from '../../story-generator/configLoader.js';
 import { logger } from '../../story-generator/logger.js';
 import { getManifestManager } from '../../story-generator/manifestManager.js';
+import { importHomeResolver, type ImportHome } from '../../story-generator/knowledge/importSpecifier.js';
+import { getCanvasComponents } from './canvasGenerate.js';
 
 interface ComponentNodeInput {
   id?: string;
@@ -145,13 +147,49 @@ ${jsx}
 `;
 }
 
+/**
+ * One import line per module, from what discovery knows about each
+ * component. A name discovery does not know falls back to the base path:
+ * the canvas rendered it, so the design-system scope had it, and the base
+ * path is the only module that scope is built from. That fallback used to be
+ * the whole rule, which imported a local design system's components from a
+ * barrel that did not export them.
+ */
+export function componentImportLines(
+  names: string[],
+  importPath: string,
+  resolveImport?: (name: string) => ImportHome | undefined,
+): string[] {
+  const named = new Map<string, string[]>();
+  const defaults: Array<{ name: string; specifier: string }> = [];
+  for (const name of names) {
+    const home = resolveImport?.(name);
+    const specifier = home?.specifier || importPath;
+    if (!specifier) continue;
+    if (home?.defaultExport) {
+      defaults.push({ name, specifier });
+    } else {
+      named.set(specifier, [...(named.get(specifier) ?? []), name]);
+    }
+  }
+  const lines: string[] = [];
+  for (const [specifier, list] of named) lines.push(`import { ${list.join(', ')} } from '${specifier}';`);
+  for (const { name, specifier } of defaults) lines.push(`import ${name} from '${specifier}';`);
+  return lines;
+}
+
 // ── JSX save (react-live canvas) ─────────────────────────────
 
 /**
  * Convert a react-live canvas component (JSX string) to a proper .stories.tsx file.
  * The input is in the format: `const Canvas = () => { ... }; render(<Canvas />);`
  */
-export function jsxCodeToStory(jsxCode: string, title: string, importPath: string): string {
+export function jsxCodeToStory(
+  jsxCode: string,
+  title: string,
+  importPath: string,
+  resolveImport?: (name: string) => ImportHome | undefined,
+): string {
   // Remove the render(<Canvas />) call at the end
   let cleanCode = jsxCode.replace(/\nrender\s*\(<Canvas\s*\/>\);?\s*$/, '').trim();
 
@@ -177,9 +215,7 @@ export function jsxCodeToStory(jsxCode: string, title: string, importPath: strin
   const needsReactImport = /\bReact\./.test(cleanCode);
 
   const lines: string[] = [];
-  if (sortedComponents.length > 0 && importPath) {
-    lines.push(`import { ${sortedComponents.join(', ')} } from '${importPath}';`);
-  }
+  lines.push(...componentImportLines(sortedComponents, importPath, resolveImport));
   if (needsReactImport) {
     lines.push(`import React${usedHooks.length > 0 ? `, { ${usedHooks.join(', ')} }` : ''} from 'react';`);
   } else if (usedHooks.length > 0) {
@@ -257,7 +293,13 @@ export async function canvasSaveHandler(req: Request, res: Response) {
 
     if (jsxCode && typeof jsxCode === 'string' && jsxCode.trim()) {
       // New path: save from react-live canvas JSX
-      code = jsxCodeToStory(jsxCode, title, importPath);
+      let resolveImport: ((name: string) => ImportHome | undefined) | undefined;
+      try {
+        resolveImport = importHomeResolver(await getCanvasComponents(config), config);
+      } catch (err) {
+        logger.warn(`[canvas-save] Discovery unavailable; importing from ${importPath}: ${err instanceof Error ? err.message : String(err)}`);
+      }
+      code = jsxCodeToStory(jsxCode, title, importPath, resolveImport);
     } else if (tree?.root && Array.isArray(tree.root)) {
       // Legacy path: save from JSON component tree
       const framework = config.componentFramework || 'react';

--- a/story-generator/framework-adapters/base-adapter.ts
+++ b/story-generator/framework-adapters/base-adapter.ts
@@ -11,12 +11,11 @@ import {
   StoryFramework,
   FrameworkAdapter,
   StoryGenerationOptions, CatalogFocus } from './types.js';
-import * as fs from 'fs';
-import * as nodePath from 'path';
 import { StoryUIConfig } from '../../story-ui.config.js';
 import { DiscoveredComponent } from '../componentDiscovery.js';
 import { logger } from '../logger.js';
 import { saysMoreThanName } from '../knowledge/descriptionQuality.js';
+import { importSpecifierFor, localImportSpecifier } from '../knowledge/importSpecifier.js';
 
 /**
  * Abstract Base Framework Adapter
@@ -213,22 +212,14 @@ export abstract class BaseFrameworkAdapter implements FrameworkAdapter {
   }
 
   /**
-   * Relative import path for components discovered from local project files
-   * (custom, non-npm component libraries). Null for npm package components.
+   * The relative import path for a component discovered from local source.
+   * Null for npm package components. See knowledge/importSpecifier.ts.
    */
   protected getLocalImportPath(
     component: DiscoveredComponent,
     config: StoryUIConfig
   ): string | null {
-    const filePath = component.filePath;
-    if (!filePath || filePath.includes('node_modules')) return null;
-    if (!nodePath.isAbsolute(filePath) || !fs.existsSync(filePath)) return null;
-
-    const generatedDir = nodePath.resolve(process.cwd(), config.generatedStoriesPath || './src/stories/generated/');
-    let relative = nodePath.relative(generatedDir, filePath).split(nodePath.sep).join('/');
-    relative = relative.replace(/\.(tsx|jsx|ts|js|vue|svelte)$/, '');
-    if (!relative.startsWith('.')) relative = './' + relative;
-    return relative;
+    return localImportSpecifier(component, config);
   }
 
   /**
@@ -332,71 +323,14 @@ export abstract class BaseFrameworkAdapter implements FrameworkAdapter {
   }
 
   /**
-   * Get the import path for a component
+   * The module a story imports a component from — the project's own answer,
+   * shared with every other writer of import lines (knowledge/importSpecifier.ts).
    */
   protected getImportPath(
     component: DiscoveredComponent,
     config: StoryUIConfig
   ): string {
-    // What the PROJECT says, before anything we infer.
-    //
-    // story-ui.config.js can declare each component with its real import
-    // specifier, and college-town does exactly that for 22 components —
-    // `CardHeader -> '@/components/card/card'` — under a comment reading
-    // "REQUIRED for proper story generation". Nothing read it. The convention
-    // guess below produced `@/components/card-header` instead, which is not a
-    // module, so 41% of that project's generated imports 404'd and roughly
-    // three quarters of its stories rendered blank.
-    //
-    // A declared path is a fact about the codebase. An inferred one is a guess
-    // about its conventions. The fact wins.
-    const declared = (config.components || []).find(c => c.name === component.name);
-    if (declared?.importPath) {
-      return declared.importPath;
-    }
-
-    // Use component's __componentPath if available
-    if (component.__componentPath) {
-      return component.__componentPath;
-    }
-
-    // Custom in-project components (discovered from local source files, not an
-    // npm package) must be imported via their real relative path from the
-    // generated-stories directory — never via the library import path.
-    const localPath = this.getLocalImportPath(component, config);
-    if (localPath) {
-      return localPath;
-    }
-
-    /**
-     * The package a component was actually discovered in.
-     *
-     * For a per-component-package design system the kebab guess below invents
-     * a package: `Layer`, re-exported from @atlaskit/popper, became
-     * `@atlaskit/layer`, which is not installed. Discovery already recorded
-     * where it found the component, and that is the answer.
-     */
-    const discoveredIn = (component as any).source;
-    if (discoveredIn?.type === 'npm' && discoveredIn.path && discoveredIn.path !== config.importPath) {
-      return discoveredIn.path;
-    }
-
-    const basePath = config.importPath || 'unknown';
-
-    /**
-     * No formula. This used to kebab-case the component name onto the base
-     * path for `importStyle: 'individual'` (`AlertDialog` → `alert-dialog`),
-     * which is one library's convention and wrong for the next. Every
-     * individual-import library this tool has met declares its paths: in
-     * `config.components[].importPath`, in discovery's `source.path`, or as a
-     * local file the relative-path branch above already resolved. When none
-     * of those exist the honest answer is the base path with a note, not a
-     * guess that fails at build time.
-     */
-    if (config.importStyle === 'individual') {
-      (component as any).__importPathUnknown = true;
-    }
-    return basePath;
+    return importSpecifierFor(component, config);
   }
 
   /**

--- a/story-generator/knowledge/importSpecifier.ts
+++ b/story-generator/knowledge/importSpecifier.ts
@@ -1,0 +1,129 @@
+/**
+ * Where a component is imported from, by the project's own account.
+ *
+ * One rule, shared by everything that writes an import line: the prompt's
+ * component catalog, the story pipeline's repairs, and the Voice Canvas save
+ * (which for a long time imported every capitalised JSX tag from
+ * `config.importPath` without asking — a canvas that used a component of a
+ * local design system saved as a story whose import did not resolve).
+ *
+ * Precedence, most authoritative first:
+ *   1. `config.components[].importPath` — the project wrote it down.
+ *   2. `__componentPath` — discovery recorded a subpath or a declared module.
+ *   3. a local source file — the real relative path from the generated dir.
+ *   4. the npm package discovery found it in, when that is not the base path.
+ *   5. `config.importPath`, and a note when the style says paths are per file.
+ */
+
+import * as fs from 'fs';
+import * as nodePath from 'path';
+import type { StoryUIConfig } from '../../story-ui.config.js';
+import type { DiscoveredComponent } from '../componentDiscovery.js';
+
+/**
+ * The relative import path for a component discovered from local source
+ * (custom, non-npm component libraries). Null for npm package components.
+ */
+export function localImportSpecifier(
+  component: DiscoveredComponent,
+  config: StoryUIConfig,
+): string | null {
+  const filePath = component.filePath;
+  if (!filePath || filePath.includes('node_modules')) return null;
+  if (!nodePath.isAbsolute(filePath) || !fs.existsSync(filePath)) return null;
+
+  const generatedDir = nodePath.resolve(process.cwd(), config.generatedStoriesPath || './src/stories/generated/');
+  let relative = nodePath.relative(generatedDir, filePath).split(nodePath.sep).join('/');
+  relative = relative.replace(/\.(tsx|jsx|ts|js|vue|svelte)$/, '');
+  if (!relative.startsWith('.')) relative = './' + relative;
+  return relative;
+}
+
+/** The module a story should import `component` from. */
+export function importSpecifierFor(
+  component: DiscoveredComponent,
+  config: StoryUIConfig,
+): string {
+  // What the PROJECT says, before anything we infer.
+  //
+  // story-ui.config.js can declare each component with its real import
+  // specifier, and college-town does exactly that for 22 components —
+  // `CardHeader -> '@/components/card/card'` — under a comment reading
+  // "REQUIRED for proper story generation". Nothing read it. The convention
+  // guess below produced `@/components/card-header` instead, which is not a
+  // module, so 41% of that project's generated imports 404'd and roughly
+  // three quarters of its stories rendered blank.
+  //
+  // A declared path is a fact about the codebase. An inferred one is a guess
+  // about its conventions. The fact wins.
+  const declared = (config.components || []).find(c => c.name === component.name);
+  if (declared?.importPath) {
+    return declared.importPath;
+  }
+
+  if (component.__componentPath) {
+    return component.__componentPath;
+  }
+
+  // Custom in-project components (discovered from local source files, not an
+  // npm package) must be imported via their real relative path from the
+  // generated-stories directory — never via the library import path.
+  const localPath = localImportSpecifier(component, config);
+  if (localPath) {
+    return localPath;
+  }
+
+  /**
+   * The package a component was actually discovered in.
+   *
+   * For a per-component-package design system the kebab guess below invented
+   * a package: `Layer`, re-exported from @atlaskit/popper, became
+   * `@atlaskit/layer`, which is not installed. Discovery already recorded
+   * where it found the component, and that is the answer.
+   */
+  const discoveredIn = (component as any).source;
+  if (discoveredIn?.type === 'npm' && discoveredIn.path && discoveredIn.path !== config.importPath) {
+    return discoveredIn.path;
+  }
+
+  const basePath = config.importPath || 'unknown';
+
+  /**
+   * No formula. This used to kebab-case the component name onto the base
+   * path for `importStyle: 'individual'` (`AlertDialog` → `alert-dialog`),
+   * which is one library's convention and wrong for the next. Every
+   * individual-import library this tool has met declares its paths: in
+   * `config.components[].importPath`, in discovery's `source.path`, or as a
+   * local file the relative-path branch above already resolved. When none
+   * of those exist the honest answer is the base path with a note, not a
+   * guess that fails at build time.
+   */
+  if (config.importStyle === 'individual') {
+    (component as any).__importPathUnknown = true;
+  }
+  return basePath;
+}
+
+export interface ImportHome {
+  specifier: string;
+  defaultExport: boolean;
+}
+
+/**
+ * A lookup from component name to import home, for code that writes import
+ * lines without the model: one entry per discovered component.
+ */
+export function importHomeResolver(
+  components: DiscoveredComponent[],
+  config: StoryUIConfig,
+): (name: string) => ImportHome | undefined {
+  const byName = new Map(components.map(c => [c.name, c] as const));
+  return (name: string) => {
+    const component = byName.get(name);
+    if (!component) return undefined;
+    return {
+      specifier: importSpecifierFor(component, config),
+      defaultExport: (component as any).__defaultExport === true,
+    };
+  };
+}

--- a/story-generator/storyTracker.ts
+++ b/story-generator/storyTracker.ts
@@ -14,9 +14,11 @@ export interface StoryMapping {
 
 export class StoryTracker {
   private mappingFile: string;
+  private storiesDir: string;
   private mappings: Map<string, StoryMapping>;
 
   constructor(config: StoryUIConfig) {
+    this.storiesDir = config.generatedStoriesPath;
     this.mappingFile = path.join(path.dirname(config.generatedStoriesPath), '.story-mappings.json');
     this.mappings = new Map();
     this.loadMappings();
@@ -211,6 +213,10 @@ export class StoryTracker {
     if (!baseTitle || typeof baseTitle !== 'string') {
       return baseTitle;
     }
+    // A deleted story's title is free again. Nothing removed mappings when a
+    // story was deleted, so "Profile Card" kept climbing to v5 through five
+    // deletions — the mapping file remembered stories that no longer existed.
+    this.cleanupOrphaned(this.storiesDir);
 
     const normalizedBase = baseTitle.toLowerCase().trim();
 

--- a/templates/StoryUI/StoryUIPanel.tsx
+++ b/templates/StoryUI/StoryUIPanel.tsx
@@ -1513,8 +1513,15 @@ function StoryUIPanel({ mcpPort }: StoryUIPanelProps) {
       return;
     }
 
-    const MAX_RECOVERY_MS = 4 * 60_000;
-    if (!pending.startedAt || Date.now() - pending.startedAt > MAX_RECOVERY_MS) {
+    // The base window alone decided this once, and it was wrong: a generation
+    // with a self-healing pass ran 4m12s, the stash was discarded as stale on
+    // the next remount, and the panel came back empty while the server was
+    // still working. Now the server's own in-flight list extends the wait
+    // (see poll below); the hard ceiling is the only unconditional cutoff.
+    const RECOVERY_WINDOW_MS = 4 * 60_000;
+    const RECOVERY_HARD_CEILING_MS = 15 * 60_000;
+    const ACTIVE_GRACE_MS = 15_000;
+    if (!pending.startedAt || Date.now() - pending.startedAt > RECOVERY_HARD_CEILING_MS) {
       try { sessionStorage.removeItem(PENDING_GEN_KEY); } catch {}
       return;
     }
@@ -1537,16 +1544,27 @@ function StoryUIPanel({ mcpPort }: StoryUIPanelProps) {
     };
 
     const poll = async () => {
-      const deadline = pending.startedAt + MAX_RECOVERY_MS;
-      while (!cancelled && Date.now() < deadline) {
+      const baseDeadline = pending.startedAt + RECOVERY_WINDOW_MS;
+      const hardDeadline = pending.startedAt + RECOVERY_HARD_CEILING_MS;
+      // Only a write newer than this request is this request's result: an
+      // update's entry already exists with an older reply, and matching it
+      // restored the previous turn as if the new one had finished.
+      const earliest = pending.startedAt - 2_000;
+      // Whether the server has /story-ui/active-generations. A 404 turns the
+      // extension off; the base window alone decides, exactly as before.
+      let activeSupported = true;
+      let lastActiveMatchAt = 0;
+      while (!cancelled && Date.now() < hardDeadline) {
         try {
           const res = await apiFetch(MANIFEST_API());
           if (res.ok) {
             const data = await res.json();
             const entries: Record<string, any> = data.stories ?? {};
             const entry = Object.values(entries).find((e: any) => {
-              if (pending.fileName && e.fileName === pending.fileName) return true;
-              return e.metadata?.prompt === pending.userInput;
+              const matches = pending.fileName ? e.fileName === pending.fileName : e.metadata?.prompt === pending.userInput;
+              if (!matches) return false;
+              const updated = Date.parse(e.updatedAt || '');
+              return Number.isNaN(updated) || updated >= earliest;
             }) as any;
             const conv = entry?.conversation ?? [];
             const last = conv[conv.length - 1];
@@ -1578,6 +1596,30 @@ function StoryUIPanel({ mcpPort }: StoryUIPanelProps) {
             }
           }
         } catch { /* server busy — keep polling */ }
+
+        if (activeSupported && !cancelled) {
+          try {
+            const res = await apiFetch(`${getApiBase()}/story-ui/active-generations`);
+            if (res.status === 404) {
+              activeSupported = false;
+            } else if (res.ok) {
+              const active: Array<{ prompt: string; fileName: string | null }> = (await res.json())?.active ?? [];
+              const match = active.some(a =>
+                a?.prompt === pending.userInput && (!pending.fileName || a.fileName === pending.fileName),
+              );
+              if (match) lastActiveMatchAt = Date.now();
+            }
+          } catch { /* a blip says nothing either way; decide on what we last knew */ }
+        }
+
+        const now = Date.now();
+        if (now >= baseDeadline) {
+          if (!activeSupported) break;
+          // The manifest write lands just before the server drops the entry,
+          // so a short grace after the last sighting lets the next poll see it.
+          const stillWorking = lastActiveMatchAt > 0 && now - lastActiveMatchAt < ACTIVE_GRACE_MS;
+          if (!stillWorking) break;
+        }
         await new Promise(resolve => setTimeout(resolve, 3000));
       }
       if (!cancelled) finishRecovery();


### PR DESCRIPTION
Found by the post-release classic-panel round on react-mantine (5.0.0 from the registry).

Voice Canvas. The canvas scope was whatever preview.tsx put on
window.__STORY_UI_DESIGN_SYSTEM__ — the npm module and nothing else — while the
prompt offered every discovered component, local ones included. The model chose
the project's own BrandBadge, react-live threw "BrandBadge is not defined", and
the saved story imported it from @mantine/core. The story now imports each
discovered component from where the project says it lives (the same rule the
prompt uses, extracted to knowledge/importSpecifier.ts and shared with the
adapter and with canvas save), through namespace imports so a wrong name is
absent rather than a build failure. A tag the scope does not have gets one
correction round, then a refusal that names it; the save groups imports by module.

Classic panel recovery. The four-minute stash window discarded a generation whose
self-healing pass ran 4m12s, and the remounted panel came back empty while the
server was still working. The panel now asks /story-ui/active-generations, as
the workspace already did, and keeps waiting while the server lists the run;
a manifest match must also be newer than the request, so an update no longer
restores the previous turn as if the new one had finished.

Story titles. Deleting a story never touched .story-mappings.json, so a title
kept versioning past stories that no longer existed (v2 → v5 through five
deletions). Orphaned mappings are dropped before a title is chosen.

`story-ui update` stamps _storyUIVersion even when every file is already current.

https://claude.ai/code/session_0158a8zxX4SKPdxm7DLfgqp4