### PR TITLE
feat(ui): classic panel thread redesign — avatar turns, hover actions, menus, composer chip

### DIFF
--- a/templates/StoryUI/StoryUIPanel.css
+++ b/templates/StoryUI/StoryUIPanel.css
@@ -86,11 +86,15 @@
   --transition-normal: 200ms cubic-bezier(0.4, 0, 0.2, 1);
   --transition-slow: 300ms cubic-bezier(0.4, 0, 0.2, 1);
 
+  /* Tint behind a status colour used as text (pills, the active tab). Light
+     text-on-tint needs a thinner wash than dark to hold 4.5:1. */
+  --tint: 0.08;
+
   /* Layout */
   --sidebar-width: 260px;
   --header-height: 44px;
   --input-height: 44px;
-  --max-chat-width: 768px;
+  --max-chat-width: 720px;
 }
 
 /* Semantic aliases for the panel's newer surfaces (Design Context, Voice
@@ -147,6 +151,7 @@
   --warning: 41 100% 45%;
   --info: 212 100% 64%;
   --info-foreground: 210 4% 11%;
+  --tint: 0.14;
 }
 
 /* Dark mode fallback using system preference when .dark class not applied */
@@ -187,6 +192,7 @@
     --warning: 41 100% 45%;
     --info: 212 100% 64%;
     --info-foreground: 210 4% 11%;
+    --tint: 0.14;
   }
 }
 
@@ -252,9 +258,10 @@
   overflow: hidden;
 }
 
+/* Collapsed from the header's sidebar button: no rail, nothing to focus */
 .sui-sidebar.collapsed {
-  width: 56px;
-  border-right: 1px solid hsl(var(--border));
+  width: 0;
+  border-right: 0;
 }
 
 .sui-sidebar-header {
@@ -268,6 +275,13 @@
   flex-direction: column;
   overflow: hidden;
   padding: var(--space-2);
+}
+
+/* "New story" — full width, one row, 36px like the mockup */
+.sui-sidebar-new {
+  width: 100%;
+  height: 36px;
+  margin-bottom: 12px;
 }
 
 /* Sidebar chat list - flex grow to fill space */
@@ -351,43 +365,278 @@
   background: hsl(var(--background));
 }
 
-/* Header */
+/* Header: three columns so the mode tabs sit centred regardless of what the
+   left and right clusters contain. */
 .sui-header {
-  min-height: var(--header-height);
-  padding: 0 12px;
-  display: flex;
+  height: var(--header-height);
+  padding: 0 16px;
+  display: grid;
+  grid-template-columns: 1fr auto 1fr;
   align-items: center;
-  justify-content: space-between;
-  flex-wrap: wrap;
-  row-gap: 4px;
-  column-gap: var(--space-3);
+  column-gap: 12px;
   border-bottom: 1px solid hsl(var(--border));
-  background: hsl(var(--card));
+  background: hsl(var(--background));
   flex-shrink: 0;
 }
 
 .sui-header-left {
   display: flex;
   align-items: center;
-  gap: var(--space-4);
+  gap: 10px;
+  min-width: 0;
+}
+
+.sui-header-center {
+  display: flex;
+  justify-content: center;
 }
 
 .sui-header-right {
   display: flex;
   align-items: center;
-  gap: var(--space-3);
+  justify-content: flex-end;
+  gap: 8px;
 }
 
 .sui-header-title {
-  font-size: 14px !important;
-  font-weight: 800;
+  font-size: 15px !important;
+  font-weight: 700;
   color: hsl(var(--foreground));
   white-space: nowrap;
 }
 
-.sui-header-subtitle {
-  font-size: 14px !important;
+/* Current story as a quiet dropdown chip beside the wordmark */
+.sui-title-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  height: 28px;
+  max-width: 280px;
+  padding: 0 6px;
+  border: 1px solid transparent;
+  border-radius: var(--radius-md);
+  background: transparent;
   color: hsl(var(--muted-foreground));
+  font-family: inherit;
+  font-size: 13px !important;
+  cursor: pointer;
+  transition: all var(--transition-fast);
+}
+
+.sui-title-chip:hover,
+.sui-title-chip[aria-expanded="true"] {
+  background: hsl(var(--secondary));
+  color: hsl(var(--foreground));
+}
+
+.sui-title-chip:focus-visible {
+  outline: 2px solid hsl(var(--ring));
+  outline-offset: 1px;
+}
+
+.sui-title-chip-text {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+/* Connection status: dot + one word; the detail lives in its title and in
+   the settings menu */
+.sui-status {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  font-size: 13px !important;
+  color: hsl(var(--muted-foreground));
+  white-space: nowrap;
+}
+
+.sui-status-dot {
+  width: 7px;
+  height: 7px;
+  border-radius: 50%;
+  background: hsl(var(--success));
+}
+
+.sui-status--bad {
+  color: hsl(var(--destructive));
+}
+
+.sui-status--bad .sui-status-dot {
+  background: hsl(var(--destructive));
+}
+
+/* Icon buttons: sidebar toggle, gear, turn actions, composer attach */
+.sui-icon-btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 28px;
+  height: 28px;
+  padding: 0;
+  border: none;
+  border-radius: var(--radius-md);
+  background: transparent;
+  color: hsl(var(--muted-foreground));
+  cursor: pointer;
+  transition: all var(--transition-fast);
+}
+
+.sui-icon-btn:hover:not(:disabled),
+.sui-icon-btn[aria-expanded="true"],
+.sui-icon-btn[aria-pressed="true"] {
+  background: hsl(var(--secondary));
+  color: hsl(var(--foreground));
+}
+
+.sui-icon-btn:focus-visible {
+  outline: 2px solid hsl(var(--ring));
+  outline-offset: 1px;
+}
+
+.sui-icon-btn:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.sui-icon-btn svg {
+  width: 16px;
+  height: 16px;
+}
+
+/* ============================================
+   Popover menus (story switcher, settings, turn actions, model chooser)
+   ============================================ */
+.sui-menu-anchor {
+  position: relative;
+  display: inline-flex;
+}
+
+.sui-menu {
+  position: absolute;
+  top: calc(100% + 4px);
+  left: 0;
+  z-index: 60;
+  min-width: 200px;
+  max-width: 320px;
+  max-height: 360px;
+  overflow-y: auto;
+  padding: 6px;
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  background: hsl(var(--popover));
+  color: hsl(var(--popover-foreground));
+  border: 1px solid hsl(var(--border));
+  border-radius: var(--radius-xl);
+  box-shadow: var(--shadow-lg);
+}
+
+.sui-menu--right {
+  left: auto;
+  right: 0;
+}
+
+.sui-menu--up {
+  top: auto;
+  bottom: calc(100% + 4px);
+}
+
+.sui-menu--stories {
+  min-width: 240px;
+}
+
+.sui-menu-item {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  width: 100%;
+  padding: 7px 10px;
+  border: none;
+  border-radius: var(--radius-md);
+  background: transparent;
+  color: hsl(var(--foreground));
+  font-family: inherit;
+  font-size: 13px !important;
+  text-align: left;
+  cursor: pointer;
+  transition: background var(--transition-fast);
+}
+
+.sui-menu-item:hover,
+.sui-menu-item:focus-visible {
+  background: hsl(var(--secondary));
+  outline: none;
+}
+
+.sui-menu-item--active {
+  color: hsl(var(--primary));
+  font-weight: 600;
+}
+
+.sui-menu-item--danger {
+  color: hsl(var(--destructive));
+}
+
+.sui-menu-item--danger:hover,
+.sui-menu-item--danger:focus-visible {
+  background: hsl(var(--destructive) / 0.1);
+}
+
+.sui-menu-item-label {
+  flex: 1 1 auto;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.sui-menu-sep {
+  height: 1px;
+  margin: 4px 6px;
+  background: hsl(var(--border));
+}
+
+.sui-menu-heading {
+  padding: 6px 10px 2px;
+  font-size: 11px !important;
+  font-weight: 700;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  color: hsl(var(--muted-foreground));
+}
+
+.sui-menu-group + .sui-menu-group {
+  margin-top: 4px;
+  padding-top: 4px;
+  border-top: 1px solid hsl(var(--border));
+}
+
+/* Informational rows in the settings menu (server, toggles) */
+.sui-menu-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+  padding: 7px 10px;
+  border-radius: var(--radius-md);
+  font-size: 13px !important;
+  color: hsl(var(--foreground));
+  white-space: nowrap;
+}
+
+.sui-menu-row--toggle {
+  cursor: pointer;
+  user-select: none;
+}
+
+.sui-menu-row--toggle:hover {
+  background: hsl(var(--secondary));
+}
+
+.sui-menu-row-value {
+  color: hsl(var(--muted-foreground));
+  font-variant-numeric: tabular-nums;
 }
 
 /* Chat Area */
@@ -400,31 +649,256 @@
   width: 100%;
 }
 
