### PR TITLE
fix: voice canvas story stays out of the Storybook sidebar; index misses name the Storybook version

### DIFF
--- a/__tests__/canvas-scope-and-versions.test.ts
+++ b/__tests__/canvas-scope-and-versions.test.ts
@@ -6,6 +6,7 @@ import { unknownCanvasComponents, voiceCanvasStorySource } from '../mcp-server/r
 import { componentImportLines, jsxCodeToStory } from '../mcp-server/routes/canvasSave.js';
 import { importSpecifierFor, importHomeResolver } from '../story-generator/knowledge/importSpecifier.js';
 import { StoryTracker } from '../story-generator/storyTracker.js';
+import { storybookWatcherHint } from '../story-generator/verify/verifyStory.js';
 
 describe('canvas scope check', () => {
   const known = ['Button', 'Card', 'Text', 'Badge'];
@@ -131,5 +132,32 @@ describe('voice canvas scope', () => {
     const comps: any = [{ name: 'Button', filePath: '' }, { name: 'Text', filePath: '' }];
     expect(voiceCanvasStorySource(config, comps)).toBe(voiceCanvasStorySource(config, comps));
     expect(voiceCanvasStorySource(config, comps)).toContain('...pick(__sui0, ["Button","Text"], []),');
+  });
+});
+
+describe('canvas story stays out of the sidebar', () => {
+  it('tags the render surface !dev so it is loadable by id but not listed', () => {
+    const source = voiceCanvasStorySource({ importPath: '@mantine/core', generatedStoriesPath: './src/stories/generated/' } as any, [{ name: 'Button', filePath: '' }] as any);
+    expect(source).toContain("tags: ['voice-canvas-internal', '!dev']");
+  });
+});
+
+describe('storybook watcher hint', () => {
+  const withVersion = (version: string | null) => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'sbv-'));
+    if (version) {
+      fs.mkdirSync(path.join(dir, 'node_modules', 'storybook'), { recursive: true });
+      fs.writeFileSync(path.join(dir, 'node_modules', 'storybook', 'package.json'), JSON.stringify({ version }));
+    }
+    return dir;
+  };
+  it('names the installed version and the fix on the affected range, and stays silent otherwise', () => {
+    expect(storybookWatcherHint(withVersion('10.5.6'))).toContain('Storybook 10.5.6 is installed');
+    expect(storybookWatcherHint(withVersion('10.5.6'))).toContain('10.5.10 or newer');
+    expect(storybookWatcherHint(withVersion('10.5.10'))).toBe('');
+    expect(storybookWatcherHint(withVersion('10.4.2'))).toBe('');
+    expect(storybookWatcherHint(withVersion('9.1.17'))).toBe('');
+    expect(storybookWatcherHint(withVersion('10.6.1'))).toBe('');
+    expect(storybookWatcherHint(withVersion(null))).toBe('');
   });
 });

--- a/cli/check.ts
+++ b/cli/check.ts
@@ -21,11 +21,8 @@ import { closeBrowserSession } from '../story-generator/verify/browserSession.js
 import { describeLaunchFailure } from '../story-generator/verify/verifyStory.js';
 
 /** a < b for dotted versions; prerelease tags ignored. */
