### PR TITLE
fix: an existing voice-canvas story is refreshed at server start

### DIFF
--- a/mcp-server/index.ts
+++ b/mcp-server/index.ts
@@ -36,7 +36,7 @@ import { getProviders, getModels } from './routes/providers.js';
 import mcpRemoteRouter from './routes/mcpRemote.js';
 // Voice Canvas endpoints
 import { canvasSaveHandler } from './routes/canvasSave.js';
-import { canvasGenerateHandler } from './routes/canvasGenerate.js';
+import { canvasGenerateHandler, refreshVoiceCanvasStory } from './routes/canvasGenerate.js';
 import { getAdapterRegistry } from '../story-generator/framework-adapters/index.js';
 // Manifest — story ↔ chat source of truth
 import {
@@ -1021,10 +1021,17 @@ app.listen(PORT, accessPolicy.host, () => {
     console.error('🔒 Loopback only. Set STORY_UI_TOKEN to expose it to other machines.');
   }
   console.error(`Stories will be generated to: ${config.generatedStoriesPath}`);
-  // The voice-canvas scratch story is NOT written here. Writing it at start
+  // The voice-canvas scratch story is NOT created here. Writing it at start
   // put "Generated/Voice Canvas" into every user's sidebar before they had
   // asked for anything; the canvas route (POST /mcp/canvas-generate) writes
-  // it on first use, which is the first time the iframe can need it.
+  // it on first use, which is the first time the iframe can need it. One
+  // that already exists is brought up to date, so an upgrade's template
+  // change (tags, catalog scope) lands on restart.
+  setTimeout(() => {
+    refreshVoiceCanvasStory(config)
+      .then(refreshed => { if (refreshed) console.error('[canvas] Voice canvas story checked against the current catalog'); })
+      .catch(err => console.error('[canvas] Voice canvas refresh skipped:', err instanceof Error ? err.message : err));
+  }, 1500);
   // Initialize manifest manager (loads file, migrates from StoryTracker, reconciles)
   setTimeout(() => {
     try {

--- a/mcp-server/routes/canvasGenerate.ts
+++ b/mcp-server/routes/canvasGenerate.ts
@@ -330,6 +330,21 @@ export function voiceCanvasStorySource(config: StoryUIConfig, components: Discov
   return VOICE_CANVAS_TEMPLATE.replace('__STORY_UI_CATALOG_IMPORTS__', block);
 }
 
+/**
+ * Refresh an EXISTING voice-canvas story at server start. Never creates one
+ * (that would put a story into every sidebar uninvited); only brings a file
+ * a previous version wrote up to the current template and catalog, so an
+ * upgrade takes effect on restart rather than on the next canvas command.
+ */
+export async function refreshVoiceCanvasStory(config: StoryUIConfig): Promise<boolean> {
+  const storiesDir = config.generatedStoriesPath || './src/stories/generated/';
+  const filePath = path.resolve(process.cwd(), storiesDir, VOICE_CANVAS_STORY_FILE);
+  if (!fs.existsSync(filePath)) return false;
+  const components = await getCanvasComponents(config);
+  ensureVoiceCanvasStory(storiesDir, voiceCanvasStorySource(config, components));
+  return true;
+}
+
 // ── Code extraction ───────────────────────────────────────────
 
 /**


### PR DESCRIPTION
The sidebar fix in 5.0.5 only reached a project on its next canvas command,
because the story file is written on first use. A file a previous version
wrote is now brought up to the current template and catalog when the server
starts; none is ever created there.

https://claude.ai/code/session_0158a8zxX4SKPdxm7DLfgqp4