-.sui-chat-messages {
-  flex: 1;
-  max-width: var(--max-chat-width);
+/* ============================================
+   Thread: right-aligned user bubbles, avatar-led assistant turns
+   ============================================ */
+.sui-thread {
   width: 100%;
-  padding: var(--space-6);
+  max-width: var(--max-chat-width);
+  padding: 28px 40px 16px;
   display: flex;
   flex-direction: column;
-  /* Turn separation must clearly exceed intra-turn spacing (~10px) so a
-     response and its suggestion chips read as one group. */
-  gap: var(--space-6);
+  /* 24px between turns; 12px inside one */
+  gap: 24px;
 }
 
-/* Input Area */
-.sui-input-area {
-  padding: var(--space-4) var(--space-6) var(--space-6);
-  background: linear-gradient(transparent, hsl(var(--background)) 20%);
+.sui-turn {
+  animation: sui-fade-in var(--transition-normal);
+}
+
+@keyframes sui-fade-in {
+  from {
+    opacity: 0;
+    transform: translateY(8px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+.sui-turn-user {
   display: flex;
-  justify-content: center;
-  align-items: center;
+  justify-content: flex-end;
 }
 
-.sui-input-container {
-  max-width: var(--max-chat-width);
-  margin: 0 auto;
-  width: 100%;
+.sui-bubble {
+  max-width: 78%;
+  padding: 10px 14px;
+  border-radius: var(--radius-xl);
+  background: hsl(var(--user-bubble-bg));
+  border: 1px solid hsl(var(--user-bubble-border));
+  color: hsl(var(--user-bubble-fg));
+  font-size: 15px !important;
+  line-height: 1.5;
+  white-space: pre-wrap;
+  overflow-wrap: anywhere;
+}
+
+.sui-turn-ai {
+  display: flex;
+  align-items: flex-start;
+  gap: 14px;
+}
+
+.sui-avatar {
+  width: 28px;
+  height: 28px;
+  flex-shrink: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 50%;
+  background: hsl(var(--accent));
+  color: hsl(var(--primary));
+  font-size: 12px !important;
+  font-weight: 700;
+}
+
+.sui-turn-body {
+  flex: 1 1 auto;
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+/* Meta row: steps disclosure, timing, "Show changes", verification pill */
+.sui-turn-meta {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 8px;
+  min-height: 24px;
+  font-size: 13px !important;
+  color: hsl(var(--muted-foreground));
+}
+
+.sui-turn-meta-text {
+  font-variant-numeric: tabular-nums;
+}
+
+.sui-turn-meta-dot {
+  opacity: 0.7;
+}
+
+.sui-steps-toggle {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 2px 4px 2px 0;
+  border: 0;
+  border-radius: var(--radius-md);
+  background: transparent;
+  color: inherit;
+  font-family: inherit;
+  font-size: 13px !important;
+  font-variant-numeric: tabular-nums;
+  cursor: pointer;
+}
+
+.sui-steps-toggle:hover {
+  color: hsl(var(--foreground));
+}
+
+.sui-steps-toggle:focus-visible {
+  outline: 2px solid hsl(var(--ring));
+  outline-offset: 1px;
+}
+
+.sui-steps-chevron {
+  display: inline-flex;
+  transition: transform var(--transition-fast);
+}
+
+.sui-steps-chevron.open {
+  transform: rotate(90deg);
+}
+
+.sui-link-btn {
+  padding: 0;
+  border: 0;
+  background: none;
+  color: hsl(var(--primary));
+  font-family: inherit;
+  font-size: 13px !important;
+  cursor: pointer;
+}
+
+.sui-link-btn:hover {
+  text-decoration: underline;
+}
+
+.sui-link-btn:focus-visible {
+  outline: 2px solid hsl(var(--ring));
+  outline-offset: 2px;
+  border-radius: 2px;
+}
+
+/* Expanded steps: the progress log, numbered */
+.sui-steps {
+  margin: 0;
+  padding: 2px 0 2px 26px;
+  border-left: 2px solid hsl(var(--border));
+  list-style: decimal;
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  font-size: 13px !important;
+  line-height: 1.45;
+  color: hsl(var(--muted-foreground));
+}
+
+/* Assistant prose: no card, reading-size type */
+.sui-turn-prose {
+  font-size: 15px !important;
+  line-height: 1.55;
+  color: hsl(var(--foreground));
+}
+
+.sui-turn-prose .sui-markdown {
+  font-size: 15px !important;
+  line-height: 1.55;
+  font-family: var(--font-sans);
+}
+
+/* Storybook's docs styles recolor paragraph text; pin it to the foreground
+   token so both themes derive from one source. */
+.sui-turn-prose .sui-markdown p,
+.sui-turn-prose .sui-markdown strong,
+.sui-turn-prose .sui-markdown em,
+.sui-turn-prose .sui-markdown span,
+.sui-turn-prose .sui-markdown li {
+  font-size: 15px !important;
+  line-height: 1.55;
+  color: hsl(var(--foreground)) !important;
+}
+
+.sui-turn-prose .sui-markdown p {
+  margin: 0 0 10px;
+}
+
+.sui-turn-prose .sui-markdown p:last-child {
+  margin-bottom: 0;
+}
+
+/* Inline code as chips */
+.sui-turn-prose .sui-markdown code {
+  font-family: var(--font-mono);
+  font-size: 13px !important;
+  padding: 1px 5px;
+  border: 0;
+  border-radius: var(--radius-md);
+  background: hsl(var(--secondary)) !important;
+  color: hsl(var(--foreground)) !important;
+}
+
+/* Generated code, opened from "Show changes" or the < > action */
+.sui-code {
+  overflow: hidden;
+  border: 1px solid hsl(var(--border));
+  border-radius: var(--radius-xl);
+  background: hsl(var(--card));
+}
+
+.sui-code pre {
+  margin: 0;
+  padding: 12px 14px;
+  max-height: 360px;
+  overflow: auto;
+  font-family: var(--font-mono);
+  font-size: 13px !important;
+  line-height: 1.5;
+  color: hsl(var(--foreground));
+}
+
+/* Quiet action row: visible on hover, on focus-within for keyboard users,
+   and while its menu is open. Always visible where hover does not exist. */
+.sui-turn-actions {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  margin-top: -4px;
+  opacity: 0;
+  transition: opacity var(--transition-fast);
+}
+
+.sui-turn-ai:hover .sui-turn-actions,
+.sui-turn-ai:focus-within .sui-turn-actions,
+.sui-turn-actions.is-open {
+  opacity: 1;
+}
+
+@media (hover: none) {
+  .sui-turn-actions {
+    opacity: 1;
+  }
+}
+
+.sui-turn-suggestions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
 }
 
 /* ============================================
@@ -481,18 +955,6 @@
 
 .sui-button-secondary:hover {
   background: hsl(var(--accent));
-}
-
-.sui-button-ghost {
-  color: hsl(var(--foreground));
-  border-radius: var(--radius-md);
-  height: 28px;
-  padding: 0 var(--space-3);
-}
-
-.sui-button-ghost:hover {
-  background: hsl(var(--secondary));
-  color: hsl(var(--foreground));
 }
 
 .sui-button-outline {
@@ -576,87 +1038,8 @@
 }
 
 /* ============================================
-   ShadCN-Style Select Component
+   Toggle switch (Storybook MCP context, in the settings menu)
    ============================================ */
-.sui-select {
-  position: relative;
-  display: inline-block;
-}
-
-/* Ghost model pickers, ChatGPT-style: text + chevron, surface on hover only.
-   Boxed 96px-wide bold buttons dominated the header next to the compact
-   mode toggle — all header controls share one quiet 28px scale now. */
-.sui-select-trigger {
-  display: inline-flex;
-  align-items: center;
-  justify-content: space-between;
-  gap: 6px;
-  height: 28px;
-  padding: 0 var(--space-2);
-  border-radius: var(--radius-md);
-  border: 1px solid transparent;
-  background: transparent;
-  font-size: 14px !important;
-  font-weight: 600;
-  color: hsl(var(--muted-foreground));
-  cursor: pointer;
-  transition: all var(--transition-fast);
-}
-
-.sui-select-trigger:hover {
-  background: hsl(var(--muted));
-  color: hsl(var(--foreground));
-}
-
-/* The visible trigger is a div; keyboard focus lands on the transparent
-   native select overlaid on it — indicate focus via :focus-within. */
-.sui-select:focus-within .sui-select-trigger {
-  outline: 2px solid hsl(var(--ring));
-  outline-offset: 1px;
-}
-
-.sui-select-native {
-  position: absolute;
-  inset: 0;
-  opacity: 0;
-  cursor: pointer;
-  width: 100%;
-  height: 100%;
-}
-
-.sui-select-icon {
-  width: 12px;
-  height: 12px;
-  color: hsl(var(--muted-foreground));
-  flex-shrink: 0;
-}
-
-/* ============================================
-   MCP Toggle Switch Component
-   ============================================ */
-.sui-mcp-toggle {
-  display: flex;
-  align-items: center;
-  margin-left: var(--space-3);
-  padding-left: var(--space-3);
-  border-left: 1px solid hsl(var(--border));
-}
-
-.sui-toggle-label {
-  display: flex;
-  align-items: center;
-  gap: var(--space-2);
-  cursor: pointer;
-  user-select: none;
-}
-
-.sui-toggle-text {
-  font-size: 14px !important;
-  font-weight: 700;
-  color: hsl(var(--muted-foreground));
-  white-space: nowrap;
-}
-
 .sui-toggle-switch {
   position: relative;
   width: 32px;
@@ -710,69 +1093,12 @@
   outline-offset: 2px;
 }
 
-.sui-toggle-label:hover .sui-toggle-slider {
+.sui-menu-row--toggle:hover .sui-toggle-slider {
   background-color: hsl(var(--accent));
 }
 
-.sui-toggle-label:hover .sui-toggle-switch input:checked + .sui-toggle-slider {
+.sui-menu-row--toggle:hover .sui-toggle-switch input:checked + .sui-toggle-slider {
   background-color: hsl(var(--primary) / 0.9);
-}
-
-/* ============================================
-   ShadCN-Style Badge Component
-   ============================================ */
-.sui-badge {
-  display: inline-flex;
-  align-items: center;
-  gap: var(--space-1);
-  padding: 0.125rem var(--space-2);
-  border-radius: var(--radius-full);
-  font-size: 14px !important;
-  line-height: 1;
-  font-weight: 700;
-  letter-spacing: 0.2px;
-  transition: all var(--transition-fast);
-}
-
-.sui-badge-default {
-  background: hsl(var(--primary));
-  color: hsl(var(--primary-foreground));
-}
-
-.sui-badge-secondary {
-  background: hsl(var(--secondary));
-  color: hsl(var(--secondary-foreground));
-}
-
-/* Connected state: Storybook's quieter status idiom — dot + plain text, no pill */
-.sui-badge-success {
-  background: transparent;
-  padding: 0;
-  color: hsl(var(--muted-foreground));
-}
-
-.sui-badge-success .sui-badge-dot {
-  background: hsl(var(--success));
-}
-
-/* Disconnected keeps the filled pill — it must attract attention */
-.sui-badge-destructive {
-  background: hsl(var(--destructive) / 0.15);
-  color: hsl(var(--destructive));
-}
-
-.sui-badge-outline {
-  border: 1px solid hsl(var(--border));
-  background: transparent;
-  color: hsl(var(--foreground));
-}
-
-/* Status dot inside badge */
-.sui-badge-dot {
-  width: 6px;
-  height: 6px;
-  border-radius: 50%;
-  background: currentColor;
 }
 
 /* ============================================
@@ -977,124 +1303,6 @@
   transform: scale(0.98);
 }
 
-/* ============================================
-   Messages
-   ============================================ */
-.sui-message {
-  animation: sui-fade-in var(--transition-normal);
-}
-
-@keyframes sui-fade-in {
-  from {
-    opacity: 0;
-    transform: translateY(8px);
-  }
-  to {
-    opacity: 1;
-    transform: translateY(0);
-  }
-}
-
-.sui-message-user {
-  display: flex;
-  justify-content: flex-end;
-}
-
-.sui-message-ai {
-  display: flex;
-  justify-content: flex-start;
-}
-
-/* Base bubble styles - shared between user and AI */
-.sui-message-bubble {
-  max-width: 85%;
-  padding: 10px 14px;
-  /* Two radius tiers panel-wide: cards/containers 8px, controls 4px. */
-  border-radius: var(--radius-xl);
-  /* Chat prose is long-form reading content, not UI chrome. */
-  font-size: 15px !important;
-  line-height: 1.55 !important;
-  border: 1px solid hsl(var(--border));
-}
-
-/* User bubble - Storybook hover-blue tint */
-.sui-message-user .sui-message-bubble {
-  max-width: 75%;
-  background: hsl(var(--user-bubble-bg));
-  color: hsl(var(--user-bubble-fg));
-  border-color: hsl(var(--user-bubble-border));
-}
-
-/* AI bubble - card surface driven by theme variables */
-.sui-message-ai .sui-message-bubble {
-  background: hsl(var(--ai-bubble-bg)) !important;
-  color: hsl(var(--ai-bubble-fg)) !important;
-  border: 1px solid hsl(var(--ai-bubble-border)) !important;
-  /* The AI card is a multi-block document (header, prose, meta, code
-     disclosure) — it needs more breathing room than a chat bubble. */
-  padding: 14px 16px;
-}
-
-/*
- * Markdown content styling
- * Using .sui-message-bubble prefix for higher specificity (0,2,x)
- * to beat Storybook's .css-xxx :where(p) selectors (0,1,x)
- */
-.sui-message-bubble .sui-markdown {
-  font-size: 15px !important;
-  line-height: 1.55;
-  font-family: var(--font-sans);
-}
-
-/* Paragraph styling - higher specificity beats Storybook */
-.sui-message-bubble .sui-markdown p {
-  font-size: 15px !important;
-  line-height: 1.55;
-  margin: 0 0 10px 0;
-  padding: 0;
-}
-
-.sui-message-bubble .sui-markdown p:last-child {
-  margin-bottom: 0;
-}
-
-.sui-message-bubble strong {
-  font-weight: 700;
-}
-
-.sui-message-bubble em {
-  font-style: italic;
-}
-
-/* CRITICAL: Force text color on all child elements
-   Storybook's design system aggressively overrides paragraph colors.
-   These rules MUST use !important and high specificity to win. */
-
-/* Storybook's docs styles aggressively recolor paragraph text; pin it to the
-   bubble foreground variable so both themes derive from one source. */
-.sui-message-ai .sui-message-bubble p,
-.sui-message-ai .sui-message-bubble strong,
-.sui-message-ai .sui-message-bubble em,
-.sui-message-ai .sui-message-bubble span,
-.sui-message-ai .sui-message-bubble li {
-  color: hsl(var(--ai-bubble-fg)) !important;
-}
-
-/* Inline code styling */
-.sui-message-bubble code {
-  font-family: var(--font-mono);
-  font-size: 14px !important;
-  background: hsl(var(--muted)) !important;
-  color: inherit !important;
-  padding: 0.1em 0.35em;
-  border-radius: 3px;
-  border: 1px solid hsl(var(--border));
-}
-
-.sui-message-ai .sui-message-bubble code {
-  background: hsl(var(--ai-bubble-border) / 0.5);
-}
-
 .sui-message-images {
   display: flex;
   gap: var(--space-2);
@@ -1110,99 +1318,144 @@
 }
 
 /* ============================================
-   Input Form (Gemini-style pill)
+   Composer: bordered card, prompt above a control row
    ============================================ */
-/* Composer modeled on ChatGPT/Claude: taller container, 15px text, larger
-   icons, prominent circular send — the familiar AI-chat input ergonomics. */
-.sui-input-form {
+.sui-composer-area {
+  padding: 8px 40px 20px;
   display: flex;
-  align-items: flex-end; /* Align buttons to bottom when textarea expands */
-  gap: var(--space-1);
-  background: hsl(var(--card));
-  border: 1px solid hsl(var(--input-strong));
-  border-radius: 16px;
-  padding: 10px;
-  min-height: 56px;
-  transition: all var(--transition-fast);
-}
-
-.sui-input-form:focus-within {
-  border-color: hsl(var(--ring));
-  box-shadow: 0 0 0 2px hsl(var(--ring) / 0.25);
-}
-
-.sui-input-form-upload {
-  width: 36px;
-  height: 36px;
-  border-radius: var(--radius-xl);
-  display: flex;
-  align-items: center;
   justify-content: center;
-  color: hsl(var(--muted-foreground));
   flex-shrink: 0;
-  border: none;
-  background: none;
-  cursor: pointer;
+}
+
+.sui-composer {
+  width: 100%;
+  max-width: var(--max-chat-width);
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  padding: 12px 14px 10px;
+  /* Form-control boundary: 3:1 against the page (WCAG 1.4.11) */
+  border: 1px solid hsl(var(--input-strong));
+  border-radius: var(--radius-xl);
+  background: hsl(var(--card));
   transition: all var(--transition-fast);
 }
 
-.sui-input-form-upload:hover:not(:disabled) {
-  background: hsl(var(--secondary));
-  color: hsl(var(--foreground));
+.sui-composer:focus-within {
+  border-color: hsl(var(--ring));
+  box-shadow: 0 0 0 2px hsl(var(--ring) / 0.2);
 }
 
-.sui-input-form-upload:disabled {
-  opacity: 0.5;
-  cursor: not-allowed;
-}
-
-.sui-input-form-field {
-  flex: 1;
+.sui-composer-field {
+  width: 100%;
+  padding: 2px 0;
   border: none;
   background: transparent;
   color: hsl(var(--foreground));
-  /* Input text is content, not chrome — 16px matches ChatGPT/Claude inputs. */
-  font-size: 16px !important;
   font-family: inherit;
-  padding: 7px 8px 7px 6px;
-  min-height: 36px;
+  font-size: 15px !important;
+  line-height: 1.5;
+  min-height: 26px;
   max-height: 200px;
-  min-width: 0;
   resize: none;
   outline: none;
-  line-height: 1.45;
   overflow-y: auto;
   /* Auto-expands with content via JS, scrolls when max-height reached */
 }
 
-.sui-input-form-field::placeholder {
+.sui-composer-field::placeholder {
   color: hsl(var(--muted-foreground));
   opacity: 1; /* Firefox dims placeholders by default */
 }
 
-.sui-input-form-send {
-  width: 36px;
-  height: 36px;
-  border-radius: var(--radius-full);
+.sui-composer-row {
   display: flex;
   align-items: center;
-  justify-content: center;
-  background: hsl(var(--primary));
-  color: hsl(var(--primary-foreground));
-  flex-shrink: 0;
-  border: none;
+  gap: 8px;
+}
+
+.sui-composer-spacer {
+  flex: 1 1 auto;
+}
+
+.sui-composer .sui-icon-btn svg {
+  width: 18px;
+  height: 18px;
+}
+
+.sui-composer .sui-voice-toggle {
+  width: 28px;
+  height: 28px;
+  border-radius: var(--radius-md);
+}
+
+.sui-composer .sui-voice-toggle svg {
+  width: 18px;
+  height: 18px;
+}
+
+/* Provider + model, as one chip that opens the chooser */
+.sui-model-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  height: 26px;
+  padding: 0 10px;
+  border: 1px solid hsl(var(--border));
+  border-radius: var(--radius-full);
+  background: transparent;
+  color: hsl(var(--muted-foreground));
+  font-family: inherit;
+  font-size: 12px !important;
+  white-space: nowrap;
   cursor: pointer;
   transition: all var(--transition-fast);
 }
 
-.sui-input-form-send:hover:not(:disabled) {
+.sui-model-chip:hover,
+.sui-model-chip[aria-expanded="true"] {
+  color: hsl(var(--foreground));
+  border-color: hsl(var(--input-strong));
+}
+
+.sui-model-chip:focus-visible {
+  outline: 2px solid hsl(var(--ring));
+  outline-offset: 1px;
+}
+
+.sui-composer-send {
+  width: 32px;
+  height: 32px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border: none;
+  border-radius: var(--radius-full);
+  background: hsl(var(--primary));
+  color: hsl(var(--primary-foreground));
+  flex-shrink: 0;
+  cursor: pointer;
+  transition: all var(--transition-fast);
+}
+
+.sui-composer-send:hover:not(:disabled) {
   background: hsl(var(--primary) / 0.9);
 }
 
-.sui-input-form-send:disabled {
+.sui-composer-send:focus-visible {
+  outline: 2px solid hsl(var(--ring));
+  outline-offset: 2px;
+}
+
+.sui-composer-send:disabled {
   background: hsl(var(--muted));
   color: hsl(var(--muted-foreground));
   cursor: not-allowed;
+}
+
+.sui-composer-send svg {
+  width: 16px;
+  height: 16px;
 }
 
 /* ============================================
@@ -1212,8 +1465,7 @@
   display: flex;
   align-items: center;
   gap: var(--space-2);
-  padding: var(--space-2) var(--space-3);
-  margin-bottom: var(--space-2);
+  padding: 2px 0;
   flex-wrap: wrap;
 }
 
@@ -1392,14 +1644,6 @@
   margin-top: var(--space-3);
   font-size: 14px !important;
   color: hsl(var(--muted-foreground)) !important;
-}
-
-/* Generation-time stamp under the AI reply — metadata, not prose */
-.sui-message-meta {
-  margin-top: 10px;
-  font-size: 14px !important;
-  color: hsl(var(--muted-foreground)) !important;
-  font-variant-numeric: tabular-nums;
 }
 
 /* Fallback story styling (error placeholder was created) */
@@ -2452,13 +2696,15 @@
   white-space: nowrap;
 }
 
-/* Mode toggle */
+/* Mode tabs: bordered group, 4px radius, the active tab tinted primary */
 .sui-mode-toggle {
   display: flex;
-  background: hsl(var(--muted));
+  align-items: center;
+  gap: 4px;
+  padding: 3px;
+  background: hsl(var(--card));
+  border: 1px solid hsl(var(--border));
   border-radius: var(--radius-md);
-  padding: 2px;
-  gap: 2px;
 }
 
 .sui-mode-toggle-btn {
@@ -2468,7 +2714,8 @@
   border-radius: var(--radius-md);
   background: transparent;
   color: hsl(var(--muted-foreground));
-  font-size: 14px !important;
+  font-family: inherit;
+  font-size: 13px !important;
   font-weight: 600;
   cursor: pointer;
   transition: all 0.15s ease;
@@ -2479,49 +2726,33 @@
   color: hsl(var(--foreground));
 }
 
+.sui-mode-toggle-btn:focus-visible {
+  outline: 2px solid hsl(var(--ring));
+  outline-offset: 1px;
+}
+
+/* A primary tint (not the accent token) keeps primary text at 4.5:1 on the
+   tab in both schemes. */
 .sui-mode-toggle-btn--active {
-  background: hsl(var(--background));
+  background: hsl(var(--primary) / var(--tint));
   color: hsl(var(--primary));
-  box-shadow: 0 1px 2px hsl(210 10% 20% / 0.12);
 }
 
 /* ============================================
    Conversational chat additions (chatSummary era)
    ============================================ */
 
-/* Suggestion chips + retry actions under AI messages. Capped at the AI
-   bubble's max-width so the row reads as part of the response card, with
-   enough clearance that it doesn't crowd the card's border. */
-.sui-message-suggestions,
-.sui-message-actions {
-  display: flex;
-  flex-wrap: wrap;
-  align-items: center;
-  gap: 8px;
-  max-width: 85%;
-}
-
-/* Whichever row comes directly after the card gets clear 16px separation;
-   the second row sits 10px under the first. */
-.sui-message-actions,
-.sui-message-suggestions {
-  margin-top: 16px;
-}
-
-.sui-message-actions + .sui-message-suggestions {
-  margin-top: 10px;
-}
-
 /* Shown when a story file was written but Storybook never indexed it. Reads as
    a notice, not an error — the story exists, it just isn't reachable yet. */
 .sui-index-stalled {
+  display: flex;
   flex-direction: column;
   align-items: flex-start;
   gap: 10px;
   padding: 12px 14px;
   border: 1px solid var(--sui-border, rgba(128, 128, 128, 0.32));
   border-left: 3px solid var(--sui-warning, #d08700);
-  border-radius: 6px;
+  border-radius: var(--radius-xl);
   background: var(--sui-surface-subtle, rgba(128, 128, 128, 0.06));
 }
 
@@ -2542,8 +2773,7 @@
   white-space: normal;
 }
 
-/* Suggestions are secondary to the one true primary action ("Open in
-   Storybook") — regular weight + muted color creates the two-tier hierarchy. */
+/* Suggestions are quiet: regular weight, muted colour, 4px radius. */
 .sui-chip-suggestion {
   font-weight: 400;
   color: hsl(var(--muted-foreground)) !important;
@@ -2556,41 +2786,6 @@
 .sui-chip-retry {
   border-color: hsl(var(--destructive) / 0.5) !important;
   color: hsl(var(--destructive)) !important;
-}
-
-/* Collapsible generated-code view inside AI messages */
-.sui-message-code {
-  margin-top: 12px;
-  border: 1px solid hsl(var(--border));
-  border-radius: var(--radius-md);
-  overflow: hidden;
-}
-
-.sui-message-code summary {
-  cursor: pointer;
-  padding: 7px 12px;
-  font-size: 14px !important;
-  font-weight: 700;
-  user-select: none;
-  color: hsl(var(--muted-foreground));
-  background: hsl(var(--muted));
-}
-
-.sui-message-code summary:hover {
-  color: hsl(var(--primary));
-}
-
-.sui-message-code[open] summary {
-  border-bottom: 1px solid hsl(var(--border));
-}
-
-.sui-message-code pre {
-  margin: 0;
-  padding: 12px;
-  max-height: 320px;
-  overflow: auto;
-  font-size: 14px !important;
-  line-height: 1.5;
 }
 
 /* Intent (plan) line inside the progress indicator. Color tokens instead of
@@ -2631,30 +2826,6 @@
   letter-spacing: normal;
 }
 
-/* Header controls must never wrap mid-label */
-.sui-select-trigger,
-.sui-header .sui-header-subtitle {
-  white-space: nowrap;
-}
-
-
-
-/* "Open in Storybook" chip — solid primary button, the primary post-generation action */
-.sui-chip-open-story {
-  gap: 6px;
-  height: 30px;
-  background: hsl(var(--primary)) !important;
-  border-color: transparent !important;
-  color: hsl(var(--primary-foreground)) !important;
-  font-weight: 700;
-}
-
-.sui-chip-open-story:hover {
-  background: hsl(var(--primary) / 0.9) !important;
-  border-color: transparent !important;
-  color: hsl(var(--primary-foreground)) !important;
-}
-
 /* ============================================
    Voice Canvas — live code stream (watch the model write)
    ============================================ */
@@ -2684,37 +2855,12 @@
   background: hsl(var(--background) / 0.92);
 }
 
-/* Suggestion chips and actions flow BELOW the bubble, not beside it */
-.sui-message-user,
-.sui-message-ai {
-  flex-wrap: wrap;
-}
-
-.sui-message-suggestions,
-.sui-message-actions {
-  flex-basis: 100%;
-}
-
-
 /* Dark mode: lighter tint behind the primary-colored completion tags keeps
    the #479DFF accent itself AA-compliant (4.64:1) without drifting its hue. */
 .sui-root.dark .sui-completion-tag {
   background: hsl(var(--primary) / 0.06) !important;
 }
 
-
-/* Composer icons at AI-chat scale (the inline SVGs default to 14-16px) */
-.sui-input-form-upload svg,
-.sui-input-form-send svg,
-.sui-input-form .sui-voice-toggle svg {
-  width: 18px;
-  height: 18px;
-}
-
-.sui-input-form .sui-voice-toggle {
-  width: 36px;
-  height: 36px;
-}
 
 /* ============================================================
    Design Context editor
@@ -2998,75 +3144,99 @@
    Verification badge + handoff
    ============================================================ */
 
+/* The badge sits inline in a turn's meta row as a pill; its detail panel
+   drops to a full-width row underneath (display: contents lets the row's
+   flex-wrap place both). */
 .sui-verify {
-  margin-top: 16px;
-  max-width: 85%;
-  border: 1px solid var(--sui-border, rgba(128, 128, 128, 0.32));
-  border-left-width: 3px;
-  border-radius: 6px;
-  background: var(--sui-surface-subtle, rgba(128, 128, 128, 0.05));
-  overflow: hidden;
+  display: contents;
 }
 
-.sui-verify--verified { border-left-color: var(--sui-success, #16a34a); }
-.sui-verify--issues { border-left-color: var(--sui-danger, #dc2626); }
-.sui-verify--not_verified { border-left-color: var(--sui-text-secondary, #9ca3af); }
-
-.sui-verify-head {
-  display: flex;
+.sui-verify-pill {
+  display: inline-flex;
   align-items: center;
-  gap: 8px;
-  width: 100%;
-  padding: 9px 12px;
+  gap: 6px;
+  padding: 3px 9px;
   border: 0;
-  background: transparent;
-  color: inherit;
-  font-size: 13px;
-  text-align: left;
+  border-radius: var(--radius-full);
+  font-family: inherit;
+  font-size: 13px !important;
+  font-weight: 600;
+  line-height: 1.4;
+  white-space: nowrap;
+}
+
+button.sui-verify-pill {
   cursor: pointer;
+}
+
+button.sui-verify-pill:hover {
+  filter: brightness(0.96);
+}
+
+.sui-root.dark button.sui-verify-pill:hover {
+  filter: brightness(1.12);
+}
+
+button.sui-verify-pill:focus-visible {
+  outline: 2px solid hsl(var(--ring));
+  outline-offset: 2px;
 }
 
 .sui-verify-dot {
   flex: 0 0 auto;
-  width: 7px;
-  height: 7px;
+  width: 6px;
+  height: 6px;
   border-radius: 50%;
   background: currentColor;
 }
 
-.sui-verify--verified .sui-verify-dot { color: var(--sui-success, #16a34a); }
-.sui-verify--issues .sui-verify-dot { color: var(--sui-danger, #dc2626); }
-.sui-verify--not_verified .sui-verify-dot { color: var(--sui-text-secondary, #9ca3af); }
-
-.sui-verify-label { font-weight: 600; }
-
-.sui-verify-summary {
-  flex: 1 1 auto;
-  min-width: 0;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
-  color: var(--sui-text-secondary, #6b7280);
+.sui-verify--ok .sui-verify-pill {
+  background: hsl(var(--success) / var(--tint));
+  color: hsl(var(--success));
 }
 
-.sui-verify-toggle {
-  flex: 0 0 auto;
-  font-size: 12px;
-  color: var(--sui-accent, #2563eb);
+.sui-verify--warn .sui-verify-pill {
+  background: hsl(var(--warning) / var(--tint));
+  color: hsl(var(--warning));
+}
+
+.sui-verify--bad .sui-verify-pill {
+  background: hsl(var(--destructive) / var(--tint));
+  color: hsl(var(--destructive));
+}
+
+.sui-verify--muted .sui-verify-pill {
+  background: hsl(var(--secondary));
+  color: hsl(var(--muted-foreground));
+}
+
+.sui-verify-detail {
+  flex-basis: 100%;
+  padding: 10px 12px;
+  border: 1px solid hsl(var(--border));
+  border-radius: var(--radius-xl);
+  background: hsl(var(--card));
+  font-size: 13px !important;
+  line-height: 1.45;
+  color: hsl(var(--foreground));
+}
+
+.sui-verify-summary {
+  color: hsl(var(--muted-foreground));
 }
 
 .sui-verify-metrics {
-  padding: 0 12px 9px;
-  font-size: 11px;
+  margin-top: 4px;
+  font-size: 12px !important;
   font-variant-numeric: tabular-nums;
-  color: var(--sui-text-secondary, #6b7280);
+  color: hsl(var(--muted-foreground));
 }
 
 .sui-verify-list {
-  margin: 0;
-  padding: 4px 12px 12px;
+  margin: 8px 0 0;
+  padding: 4px 0 0;
   list-style: none;
-  border-top: 1px solid var(--sui-border, rgba(128, 128, 128, 0.22));
+  border-top: 1px solid hsl(var(--border));
 }
 
 .sui-verify-item {
@@ -3078,7 +3248,7 @@
 }
 
 .sui-verify-item + .sui-verify-item {
-  border-top: 1px solid var(--sui-border, rgba(128, 128, 128, 0.14));
+  border-top: 1px solid hsl(var(--border) / 0.6);
 }
 
 .sui-verify-item-sev {
@@ -3088,15 +3258,15 @@
   text-transform: uppercase;
 }
 
-.sui-verify-item--blocker .sui-verify-item-sev { color: var(--sui-danger, #dc2626); }
-.sui-verify-item--warning .sui-verify-item-sev { color: var(--sui-warning, #d08700); }
+.sui-verify-item--blocker .sui-verify-item-sev { color: hsl(var(--destructive)); }
+.sui-verify-item--warning .sui-verify-item-sev { color: hsl(var(--warning)); }
 
-.sui-verify-item-ev { font-size: 12px; color: var(--sui-text-secondary, #6b7280); }
+.sui-verify-item-ev { font-size: 12px; color: hsl(var(--muted-foreground)); }
 
 .sui-verify-item-sel {
-  font-family: var(--sui-mono, ui-monospace, SFMono-Regular, Menlo, monospace);
+  font-family: var(--font-mono);
   font-size: 11px;
-  color: var(--sui-text-secondary, #6b7280);
+  color: hsl(var(--muted-foreground));
   overflow-wrap: anywhere;
 }
 

--- a/templates/StoryUI/StoryUIPanel.tsx
+++ b/templates/StoryUI/StoryUIPanel.tsx
@@ -82,6 +82,13 @@ interface Message {
   generationTimeMs?: number;
   /** Storybook component id (persisted) — resolved to a full entry id on chat open. */
   storybookComponentId?: string;
+  /**
+   * Progress messages seen while this reply streamed, in order — the
+   * "12 steps · 31s" disclosure. Live only: the manifest does not keep them.
+   */
+  steps?: string[];
+  /** True when this reply updated an existing story rather than creating one. */
+  isUpdate?: boolean;
 }
 
 interface ChatSession {
@@ -1058,10 +1065,25 @@ const Icons = {
       <path d="M14.7 6.3a1 1 0 0 0 0 1.4l1.6 1.6a1 1 0 0 0 1.4 0l3.77-3.77a6 6 0 0 1-7.94 7.94l-6.91 6.91a2.12 2.12 0 0 1-3-3l6.91-6.91a6 6 0 0 1 7.94-7.94l-3.76 3.76z" />
     </svg>
   ),
-  openExternal: ( /* Storybook ShareAltIcon geometry — used by "Open in Storybook" */
-    <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round">
-      <path d="M12.5 4.5H5.75A1.75 1.75 0 0 0 4 6.25v12A1.75 1.75 0 0 0 5.75 20h12a1.75 1.75 0 0 0 1.75-1.75V11.5" />
-      <path d="M14.5 3.5H20.5V9.5M20 4 11.5 12.5" />
+  openExternal: ( /* "Open in Storybook" — box with an arrow leaving it */
+    <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.8" strokeLinecap="round" strokeLinejoin="round">
+      <path d="M14 4h6v6M20 4l-9 9M18 13v6H5V6h6" />
+    </svg>
+  ),
+  code: ( /* "View code" — angle brackets */
+    <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.8" strokeLinecap="round" strokeLinejoin="round">
+      <path d="M8 7l-5 5 5 5M16 7l5 5-5 5" />
+    </svg>
+  ),
+  chevronRight: ( /* steps disclosure; rotated 90° by CSS when open */
+    <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+      <path d="M9 6l6 6-6 6" />
+    </svg>
+  ),
+  gear: ( /* settings */
+    <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.8" strokeLinecap="round" strokeLinejoin="round">
+      <circle cx="12" cy="12" r="3" />
+      <path d="M19.4 15a1.7 1.7 0 0 0 .3 1.8l.1.1a2 2 0 1 1-2.8 2.8l-.1-.1a1.7 1.7 0 0 0-1.8-.3 1.7 1.7 0 0 0-1 1.5V21a2 2 0 1 1-4 0v-.1a1.7 1.7 0 0 0-1.1-1.5 1.7 1.7 0 0 0-1.8.3l-.1.1a2 2 0 1 1-2.8-2.8l.1-.1a1.7 1.7 0 0 0 .3-1.8 1.7 1.7 0 0 0-1.5-1H3a2 2 0 1 1 0-4h.1a1.7 1.7 0 0 0 1.5-1.1 1.7 1.7 0 0 0-.3-1.8l-.1-.1a2 2 0 1 1 2.8-2.8l.1.1a1.7 1.7 0 0 0 1.8.3H9a1.7 1.7 0 0 0 1-1.5V3a2 2 0 1 1 4 0v.1a1.7 1.7 0 0 0 1 1.5 1.7 1.7 0 0 0 1.8-.3l.1-.1a2 2 0 1 1 2.8 2.8l-.1.1a1.7 1.7 0 0 0-.3 1.8V9a1.7 1.7 0 0 0 1.5 1H21a2 2 0 1 1 0 4h-.1a1.7 1.7 0 0 0-1.5 1z" />
     </svg>
   ),
 };
@@ -1194,16 +1216,6 @@ function parseInline(text: string): React.ReactNode[] {
 // Sub-Components
 // ============================================
 
-interface BadgeProps {
-  variant?: 'default' | 'secondary' | 'success' | 'destructive' | 'outline';
-  children: React.ReactNode;
-  className?: string;
-}
-
-const Badge: React.FC<BadgeProps> = ({ variant = 'default', children, className = '' }) => (
-  <span className={`sui-badge sui-badge-${variant} ${className}`}>{children}</span>
-);
-
 interface ProgressIndicatorProps {
   streamingState: StreamingState;
 }
@@ -1319,6 +1331,13 @@ function StoryUIPanel({ mcpPort }: StoryUIPanelProps) {
   const [orphanCount, setOrphanCount] = useState<number>(0);
   const [isDeletingOrphans, setIsDeletingOrphans] = useState<boolean>(false);
   const [storybookOrder, setStorybookOrder] = useState<Map<string, number>>(new Map());
+  // Presentation-only state for the thread: which popover is open (one at a
+  // time), which turns show their steps / code, and a transient "Copied".
+  type OpenMenu = null | 'title' | 'gear' | 'model' | { turn: number };
+  const [openMenu, setOpenMenu] = useState<OpenMenu>(null);
+  const [openSteps, setOpenSteps] = useState<Record<number, boolean>>({});
+  const [openCode, setOpenCode] = useState<Record<number, boolean>>({});
+  const [copiedTurn, setCopiedTurn] = useState<number | null>(null);
   const chatEndRef = useRef<HTMLDivElement>(null);
   const inputRef = useRef<HTMLTextAreaElement>(null);
 
@@ -1766,6 +1785,44 @@ function StoryUIPanel({ mcpPort }: StoryUIPanelProps) {
       document.removeEventListener('keydown', handleEscape);
     };
   }, [contextMenuId]);
+
+  // One popover at a time: a press outside its anchor, or Escape, closes it.
+  useEffect(() => {
+    if (!openMenu) return;
+    const handlePointerDown = (e: MouseEvent) => {
+      const target = e.target as HTMLElement | null;
+      if (!target?.closest?.('.sui-menu-anchor')) setOpenMenu(null);
+    };
+    const handleEscape = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') setOpenMenu(null);
+    };
+    document.addEventListener('mousedown', handlePointerDown);
+    document.addEventListener('keydown', handleEscape);
+    return () => {
+      document.removeEventListener('mousedown', handlePointerDown);
+      document.removeEventListener('keydown', handleEscape);
+    };
+  }, [openMenu]);
+
+  // Disclosure state is keyed by turn index; it must not carry over from one
+  // conversation into the next.
+  useEffect(() => {
+    setOpenSteps({});
+    setOpenCode({});
+    setOpenMenu(null);
+  }, [state.activeChatId]);
+
+  const copyCode = useCallback((turn: number, code: string) => {
+    const fail = () => dispatch({ type: 'SET_ERROR', payload: 'Could not copy the code to the clipboard.' });
+    try {
+      navigator.clipboard.writeText(code).then(() => {
+        setCopiedTurn(turn);
+        window.setTimeout(() => setCopiedTurn(t => (t === turn ? null : t)), 1600);
+      }).catch(fail);
+    } catch {
+      fail();
+    }
+  }, []);
 
   // Initialize on mount
   useEffect(() => {
@@ -2277,7 +2334,7 @@ function StoryUIPanel({ mcpPort }: StoryUIPanelProps) {
   }, []);
 
   // Finalize streaming
-  const finalizeStreamingConversation = useCallback(async (newConversation: Message[], completion: CompletionFeedback, userInput: string) => {
+  const finalizeStreamingConversation = useCallback(async (newConversation: Message[], completion: CompletionFeedback, userInput: string, steps?: string[]) => {
     // Track this story as panel-generated to prevent false MCP detection
     // The story ID is the fileName without .stories.tsx extension
     if (completion.success && completion.fileName) {
@@ -2300,6 +2357,8 @@ function StoryUIPanel({ mcpPort }: StoryUIPanelProps) {
       verification: completion.verification,
       storyFileName: completion.fileName,
       storyTitle: completion.title,
+      steps: steps?.length ? steps : undefined,
+      isUpdate,
     };
     const updatedConversation = [...newConversation, aiMsg];
     dispatch({ type: 'SET_CONVERSATION', payload: updatedConversation });
@@ -2457,6 +2516,8 @@ function StoryUIPanel({ mcpPort }: StoryUIPanelProps) {
         let buffer = '';
         let completionData: CompletionFeedback | null = null;
         let errorData: ErrorFeedback | null = null;
+        // Every progress message, once — becomes the reply's steps disclosure.
+        const progressLog: string[] = [];
         while (true) {
           const { done, value } = await reader.read();
           if (done) break;
@@ -2471,15 +2532,23 @@ function StoryUIPanel({ mcpPort }: StoryUIPanelProps) {
                   case 'intent':
                     dispatch({ type: 'UPDATE_STREAMING_STATE', payload: { intent: event.data as IntentPreview } });
                     break;
-                  case 'progress':
-                    dispatch({ type: 'UPDATE_STREAMING_STATE', payload: { progress: event.data as ProgressUpdate } });
+                  case 'progress': {
+                    const progress = event.data as ProgressUpdate;
+                    if (progress?.message && progressLog[progressLog.length - 1] !== progress.message) {
+                      progressLog.push(progress.message);
+                    }
+                    dispatch({ type: 'UPDATE_STREAMING_STATE', payload: { progress } });
                     break;
+                  }
                   case 'validation':
                     dispatch({ type: 'UPDATE_STREAMING_STATE', payload: { validation: event.data as ValidationFeedback } });
                     break;
-                  case 'retry':
-                    dispatch({ type: 'UPDATE_STREAMING_STATE', payload: { retry: event.data as RetryInfo } });
+                  case 'retry': {
+                    const retry = event.data as RetryInfo;
+                    if (retry?.reason) progressLog.push(`Retry ${retry.attempt}/${retry.maxAttempts}: ${retry.reason}`);
+                    dispatch({ type: 'UPDATE_STREAMING_STATE', payload: { retry } });
                     break;
+                  }
                   case 'completion':
                     completionData = event.data as CompletionFeedback;
                     // Register immediately so the story poller never classifies
@@ -2502,7 +2571,7 @@ function StoryUIPanel({ mcpPort }: StoryUIPanelProps) {
         }
         try { sessionStorage.removeItem(PENDING_GEN_KEY); } catch {}
         if (completionData) {
-          finalizeStreamingConversation(newConversation, completionData, userInput);
+          finalizeStreamingConversation(newConversation, completionData, userInput, progressLog);
         } else if (errorData) {
           dispatch({ type: 'SET_ERROR', payload: errorData.message });
           const errorConversation = [...newConversation, {
@@ -2857,37 +2926,36 @@ function StoryUIPanel({ mcpPort }: StoryUIPanelProps) {
   // ours on a tie and painted every heading and paragraph in the Design
   // Context and Voice Canvas tabs in the docs theme's fixed text colour:
   // #2E3338 on a dark panel, 1.2:1.
+  const connected = state.connectionStatus.connected;
+  // One ordering for the sidebar and the header's story switcher: Storybook's
+  // own sidebar order (from /index.json), alphabetical fallback.
+  const sortedChats = [...state.recentChats].sort((a, b) => {
+    const posA = storybookOrder.get(a.title.toLowerCase()) ?? Infinity;
+    const posB = storybookOrder.get(b.title.toLowerCase()) ?? Infinity;
+    if (posA !== posB) return posA - posB;
+    return a.title.localeCompare(b.title);
+  });
+  const composerPlaceholder = state.attachedImages.length > 0
+    ? 'Describe what to build from these images…'
+    : state.conversation.length > 0
+      ? 'Describe a change, or ask for something new'
+      : 'Describe a component or layout…';
+
   return (
     <div className={`sui-root sb-unstyled ${state.isDarkMode ? 'dark' : 'light'}`}>
-      {/* Sidebar */}
-      <aside className={`sui-sidebar ${state.sidebarOpen ? '' : 'collapsed'}`} aria-label="Chat history">
+      {/* Sidebar — toggled from the header; collapsed means zero width, and
+          its contents unmount so nothing hidden stays in the tab order. */}
+      <aside className={`sui-sidebar ${state.sidebarOpen ? '' : 'collapsed'}`} aria-label="Chat history" aria-hidden={!state.sidebarOpen}>
         {state.sidebarOpen && (
           <div className="sui-sidebar-content">
-            {/* New story + hide sidebar (icon-only) on one row */}
-            <div style={{ display: 'flex', alignItems: 'center', gap: '8px', marginBottom: '16px' }}>
-              <button className="sui-button sui-button-default" onClick={handleNewChat} style={{ flex: 1 }}>
-                {Icons.plus}
-                <span>{panelMode === 'canvas' ? 'New canvas' : 'New story'}</span>
-              </button>
-              <button
-                className="sui-button sui-button-ghost sui-button-icon"
-                onClick={() => dispatch({ type: 'TOGGLE_SIDEBAR' })}
-                aria-label="Hide sidebar"
-                title="Hide sidebar"
-              >
-                {Icons.panelLeft}
-              </button>
-            </div>
+            <button className="sui-button sui-button-default sui-sidebar-new" onClick={handleNewChat}>
+              {Icons.plus}
+              <span>{panelMode === 'canvas' ? 'New canvas' : 'New story'}</span>
+            </button>
 
             {/* Chat history */}
             <div className="sui-sidebar-chats">
-              {[...state.recentChats].sort((a, b) => {
-                // Match Storybook sidebar order (from /index.json); alphabetical fallback
-                const posA = storybookOrder.get(a.title.toLowerCase()) ?? Infinity;
-                const posB = storybookOrder.get(b.title.toLowerCase()) ?? Infinity;
-                if (posA !== posB) return posA - posB;
-                return a.title.localeCompare(b.title);
-              }).map(chat => (
+              {sortedChats.map(chat => (
                 <div
                   key={chat.id}
                   className={`sui-chat-item ${state.activeChatId === chat.id ? 'active' : ''} ${contextMenuId === chat.id ? 'menu-open' : ''} ${chat.conversation.length === 0 ? 'sui-chat-item--no-history' : ''}`}
@@ -2994,13 +3062,6 @@ function StoryUIPanel({ mcpPort }: StoryUIPanelProps) {
 
           </div>
         )}
-        {!state.sidebarOpen && (
-          <div style={{ padding: '12px', display: 'flex', justifyContent: 'center' }}>
-            <button className="sui-button sui-button-ghost sui-button-icon" onClick={() => dispatch({ type: 'SET_SIDEBAR', payload: true })} aria-label="Show sidebar">
-              {Icons.panelLeft}
-            </button>
-          </div>
-        )}
       </aside>
 
       {/* Main */}
@@ -3015,14 +3076,60 @@ function StoryUIPanel({ mcpPort }: StoryUIPanelProps) {
           </div>
         )}
 
-        {/* Header */}
+        {/* Header: wordmark + current story on the left, mode tabs centred,
+            status / settings / New on the right. Provider and model live in
+            the composer; the Storybook MCP toggle lives behind the gear. */}
         <header className="sui-header">
           <div className="sui-header-left">
+            <button
+              type="button"
+              className="sui-icon-btn"
+              onClick={() => dispatch({ type: 'TOGGLE_SIDEBAR' })}
+              aria-label={state.sidebarOpen ? 'Hide sidebar' : 'Show sidebar'}
+              title={state.sidebarOpen ? 'Hide sidebar' : 'Show sidebar'}
+            >
+              {Icons.panelLeft}
+            </button>
             <span className="sui-header-title">Story UI</span>
-            <Badge variant={state.connectionStatus.connected ? 'success' : 'destructive'}>
-              <span className="sui-badge-dot" />
-              {state.connectionStatus.connected ? getConnectionDisplayText() : 'Disconnected'}
-            </Badge>
+            {panelMode === 'chat' && (
+              <div className="sui-menu-anchor">
+                <button
+                  type="button"
+                  className="sui-title-chip"
+                  aria-haspopup="menu"
+                  aria-expanded={openMenu === 'title'}
+                  onClick={() => setOpenMenu(m => (m === 'title' ? null : 'title'))}
+                  title="Switch story"
+                >
+                  <span className="sui-title-chip-text">{state.activeTitle || 'New story'}</span>
+                  {Icons.chevronDown}
+                </button>
+                {openMenu === 'title' && (
+                  <div className="sui-menu sui-menu--stories" role="menu" aria-label="Stories">
+                    <button type="button" role="menuitem" className="sui-menu-item" onClick={() => { setOpenMenu(null); handleNewChat(); }}>
+                      {Icons.plus}
+                      <span className="sui-menu-item-label">New story</span>
+                    </button>
+                    {sortedChats.length > 0 && <div className="sui-menu-sep" role="separator" />}
+                    {sortedChats.map(chat => (
+                      <button
+                        key={chat.id}
+                        type="button"
+                        role="menuitemradio"
+                        aria-checked={chat.id === state.activeChatId}
+                        className={`sui-menu-item ${chat.id === state.activeChatId ? 'sui-menu-item--active' : ''}`}
+                        onClick={() => { setOpenMenu(null); handleSelectChat(chat); }}
+                      >
+                        <span className="sui-menu-item-label">{chat.title}</span>
+                        {chat.id === state.activeChatId && Icons.check}
+                      </button>
+                    ))}
+                  </div>
+                )}
+              </div>
+            )}
+          </div>
+          <div className="sui-header-center">
             <div className="sui-mode-toggle">
               <button
                 type="button"
@@ -3050,66 +3157,58 @@ function StoryUIPanel({ mcpPort }: StoryUIPanelProps) {
             </div>
           </div>
           <div className="sui-header-right">
-            {state.connectionStatus.connected && state.availableProviders.length > 0 && (
-              <>
-                <div className="sui-select">
-                  <div className="sui-select-trigger">
-                    <span>{state.availableProviders.find(p => p.type === state.selectedProvider)?.name || 'Provider'}</span>
-                    {Icons.chevronDown}
+            <span
+              className={`sui-status ${connected ? 'sui-status--ok' : 'sui-status--bad'}`}
+              title={connected ? getConnectionDisplayText() : (state.connectionStatus.error || 'Server not running')}
+            >
+              <span className="sui-status-dot" aria-hidden="true" />
+              {connected ? 'Connected' : 'Disconnected'}
+            </span>
+            <div className="sui-menu-anchor">
+              <button
+                type="button"
+                className="sui-icon-btn"
+                aria-label="Settings"
+                title="Settings"
+                aria-haspopup="menu"
+                aria-expanded={openMenu === 'gear'}
+                onClick={() => setOpenMenu(m => (m === 'gear' ? null : 'gear'))}
+              >
+                {Icons.gear}
+              </button>
+              {openMenu === 'gear' && (
+                <div className="sui-menu sui-menu--right" role="menu" aria-label="Settings">
+                  <div className="sui-menu-row" role="presentation">
+                    <span>Server</span>
+                    <span className="sui-menu-row-value">{connected ? getConnectionDisplayText() : (state.connectionStatus.error || 'Not connected')}</span>
                   </div>
-                  <select
-                    className="sui-select-native"
-                    value={state.selectedProvider}
-                    onChange={e => {
-                      const newProvider = e.target.value;
-                      dispatch({ type: 'SET_SELECTED_PROVIDER', payload: newProvider });
-                      const provider = state.availableProviders.find(p => p.type === newProvider);
-                      if (provider?.models.length) dispatch({ type: 'SET_SELECTED_MODEL', payload: provider.models[0] });
-                    }}
-                    aria-label="Select provider"
-                  >
-                    {state.availableProviders.map(p => <option key={p.type} value={p.type}>{p.name}</option>)}
-                  </select>
+                  {/* Storybook MCP toggle — only when the addon is detected */}
+                  {state.storybookMcpAvailable && (
+                    <label className="sui-menu-row sui-menu-row--toggle" title="Use Storybook MCP context for enhanced component generation">
+                      <span>MCP context</span>
+                      <span className="sui-toggle-switch">
+                        <input
+                          type="checkbox"
+                          role="menuitemcheckbox"
+                          checked={state.useStorybookMcp}
+                          onChange={e => {
+                            const enabled = e.target.checked;
+                            dispatch({ type: 'SET_USE_STORYBOOK_MCP', payload: enabled });
+                            saveStorybookMcpPref(enabled);
+                          }}
+                          aria-label="Use Storybook MCP context"
+                        />
+                        <span className="sui-toggle-slider" />
+                      </span>
+                    </label>
+                  )}
                 </div>
-                <div className="sui-select">
-                  <div className="sui-select-trigger">
-                    <span>{getModelDisplayName(state.selectedModel)}</span>
-                    {Icons.chevronDown}
-                  </div>
-                  <select
-                    className="sui-select-native"
-                    value={state.selectedModel}
-                    onChange={e => dispatch({ type: 'SET_SELECTED_MODEL', payload: e.target.value })}
-                    aria-label="Select model"
-                  >
-                    {state.availableProviders.find(p => p.type === state.selectedProvider)?.models.map(model => (
-                      <option key={model} value={model}>{getModelDisplayName(model)}</option>
-                    ))}
-                  </select>
-                </div>
-              </>
-            )}
-            {/* Storybook MCP Toggle - only shown when MCP addon is detected */}
-            {state.storybookMcpAvailable && (
-              <div className="sui-mcp-toggle" title="Use Storybook MCP context for enhanced component generation">
-                <label className="sui-toggle-label">
-                  <span className="sui-toggle-text">MCP context</span>
-                  <div className="sui-toggle-switch">
-                    <input
-                      type="checkbox"
-                      checked={state.useStorybookMcp}
-                      onChange={e => {
-                        const enabled = e.target.checked;
-                        dispatch({ type: 'SET_USE_STORYBOOK_MCP', payload: enabled });
-                        saveStorybookMcpPref(enabled);
-                      }}
-                      aria-label="Use Storybook MCP context"
-                    />
-                    <span className="sui-toggle-slider" />
-                  </div>
-                </label>
-              </div>
-            )}
+              )}
+            </div>
+            <button type="button" className="sui-button sui-button-default" onClick={handleNewChat}>
+              {Icons.plus}
+              <span>New</span>
+            </button>
           </div>
         </header>
 
@@ -3197,128 +3296,264 @@ function StoryUIPanel({ mcpPort }: StoryUIPanelProps) {
               </div>
             </div>
           ) : (
-            <div className="sui-chat-messages" role="log">
+            <div className="sui-thread" role="log">
               {state.conversation.map((msg, i) => {
                 const isLastMessage = i === state.conversation.length - 1;
-                return (
-                <article key={i} className={`sui-message ${msg.role === 'user' ? 'sui-message-user' : 'sui-message-ai'}`}>
-                  <div className="sui-message-bubble">
-                    {msg.role === 'ai' ? renderMarkdown(msg.content) : msg.content}
-                    {msg.role === 'user' && msg.attachedImages && msg.attachedImages.length > 0 && (
-                      <div className="sui-message-images">
-                        {msg.attachedImages.map(img => (
-                          <img key={img.id} src={img.base64 ? `data:${img.mediaType};base64,${img.base64}` : img.preview} alt="Image attached to this message" className="sui-message-image" />
-                        ))}
+
+                if (msg.role === 'user') {
+                  return (
+                    <article key={i} className="sui-turn sui-turn-user">
+                      <div className="sui-bubble">
+                        {msg.content}
+                        {msg.attachedImages && msg.attachedImages.length > 0 && (
+                          <div className="sui-message-images">
+                            {msg.attachedImages.map(img => (
+                              <img key={img.id} src={img.base64 ? `data:${img.mediaType};base64,${img.base64}` : img.preview} alt="Image attached to this message" className="sui-message-image" />
+                            ))}
+                          </div>
+                        )}
+                        {/* Reloaded from storage: the live attachments are gone, but
+                            the persisted thumbnails still show what was referenced. */}
+                        {!msg.attachedImages?.length && !!msg.thumbnails?.length && (
+                          <div className="sui-message-images">
+                            {msg.thumbnails.map((src, ti) => (
+                              <img key={ti} src={src} alt="Image attached to this message" className="sui-message-image" />
+                            ))}
+                          </div>
+                        )}
                       </div>
-                    )}
-                    {/* Reloaded from storage: the live attachments are gone, but
-                        the persisted thumbnails still show what was referenced. */}
-                    {msg.role === 'user' && !msg.attachedImages?.length && !!msg.thumbnails?.length && (
-                      <div className="sui-message-images">
-                        {msg.thumbnails.map((src, ti) => (
-                          <img key={ti} src={src} alt="Image attached to this message" className="sui-message-image" />
-                        ))}
-                      </div>
-                    )}
-                    {msg.role === 'ai' && typeof msg.generationTimeMs === 'number' && msg.generationTimeMs > 0 && (
-                      <div className="sui-message-meta">{(msg.generationTimeMs / 1000).toFixed(1)}s</div>
-                    )}
-                    {msg.role === 'ai' && msg.code && (
-                      <details className="sui-message-code">
-                        <summary>View generated code</summary>
-                        <pre><code>{msg.code}</code></pre>
-                      </details>
-                    )}
-                  </div>
-                  {msg.role === 'ai' && msg.isError && msg.retryInput && isLastMessage && !state.loading && (
-                    <div className="sui-message-actions">
+                    </article>
+                  );
+                }
+
+                // An update turn puts its meta line under the prose ("Updated ·
+                // Show changes · Verified"); a creation turn leads with it.
+                // Messages restored from the manifest predate the flag, so fall
+                // back to position: any reply after the first is an update.
+                const aiOrdinal = state.conversation.slice(0, i).filter(m => m.role === 'ai').length;
+                const isUpdateTurn = msg.isUpdate ?? aiOrdinal > 0;
+                const steps = msg.steps ?? [];
+                const secs = typeof msg.generationTimeMs === 'number' && msg.generationTimeMs > 0
+                  ? `${Math.round(msg.generationTimeMs / 1000)}s`
+                  : null;
+                const stepsOpen = !!openSteps[i];
+                const codeOpen = !!openCode[i];
+                const menuOpen = typeof openMenu === 'object' && openMenu !== null && openMenu.turn === i;
+                const showChanges = isUpdateTurn && !!msg.code;
+                const hasMeta = !msg.isError && (steps.length > 0 || !!secs || !!msg.verification || showChanges);
+                const canAct = !msg.isError && !state.loading && !!(msg.storyEntryId || msg.code || msg.storyFileName || state.activeChatId);
+                const priorUser = isLastMessage
+                  ? [...state.conversation.slice(0, i)].reverse().find(m => m.role === 'user')
+                  : undefined;
+                const toggleCode = () => setOpenCode(s => ({ ...s, [i]: !s[i] }));
+
+                const metaRow = hasMeta && (
+                  <div className="sui-turn-meta">
+                    {steps.length > 0 ? (
                       <button
                         type="button"
-                        className="sui-chip sui-chip-retry"
-                        onClick={() => handleSend(undefined, msg.retryInput)}
+                        className="sui-steps-toggle"
+                        aria-expanded={stepsOpen}
+                        onClick={() => setOpenSteps(s => ({ ...s, [i]: !s[i] }))}
+                        title={stepsOpen ? 'Hide generation steps' : 'Show generation steps'}
                       >
-                        ↻ Try again
+                        <span className={`sui-steps-chevron ${stepsOpen ? 'open' : ''}`} aria-hidden="true">{Icons.chevronRight}</span>
+                        <span>{steps.length} {steps.length === 1 ? 'step' : 'steps'}{secs ? ` · ${secs}` : ''}</span>
                       </button>
-                    </div>
-                  )}
-                  {/* Primary action on its own row; suggestions grouped below —
-                      mixing them in one wrapped row produced ragged layouts. */}
-                  {/* What the browser actually observed. "Not verified" is shown
-                      as plainly as a pass — claiming success we cannot prove is
-                      the failure mode this whole subsystem exists to end. */}
-                  {msg.role === 'ai' && !msg.isError && msg.verification && !state.loading && (
-                    <VerificationBadge verification={msg.verification} />
-                  )}
-                  {msg.role === 'ai' && !msg.isError && msg.storyEntryId && !state.loading && (
-                    <div className="sui-message-actions" aria-label="Story actions">
-                      <button
-                        type="button"
-                        className="sui-chip sui-chip-open-story"
-                        onClick={() => openStoryInStorybook(msg.storyEntryId!)}
-                      >
-                        Open in Storybook {Icons.openExternal}
-                      </button>
-                      {handoffStatus?.available && msg.storyFileName && (
-                        <button
-                          type="button"
-                          className="sui-chip"
-                          title="Commit this story to a new branch for a product engineer"
-                          onClick={() => setHandoffFor({ fileName: msg.storyFileName!, title: msg.storyTitle || 'Story' })}
-                        >
-                          Hand off →
+                    ) : secs ? (
+                      <span className="sui-turn-meta-text">{isUpdateTurn ? `Updated in ${secs}` : secs}</span>
+                    ) : showChanges ? (
+                      <span className="sui-turn-meta-text">Updated the story</span>
+                    ) : null}
+                    {showChanges && (
+                      <>
+                        <span className="sui-turn-meta-dot" aria-hidden="true">·</span>
+                        <button type="button" className="sui-link-btn" aria-expanded={codeOpen} onClick={toggleCode}>
+                          {codeOpen ? 'Hide changes' : 'Show changes'}
                         </button>
+                      </>
+                    )}
+                    {msg.verification && <VerificationBadge verification={msg.verification} />}
+                  </div>
+                );
+
+                return (
+                  <article key={i} className="sui-turn sui-turn-ai">
+                    <div className="sui-avatar" aria-hidden="true">S</div>
+                    <div className="sui-turn-body">
+                      {!isUpdateTurn && metaRow}
+                      {stepsOpen && steps.length > 0 && (
+                        <ol className="sui-steps" aria-label="Generation steps">
+                          {steps.map((s, si) => <li key={si}>{s}</li>)}
+                        </ol>
+                      )}
+                      <div className="sui-turn-prose">{renderMarkdown(msg.content)}</div>
+                      {isUpdateTurn && metaRow}
+                      {codeOpen && msg.code && (
+                        <div className="sui-code">
+                          <pre><code>{msg.code}</code></pre>
+                        </div>
+                      )}
+                      {msg.isError && msg.retryInput && isLastMessage && !state.loading && (
+                        <div className="sui-turn-suggestions">
+                          <button
+                            type="button"
+                            className="sui-chip sui-chip-retry"
+                            onClick={() => handleSend(undefined, msg.retryInput)}
+                          >
+                            ↻ Try again
+                          </button>
+                        </div>
+                      )}
+                      {/* The story exists on disk but Storybook's watcher never
+                          indexed it. Tell the user plainly and give them a way out
+                          instead of rendering nothing. */}
+                      {!msg.isError && !msg.storyEntryId && msg.storyIndexStalled && !state.loading && (
+                        <div className="sui-index-stalled" aria-label="Story indexing notice">
+                          <div className="sui-index-stalled-text">
+                            Storybook hasn’t picked this story up yet. The file was written
+                            {msg.storyIndexStalled.fileName ? ` to ${msg.storyIndexStalled.fileName}` : ''}, but
+                            it isn’t in the story index — this usually means Storybook’s file watcher stopped.
+                            Restart Storybook, then check again.
+                          </div>
+                          <button
+                            type="button"
+                            className="sui-chip"
+                            onClick={async () => {
+                              const found = await recheckStoryIndex(msg.storyIndexStalled!.storybookId);
+                              if (!found) {
+                                dispatch({ type: 'SET_ERROR', payload: 'Still not in the story index. Restart Storybook to pick up newly generated stories.' });
+                              }
+                            }}
+                          >
+                            Check again
+                          </button>
+                        </div>
+                      )}
+                      {/* Quiet action row: shown on hover, on focus-within for
+                          keyboard users, and while its menu is open. */}
+                      {canAct && (
+                        <div className={`sui-turn-actions ${menuOpen ? 'is-open' : ''}`} aria-label="Story actions">
+                          {msg.storyEntryId && (
+                            <button
+                              type="button"
+                              className="sui-icon-btn"
+                              title="Open in Storybook"
+                              aria-label="Open in Storybook"
+                              onClick={() => openStoryInStorybook(msg.storyEntryId!)}
+                            >
+                              {Icons.openExternal}
+                            </button>
+                          )}
+                          {msg.code && (
+                            <button
+                              type="button"
+                              className="sui-icon-btn"
+                              title={codeOpen ? 'Hide code' : 'View code'}
+                              aria-label={codeOpen ? 'Hide code' : 'View code'}
+                              aria-pressed={codeOpen}
+                              onClick={toggleCode}
+                            >
+                              {Icons.code}
+                            </button>
+                          )}
+                          <div className="sui-menu-anchor">
+                            <button
+                              type="button"
+                              className="sui-icon-btn"
+                              title="More actions"
+                              aria-label="More actions"
+                              aria-haspopup="menu"
+                              aria-expanded={menuOpen}
+                              onClick={() => setOpenMenu(m => (typeof m === 'object' && m !== null && m.turn === i ? null : { turn: i }))}
+                            >
+                              {Icons.moreVertical}
+                            </button>
+                            {menuOpen && (
+                              <div className="sui-menu" role="menu" aria-label="More actions">
+                                {handoffStatus?.available && msg.storyFileName && (
+                                  <button
+                                    type="button"
+                                    role="menuitem"
+                                    className="sui-menu-item"
+                                    title="Commit this story to a new branch for a product engineer"
+                                    onClick={() => { setOpenMenu(null); setHandoffFor({ fileName: msg.storyFileName!, title: msg.storyTitle || state.activeTitle || 'Story' }); }}
+                                  >
+                                    Hand off
+                                  </button>
+                                )}
+                                {msg.code && (
+                                  <button type="button" role="menuitem" className="sui-menu-item" onClick={() => { setOpenMenu(null); copyCode(i, msg.code!); }}>
+                                    Copy code
+                                  </button>
+                                )}
+                                {priorUser && (
+                                  <button type="button" role="menuitem" className="sui-menu-item" onClick={() => { setOpenMenu(null); handleSend(undefined, priorUser.content); }}>
+                                    Regenerate
+                                  </button>
+                                )}
+                                {state.activeChatId && (
+                                  <button
+                                    type="button"
+                                    role="menuitem"
+                                    className="sui-menu-item"
+                                    onClick={() => {
+                                      setOpenMenu(null);
+                                      // Rename edits inline in the sidebar list, so make sure it is visible.
+                                      dispatch({ type: 'SET_SIDEBAR', payload: true });
+                                      handleStartRename(state.activeChatId!, state.activeTitle);
+                                    }}
+                                  >
+                                    Rename story
+                                  </button>
+                                )}
+                                {state.activeChatId && (
+                                  <>
+                                    <div className="sui-menu-sep" role="separator" />
+                                    <button
+                                      type="button"
+                                      role="menuitem"
+                                      className="sui-menu-item sui-menu-item--danger"
+                                      onClick={() => { setOpenMenu(null); handleDeleteChat(state.activeChatId!); }}
+                                    >
+                                      Delete story
+                                    </button>
+                                  </>
+                                )}
+                              </div>
+                            )}
+                          </div>
+                          {copiedTurn === i && <span className="sui-turn-meta-text" role="status">Copied</span>}
+                        </div>
+                      )}
+                      {!msg.isError && isLastMessage && !state.loading && (msg.suggestions?.length ?? 0) > 0 && (
+                        <div className="sui-turn-suggestions" aria-label="Suggested follow-ups">
+                          {msg.suggestions!.map((suggestion, si) => (
+                            <button
+                              key={si}
+                              type="button"
+                              className="sui-chip sui-chip-suggestion"
+                              onClick={() => handleSend(undefined, suggestion)}
+                            >
+                              {suggestion}
+                            </button>
+                          ))}
+                        </div>
                       )}
                     </div>
-                  )}
-                  {/* The story exists on disk but Storybook's watcher never
-                      indexed it. Tell the user plainly and give them a way out
-                      instead of rendering nothing. */}
-                  {msg.role === 'ai' && !msg.isError && !msg.storyEntryId && msg.storyIndexStalled && !state.loading && (
-                    <div className="sui-message-actions sui-index-stalled" aria-label="Story indexing notice">
-                      <div className="sui-index-stalled-text">
-                        Storybook hasn’t picked this story up yet. The file was written
-                        {msg.storyIndexStalled.fileName ? ` to ${msg.storyIndexStalled.fileName}` : ''}, but
-                        it isn’t in the story index — this usually means Storybook’s file watcher stopped.
-                        Restart Storybook, then check again.
-                      </div>
-                      <button
-                        type="button"
-                        className="sui-chip"
-                        onClick={async () => {
-                          const found = await recheckStoryIndex(msg.storyIndexStalled!.storybookId);
-                          if (!found) {
-                            dispatch({ type: 'SET_ERROR', payload: 'Still not in the story index. Restart Storybook to pick up newly generated stories.' });
-                          }
-                        }}
-                      >
-                        Check again
-                      </button>
-                    </div>
-                  )}
-                  {msg.role === 'ai' && !msg.isError && isLastMessage && !state.loading && (msg.suggestions?.length ?? 0) > 0 && (
-                    <div className="sui-message-suggestions" aria-label="Suggested follow-ups">
-                      {msg.suggestions!.map((suggestion, si) => (
-                        <button
-                          key={si}
-                          type="button"
-                          className="sui-chip sui-chip-suggestion"
-                          onClick={() => handleSend(undefined, suggestion)}
-                        >
-                          {suggestion}
-                        </button>
-                      ))}
-                    </div>
-                  )}
-                </article>
+                  </article>
                 );
               })}
               {state.loading && (
-                <div className="sui-message sui-message-ai">
-                  {state.streamingState ? <ProgressIndicator streamingState={state.streamingState} /> : (
-                    <div className="sui-progress">
-                      <span className="sui-progress-label">Generating your story<span className="sui-loading" /></span>
-                    </div>
-                  )}
+                <div className="sui-turn sui-turn-ai">
+                  <div className="sui-avatar" aria-hidden="true">S</div>
+                  <div className="sui-turn-body">
+                    {state.streamingState ? <ProgressIndicator streamingState={state.streamingState} /> : (
+                      <div className="sui-progress">
+                        <span className="sui-progress-label">Generating your story<span className="sui-loading" /></span>
+                      </div>
+                    )}
+                  </div>
                 </div>
               )}
               <div ref={chatEndRef} />
@@ -3326,9 +3561,10 @@ function StoryUIPanel({ mcpPort }: StoryUIPanelProps) {
           )}
         </section>
 
-        {/* Input area */}
-        <div className="sui-input-area">
-          <div className="sui-input-container">
+        {/* Composer: bordered card; the prompt on top, controls underneath —
+            attach, voice, model chip, and the round send at the right. */}
+        <div className="sui-composer-area">
+          <form onSubmit={handleSend} className="sui-composer">
             <input ref={fileInputRef} type="file" accept="image/*" multiple style={{ display: 'none' }} onChange={handleFileSelect} />
             {state.attachedImages.length > 0 && (
               <div className="sui-image-previews">
@@ -3336,33 +3572,41 @@ function StoryUIPanel({ mcpPort }: StoryUIPanelProps) {
                 {state.attachedImages.map(img => (
                   <div key={img.id} className="sui-image-preview-item">
                     <img src={img.preview} alt="Attached image preview" className="sui-image-preview-thumb" />
-                    <button className="sui-image-preview-remove" onClick={() => removeAttachedImage(img.id)} aria-label="Remove attached image">{Icons.x}</button>
+                    <button type="button" className="sui-image-preview-remove" onClick={() => removeAttachedImage(img.id)} aria-label="Remove attached image">{Icons.x}</button>
                   </div>
                 ))}
               </div>
             )}
-            <form onSubmit={handleSend} className="sui-input-form" style={state.attachedImages.length > 0 ? { borderTopLeftRadius: 0, borderTopRightRadius: 0 } : undefined}>
-              <button type="button" className="sui-input-form-upload" onClick={() => fileInputRef.current?.click()} disabled={state.loading || state.attachedImages.length >= MAX_IMAGES} aria-label="Attach images">
-                {Icons.image}
-              </button>
-              <textarea
-                ref={inputRef}
-                rows={1}
-                className="sui-input-form-field"
-                value={state.input}
-                onChange={e => dispatch({ type: 'SET_INPUT', payload: e.target.value })}
-                onKeyDown={e => {
-                  // Submit on Enter, newline on Shift+Enter
-                  if (e.key === 'Enter' && !e.shiftKey) {
-                    e.preventDefault();
-                    if (!state.loading && (state.input.trim() || state.attachedImages.length > 0)) {
-                      handleSend(e as unknown as React.FormEvent);
-                    }
+            <textarea
+              ref={inputRef}
+              rows={1}
+              className="sui-composer-field"
+              value={state.input}
+              onChange={e => dispatch({ type: 'SET_INPUT', payload: e.target.value })}
+              onKeyDown={e => {
+                // Submit on Enter, newline on Shift+Enter
+                if (e.key === 'Enter' && !e.shiftKey) {
+                  e.preventDefault();
+                  if (!state.loading && (state.input.trim() || state.attachedImages.length > 0)) {
+                    handleSend(e as unknown as React.FormEvent);
                   }
-                }}
-                onPaste={handlePaste}
-                placeholder={state.attachedImages.length > 0 ? 'Describe what to build from these images…' : 'Describe a component or layout…'}
-              />
+                }
+              }}
+              onPaste={handlePaste}
+              placeholder={composerPlaceholder}
+              aria-label="Prompt"
+            />
+            <div className="sui-composer-row">
+              <button
+                type="button"
+                className="sui-icon-btn"
+                onClick={() => fileInputRef.current?.click()}
+                disabled={state.loading || state.attachedImages.length >= MAX_IMAGES}
+                aria-label="Attach images"
+                title="Attach images"
+              >
+                {Icons.plus}
+              </button>
               <VoiceControls
                 onTranscript={handleVoiceTranscript}
                 onCommand={handleVoiceCommand}
@@ -3370,11 +3614,56 @@ function StoryUIPanel({ mcpPort }: StoryUIPanelProps) {
                 onListeningChange={(listening) => { voiceModeActiveRef.current = listening; }}
                 disabled={state.loading}
               />
-              <button type="submit" className="sui-input-form-send" disabled={state.loading || (!state.input.trim() && state.attachedImages.length === 0)} aria-label="Send">
+              {connected && state.availableProviders.length > 0 && (
+                <div className="sui-menu-anchor">
+                  <button
+                    type="button"
+                    className="sui-model-chip"
+                    aria-haspopup="menu"
+                    aria-expanded={openMenu === 'model'}
+                    onClick={() => setOpenMenu(m => (m === 'model' ? null : 'model'))}
+                    title="Choose provider and model"
+                  >
+                    <span>{state.selectedModel ? getModelDisplayName(state.selectedModel) : 'Model'}</span>
+                    {Icons.chevronDown}
+                  </button>
+                  {openMenu === 'model' && (
+                    <div className="sui-menu sui-menu--up" role="menu" aria-label="Provider and model">
+                      {state.availableProviders.map(p => (
+                        <div key={p.type} className="sui-menu-group" role="group" aria-label={p.name}>
+                          <div className="sui-menu-heading">{p.name}</div>
+                          {p.models.map(model => {
+                            const selected = p.type === state.selectedProvider && model === state.selectedModel;
+                            return (
+                              <button
+                                key={model}
+                                type="button"
+                                role="menuitemradio"
+                                aria-checked={selected}
+                                className={`sui-menu-item ${selected ? 'sui-menu-item--active' : ''}`}
+                                onClick={() => {
+                                  dispatch({ type: 'SET_SELECTED_PROVIDER', payload: p.type });
+                                  dispatch({ type: 'SET_SELECTED_MODEL', payload: model });
+                                  setOpenMenu(null);
+                                }}
+                              >
+                                <span className="sui-menu-item-label">{getModelDisplayName(model)}</span>
+                                {selected && Icons.check}
+                              </button>
+                            );
+                          })}
+                        </div>
+                      ))}
+                    </div>
+                  )}
+                </div>
+              )}
+              <span className="sui-composer-spacer" />
+              <button type="submit" className="sui-composer-send" disabled={state.loading || (!state.input.trim() && state.attachedImages.length === 0)} aria-label="Send">
                 {Icons.send}
               </button>
-            </form>
-          </div>
+            </div>
+          </form>
         </div>
         </>
         )}

--- a/templates/StoryUI/VerificationBadge.tsx
+++ b/templates/StoryUI/VerificationBadge.tsx
@@ -7,6 +7,11 @@
  * story works, is broken, or does not exist. So "not verified" is presented as
  * plainly as a pass here; a confident green tick we cannot back up is worse than
  * no tick at all.
+ *
+ * Rendered as a pill in the turn's meta row ("● Verified · 6/6 checks"). The
+ * pill is a button only when there is something to reveal — findings, a
+ * reason, metrics — and a plain span otherwise, so nothing advertises a
+ * control that no-ops.
  */
 
 import React, { useState } from 'react';
@@ -26,12 +31,6 @@ interface VerificationResult {
   findings: VerificationFinding[];
   metrics?: Record<string, number | string | boolean | string[]>;
 }
-
-const LABEL: Record<VerificationResult['outcome'], string> = {
-  verified: 'Verified in browser',
-  issues: 'Issues found',
-  not_verified: 'Not verified',
-};
 
 /** Metrics worth showing a designer, in the order they answer "does it work". */
 const HEADLINE_METRICS: Array<{ key: string; label: string }> = [
@@ -55,52 +54,84 @@ export const VerificationBadge: React.FC<{ verification: VerificationResult }> =
   const blockerCount = blockers.length || Number(metrics?.blockers ?? 0) || 0;
   const warningCount = warnings.length || Number(metrics?.warnings ?? 0) || 0;
 
-  const summary = outcome === 'not_verified'
-    ? reason || 'Verification could not run'
-    : [
-        blockerCount ? `${blockerCount} blocking` : '',
-        warningCount ? `${warningCount} warning${warningCount === 1 ? '' : 's'}` : '',
-      ].filter(Boolean).join(', ') || 'no issues found';
+  const checksRun = typeof metrics?.checksRun === 'number' ? metrics.checksRun : undefined;
+  const checksTotal = typeof metrics?.checksTotal === 'number' ? metrics.checksTotal : undefined;
+  const checksLabel = checksRun !== undefined && checksTotal !== undefined ? `${checksRun}/${checksTotal} checks` : '';
+
+  const issueSummary = [
+    blockerCount ? `${blockerCount} blocking` : '',
+    warningCount ? `${warningCount} warning${warningCount === 1 ? '' : 's'}` : '',
+  ].filter(Boolean).join(', ');
+
+  // Green for a clean pass, amber for warnings only, red once anything
+  // blocks, grey when the check could not run at all.
+  const tone = outcome === 'verified' ? 'ok'
+    : outcome === 'issues' ? (blockerCount > 0 ? 'bad' : 'warn')
+    : 'muted';
+
+  const label = outcome === 'verified'
+    ? `Verified${checksLabel ? ` · ${checksLabel}` : ''}`
+    : outcome === 'issues'
+      ? `Issues${issueSummary ? ` · ${issueSummary}` : ''}`
+      : 'Not verified';
 
   const metricBits = metrics
     ? HEADLINE_METRICS
         .filter(m => typeof metrics[m.key] === 'number')
         .map(m => `${metrics[m.key]} ${m.label}`)
     : [];
+  const notRun = Array.isArray(metrics?.checksNotRun) ? (metrics!.checksNotRun as string[]) : [];
+
+  const summary = outcome === 'not_verified'
+    ? reason || 'Verification could not run'
+    : outcome === 'verified'
+      ? (checksLabel ? `${checksLabel} passed in the browser` : 'No issues found in the browser')
+      : issueSummary;
+
+  const expandable = shown.length > 0 || metricBits.length > 0 || notRun.length > 0 || !!reason;
 
   return (
-    <div className={`sui-verify sui-verify--${outcome}`}>
-      <button
-        type="button"
-        className="sui-verify-head"
-        onClick={() => shown.length > 0 && setOpen(o => !o)}
-        aria-expanded={shown.length > 0 ? open : undefined}
-        // Nothing to expand when clean — don't advertise a control that no-ops.
-        style={shown.length === 0 ? { cursor: 'default' } : undefined}
-      >
-        <span className="sui-verify-dot" aria-hidden="true" />
-        <span className="sui-verify-label">{LABEL[outcome]}</span>
-        <span className="sui-verify-summary">{summary}</span>
-        {shown.length > 0 && (
-          <span className="sui-verify-toggle">{open ? 'Hide' : 'Details'}</span>
-        )}
-      </button>
-
-      {metricBits.length > 0 && (
-        <div className="sui-verify-metrics">{metricBits.join(' · ')}</div>
+    <div className={`sui-verify sui-verify--${tone}`}>
+      {expandable ? (
+        <button
+          type="button"
+          className="sui-verify-pill"
+          onClick={() => setOpen(o => !o)}
+          aria-expanded={open}
+          title={summary}
+        >
+          <span className="sui-verify-dot" aria-hidden="true" />
+          <span>{label}</span>
+        </button>
+      ) : (
+        <span className="sui-verify-pill" title={summary}>
+          <span className="sui-verify-dot" aria-hidden="true" />
+          <span>{label}</span>
+        </span>
       )}
 
-      {open && shown.length > 0 && (
-        <ul className="sui-verify-list">
-          {shown.map(f => (
-            <li key={f.id} className={`sui-verify-item sui-verify-item--${f.severity}`}>
-              <span className="sui-verify-item-sev">{f.severity === 'blocker' ? 'Blocking' : 'Warning'}</span>
-              <span className="sui-verify-item-msg">{f.message}</span>
-              {f.evidence && <span className="sui-verify-item-ev">{f.evidence}</span>}
-              {f.selector && <code className="sui-verify-item-sel">{f.selector}</code>}
-            </li>
-          ))}
-        </ul>
+      {open && expandable && (
+        <div className="sui-verify-detail">
+          <div className="sui-verify-summary">{summary}</div>
+          {(metricBits.length > 0 || notRun.length > 0) && (
+            <div className="sui-verify-metrics">
+              {metricBits.join(' · ')}
+              {notRun.length > 0 && `${metricBits.length ? ' · ' : ''}not run: ${notRun.join(', ')}`}
+            </div>
+          )}
+          {shown.length > 0 && (
+            <ul className="sui-verify-list">
+              {shown.map(f => (
+                <li key={f.id} className={`sui-verify-item sui-verify-item--${f.severity}`}>
+                  <span className="sui-verify-item-sev">{f.severity === 'blocker' ? 'Blocking' : 'Warning'}</span>
+                  <span className="sui-verify-item-msg">{f.message}</span>
+                  {f.evidence && <span className="sui-verify-item-ev">{f.evidence}</span>}
+                  {f.selector && <code className="sui-verify-item-sel">{f.selector}</code>}
+                </li>
+              ))}
+            </ul>
+          )}
+        </div>
       )}
     </div>
   );


### PR DESCRIPTION

Direction B from the approved design canvas. Assistant turns get an avatar, a
"N steps · Ns" disclosure and the verification result as a pill; the actions
under a reply collapse to open-in-Storybook, view code and a ⋯ menu (hand off,
copy code, regenerate, rename, delete). Provider and model move into a chip in
the composer, the MCP toggle and server address behind a gear. 24px between
turns, 8px cards, 4px controls; all colours from the panel's tokens, measured
≥ 4.5:1 in both schemes. Presentation only: reducer, network and recovery
logic untouched.


Screenshots reviewed in light and dark; live generation, update, open-in-Storybook, rename and delete exercised on react-mantine.

https://claude.ai/code/session_0158a8zxX4SKPdxm7DLfgqp4