-export function semverLt(a: string, b: string): boolean {
-  const pa = a.split('-')[0].split('.').map(Number); const pb = b.split('-')[0].split('.').map(Number);
-  for (let i = 0; i < 3; i++) { const x = pa[i] || 0, y = pb[i] || 0; if (x !== y) return x < y; }
-  return false;
-}
+import { semverLt } from '../story-generator/semver.js';
+export { semverLt };
 
 export interface CheckItem {
   id: string;

--- a/mcp-server/routes/canvasGenerate.ts
+++ b/mcp-server/routes/canvasGenerate.ts
@@ -135,7 +135,11 @@ const VOICE_CANVAS_TEMPLATE = `import React, { useState, useEffect } from 'react
 import { LiveProvider, LivePreview, LiveError } from 'react-live';
 import type { Meta, StoryObj } from '@storybook/react';
 
-const meta: Meta = { title: 'Generated/Voice Canvas', tags: ['voice-canvas-internal'] };
+// '!dev' keeps this out of the Storybook sidebar: it is the canvas's render
+// surface, not a generated story, and a sidebar entry that shows only
+// "Voice Canvas is ready" was a link that did nothing. It stays in the index,
+// so the panel's iframe can still load it by id.
+const meta: Meta = { title: 'Generated/Voice Canvas', tags: ['voice-canvas-internal', '!dev'] };
 export default meta;
 
 __STORY_UI_CATALOG_IMPORTS__

--- a/story-generator/semver.ts
+++ b/story-generator/semver.ts
@@ -1,0 +1,6 @@
+/** Minimal semver comparison for version gates; prerelease suffixes ignored. */
+export function semverLt(a: string, b: string): boolean {
+  const pa = a.split('-')[0].split('.').map(Number); const pb = b.split('-')[0].split('.').map(Number);
+  for (let i = 0; i < 3; i++) { const x = pa[i] || 0, y = pb[i] || 0; if (x !== y) return x < y; }
+  return false;
+}

--- a/story-generator/verify/verifyStory.ts
+++ b/story-generator/verify/verifyStory.ts
@@ -11,6 +11,9 @@
  *     measurements have to be trusted before they are allowed to spend tokens.
  */
 
+import fs from 'fs';
+import path from 'path';
+import { semverLt } from '../semver.js';
 import { logger } from '../logger.js';
 import { resolveHostTooling, canLaunchBrowser } from './hostTooling.js';
 import { renderStory, waitForStoryIndexed, indexIsStale, type IndexLookup } from './renderHarness.js';
@@ -105,6 +108,21 @@ const notVerified = (
  * the index" was also what a story indexed on :6103 got when verification
  * had been looking at :6006.
  */
+
+/**
+ * Storybook 10.5.5–10.5.6 stopped watching for new story files after a
+ * while in testing; 10.5.10 did not. A "not indexed" result on one of those
+ * versions is almost always that, so say so where the user is looking —
+ * `story-ui check` already does, but nobody runs check when a story fails.
+ */
+export function storybookWatcherHint(cwd: string = process.cwd()): string {
+  let version = '';
+  try { version = JSON.parse(fs.readFileSync(path.join(cwd, 'node_modules', 'storybook', 'package.json'), 'utf8')).version || ''; } catch { return ''; }
+  // Only the range that showed it: older majors fail the install check outright.
+  if (!version || semverLt(version, '10.5.0') || !semverLt(version, '10.5.10')) return '';
+  return ` Storybook ${version} is installed; 10.5.5–10.5.6 stopped watching for new files in testing and 10.5.10 did not — restart Storybook now, and upgrade to 10.5.10 or newer so this stops recurring.`;
+}
+
 export function classifyIndexMiss(
   storybookUrl: string,
   lookup: Pick<IndexLookup, 'reachable' | 'error'>,
@@ -126,7 +144,7 @@ export function classifyIndexMiss(
   }
   if (staleness.stale) {
     return {
-      reason: `Storybook's index at ${url} is behind the filesystem — its file watcher has stopped picking up changes. Restart Storybook to verify.`,
+      reason: `Storybook's index at ${url} is behind the filesystem — its file watcher has stopped picking up changes. Restart Storybook to verify.${storybookWatcherHint()}`,
       finding: {
         id: 'stale-index', severity: 'warning', class: 'infrastructure',
         message: 'Storybook\'s story index is stale — this is a dev-server problem, not a defect in the generated story',
@@ -136,7 +154,7 @@ export function classifyIndexMiss(
     };
   }
   return {
-    reason: `Story did not appear in the index at ${url} — it may not have been picked up yet`,
+    reason: `Story did not appear in the index at ${url} — it may not have been picked up yet${storybookWatcherHint() ? '.' + storybookWatcherHint() : ''}`,
     finding: {
       id: 'not-indexed', severity: 'warning', class: 'infrastructure',
       message: `Storybook at ${url} has not indexed the generated story`,


### PR DESCRIPTION
The canvas's render surface was listed under Generated as "Voice Canvas", a
link that showed only "Voice Canvas is ready". It is not a generated story.
Tagged `!dev`, Storybook's own opt-out: gone from the sidebar, still in the
index, so the panel's iframe loads it by id as before.

A story that never appears in the index on Storybook 10.5.5–10.5.6 is almost
always that version's file watcher stopping — `story-ui check` says so, but
nobody runs check when a generation fails. The "not indexed" and "stale index"
reasons now name the installed version and the fix (restart now, upgrade to
10.5.10 or newer). Observed on Sail Shelf: a valid form story, every import
correct, reported as broken because the watcher had died.

https://claude.ai/code/session_0158a8zxX4SKPdxm7DLfgqp4