### PR TITLE
fix(ui): classic panel opts out of docs typography; semantic tokens defined in both schemes

### DIFF
--- a/templates/StoryUI/StoryUIPanel.css
+++ b/templates/StoryUI/StoryUIPanel.css
@@ -93,6 +93,23 @@
   --max-chat-width: 768px;
 }
 
+/* Semantic aliases for the panel's newer surfaces (Design Context, Voice
+   Canvas, verification). Their styles read these names; nothing defined them,
+   so every one fell back to a light-mode literal in both schemes. Derived
+   from the hsl tokens above, so the dark block below re-colours them too. */
+.sui-root {
+  --sui-text: hsl(var(--foreground));
+  --sui-text-secondary: hsl(var(--muted-foreground));
+  --sui-border: hsl(var(--border));
+  --sui-surface: hsl(var(--card));
+  --sui-surface-subtle: hsl(var(--secondary));
+  --sui-accent: hsl(var(--primary));
+  --sui-success: hsl(var(--success));
+  --sui-warning: hsl(var(--warning));
+  --sui-danger: hsl(var(--destructive));
+  --sui-mono: var(--font-mono, ui-monospace, SFMono-Regular, Menlo, monospace);
+}
+
 /* Dark Mode - Storybook 10 dark palette */
 .sui-root.dark {
   --background: 220 4% 14%;

--- a/templates/StoryUI/StoryUIPanel.tsx
+++ b/templates/StoryUI/StoryUIPanel.tsx
@@ -2850,8 +2850,15 @@ function StoryUIPanel({ mcpPort }: StoryUIPanelProps) {
   // Explicit light/dark class: the CSS prefers-color-scheme fallback only
   // applies to .sui-root:not(.light), so a detected-light panel must carry
   // the .light class or a dark-mode OS forces dark variables anyway.
+  //
+  // `sb-unstyled` opts the whole panel out of Storybook's docs typography.
+  // Those rules are `:where(h2:not(.sb-unstyled, .sb-unstyled h2))` — zero
+  // specificity, injected after this stylesheet, so they beat any class of
+  // ours on a tie and painted every heading and paragraph in the Design
+  // Context and Voice Canvas tabs in the docs theme's fixed text colour:
+  // #2E3338 on a dark panel, 1.2:1.
   return (
-    <div className={`sui-root ${state.isDarkMode ? 'dark' : 'light'}`}>
+    <div className={`sui-root sb-unstyled ${state.isDarkMode ? 'dark' : 'light'}`}>
       {/* Sidebar */}
       <aside className={`sui-sidebar ${state.sidebarOpen ? '' : 'collapsed'}`} aria-label="Chat history">
         {state.sidebarOpen && (


### PR DESCRIPTION
Measured on Sail Shelf (Storybook 10.5.6) through Playwright, light and dark.

The Design Context heading and description, and the Voice Canvas empty state,
read at 1.23:1 in dark mode: #2E3338 on a dark panel. Storybook's docs page
styles every h2 and p with `:where(h2:not(.sb-unstyled, .sb-unstyled h2))` —
zero specificity, injected after the panel's stylesheet — so they beat the
panel's own classes on a tie. The root now carries `sb-unstyled`, Storybook's
own opt-out, as the workspace already did.

The same surfaces read `--sui-text`, `--sui-text-secondary`, `--sui-border`,
`--sui-surface*`, `--sui-accent` and the status colours, and nothing defined
them, so each fell back to a light-mode literal in both schemes (#6b7280 on a
dark panel, 3.25:1). They are now aliases of the panel's hsl tokens and follow
the dark block.

After: every measured element is at 5.48:1 or better in both schemes.

https://claude.ai/code/session_0158a8zxX4SKPdxm7DLfgqp4