### PR TITLE
fix(cli): init and update make Storybook's index watcher poll on macOS; check proves it live

### DIFF
--- a/__tests__/canvas-scope-and-versions.test.ts
+++ b/__tests__/canvas-scope-and-versions.test.ts
@@ -151,13 +151,18 @@ describe('storybook watcher hint', () => {
     }
     return dir;
   };
-  it('names the installed version and the fix on the affected range, and stays silent otherwise', () => {
-    expect(storybookWatcherHint(withVersion('10.5.6'))).toContain('Storybook 10.5.6 is installed');
-    expect(storybookWatcherHint(withVersion('10.5.6'))).toContain('10.5.10 or newer');
-    expect(storybookWatcherHint(withVersion('10.5.10'))).toBe('');
-    expect(storybookWatcherHint(withVersion('10.4.2'))).toBe('');
-    expect(storybookWatcherHint(withVersion('9.1.17'))).toBe('');
-    expect(storybookWatcherHint(withVersion('10.6.1'))).toBe('');
-    expect(storybookWatcherHint(withVersion(null))).toBe('');
+  // The hint is about the platform's watcher, not a version range: every
+  // 10.x tested indexed a new file in ~1s on the same project that lost
+  // every event for ten minutes on 10.5.6. The fix it names is polling.
+  it('names the mechanism and the polling fix on macOS without polling, and stays silent otherwise', () => {
+    for (const v of ['10.5.6', '10.5.10', '10.6.1', '10.4.2']) {
+      const hint = storybookWatcherHint(withVersion(v), {}, 'darwin');
+      expect(hint).toContain(`Storybook ${v} on macOS`);
+      expect(hint).toContain('WATCHPACK_POLLING=1000');
+      expect(hint).not.toContain('10.5.10 or newer');
+    }
+    expect(storybookWatcherHint(withVersion('10.5.6'), { WATCHPACK_POLLING: '1000' }, 'darwin')).toBe('');
+    expect(storybookWatcherHint(withVersion('10.5.6'), {}, 'linux')).toBe('');
+    expect(storybookWatcherHint(withVersion(null), {}, 'darwin')).toBe('');
   });
 });

--- a/__tests__/storybook-watcher.test.ts
+++ b/__tests__/storybook-watcher.test.ts
@@ -1,0 +1,166 @@
+/**
+ * Storybook's index watcher is fs.watch, and on macOS fs.watch is one
+ * FSEvents stream rooted at the home directory that drops events under load
+ * and never recovers. That is not a version: 10.1.2, 10.5.6, 10.5.10 and
+ * 10.6.0 all indexed a new file in ~1s on the project that had lost every
+ * event for ten minutes. So the check does not read a version range — it
+ * writes a story and watches the index — and its static advice names the
+ * platform and the polling switch that removes fs.watch from the picture.
+ *
+ * Nothing here touches the repo's own node_modules: versions are read from
+ * a temp dir, and Storybook is a stubbed fetch.
+ */
+
+import { describe, it, expect } from 'vitest';
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import {
+  installedVersion, watchpackPolling, storybookWatcherAdvice, storybookWatcherHint,
+  probeStorybookWatcher, removeStaleProbes, POLLING_FIX,
+} from '../story-generator/verify/storybookWatcher.js';
+
+const project = (storybookVersion: string | null) => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'sbw-'));
+  if (storybookVersion) {
+    fs.mkdirSync(path.join(dir, 'node_modules', 'storybook'), { recursive: true });
+    fs.writeFileSync(path.join(dir, 'node_modules', 'storybook', 'package.json'), JSON.stringify({ version: storybookVersion }));
+  }
+  fs.mkdirSync(path.join(dir, 'src', 'stories', 'generated'), { recursive: true });
+  return dir;
+};
+
+describe('installedVersion', () => {
+  it('reads the version from node_modules and returns "" when the package is absent', () => {
+    expect(installedVersion(project('10.5.6'), 'storybook')).toBe('10.5.6');
+    expect(installedVersion(project(null), 'storybook')).toBe('');
+    expect(installedVersion(project('10.5.6'), 'vite')).toBe('');
+  });
+});
+
+describe('watchpackPolling', () => {
+  it('reads the variable the way watchpack does', () => {
+    expect(watchpackPolling(undefined)).toBe(false);
+    expect(watchpackPolling('')).toBe(false);
+    expect(watchpackPolling('false')).toBe(false);
+    expect(watchpackPolling('1000')).toBe(1000);
+    expect(watchpackPolling('true')).toBe(true);
+  });
+});
+
+describe('storybookWatcherAdvice', () => {
+  it('names the FSEvents risk and the polling fix on macOS, for every 10.x alike', () => {
+    for (const v of ['10.1.2', '10.5.6', '10.5.10', '10.6.0']) {
+      const advice = storybookWatcherAdvice({ platform: 'darwin', storybookVersion: v, polling: false });
+      expect(advice.risk).toBe('fsevents');
+      expect(advice.detail).toContain(`Storybook ${v}`);
+      expect(advice.detail).toContain('FSEvents');
+      expect(advice.fix).toContain(POLLING_FIX);
+      expect(advice.detail).not.toMatch(/or newer|upgrade|stopped indexing/);
+    }
+  });
+  it('reports no risk once polling is on, and says which interval', () => {
+    const advice = storybookWatcherAdvice({ platform: 'darwin', storybookVersion: '10.5.6', polling: 1000 });
+    expect(advice.risk).toBe('none');
+    expect(advice.detail).toContain('WATCHPACK_POLLING=1000');
+    expect(advice.fix).toBeUndefined();
+  });
+  it('does not claim the macOS finding for other platforms, and says so', () => {
+    const advice = storybookWatcherAdvice({ platform: 'linux', storybookVersion: '10.5.6', polling: false });
+    expect(advice.risk).toBe('none');
+    expect(advice.detail).toContain('linux');
+    expect(advice.fix).toBeUndefined();
+  });
+  it('is unknown without Storybook', () => {
+    expect(storybookWatcherAdvice({ platform: 'darwin', storybookVersion: '', polling: false }).risk).toBe('unknown');
+  });
+});
+
+describe('storybookWatcherHint', () => {
+  it('reads the version from the project and the switch from the environment', () => {
+    const cwd = project('10.5.6');
+    expect(storybookWatcherHint(cwd, {}, 'darwin')).toContain('Storybook 10.5.6 on macOS');
+    expect(storybookWatcherHint(cwd, {}, 'darwin')).toContain('WATCHPACK_POLLING=1000');
+    expect(storybookWatcherHint(cwd, { WATCHPACK_POLLING: 'true' }, 'darwin')).toBe('');
+    expect(storybookWatcherHint(cwd, {}, 'win32')).toBe('');
+    expect(storybookWatcherHint(project(null), {}, 'darwin')).toBe('');
+  });
+});
+
+/** A Storybook whose watcher is alive: the index lists whatever is on disk. */
+const liveStorybook = (generatedDir: string) => {
+  const calls: string[] = [];
+  const fetchImpl = (async (url: string) => {
+    calls.push(String(url));
+    const entries: Record<string, { title: string }> = {};
+    for (const name of fs.readdirSync(generatedDir)) {
+      if (!name.endsWith('.stories.ts')) continue;
+      const m = fs.readFileSync(path.join(generatedDir, name), 'utf8').match(/title: "([^"]+)"/);
+      if (m) entries[name] = { title: m[1] };
+    }
+    return { ok: true, status: 200, json: async () => ({ entries }) };
+  }) as unknown as typeof fetch;
+  return { fetchImpl, calls };
+};
+
+/** A Storybook whose watcher is dead: the index never changes. */
+const frozenStorybook = () => (async () => ({ ok: true, status: 200, json: async () => ({ entries: { 'x--y': { title: 'X' } } }) })) as unknown as typeof fetch;
+
+describe('probeStorybookWatcher', () => {
+  it('reports alive when the index picks the probe up, and removes the probe', async () => {
+    const generatedDir = path.join(project('10.5.6'), 'src', 'stories', 'generated');
+    const sb = liveStorybook(generatedDir);
+    const result = await probeStorybookWatcher({ storybookUrl: 'http://localhost:6110/', generatedDir, fetchImpl: sb.fetchImpl, timeoutMs: 2000, intervalMs: 10 });
+    expect(result.outcome).toBe('alive');
+    expect(sb.calls[0]).toBe('http://localhost:6110/index.json');
+    expect(fs.readdirSync(generatedDir)).toEqual([]);
+  });
+
+  it('reports dead when the index never changes, after the timeout, and removes the probe', async () => {
+    const generatedDir = path.join(project('10.5.6'), 'src', 'stories', 'generated');
+    const result = await probeStorybookWatcher({ storybookUrl: 'http://localhost:6110', generatedDir, fetchImpl: frozenStorybook(), timeoutMs: 120, intervalMs: 10 });
+    expect(result.outcome).toBe('dead');
+    if (result.outcome === 'dead') expect(result.ms).toBeGreaterThanOrEqual(120);
+    expect(fs.readdirSync(generatedDir)).toEqual([]);
+  });
+
+  it('reports unreachable, without writing anything, when Storybook does not answer', async () => {
+    const generatedDir = path.join(project('10.5.6'), 'src', 'stories', 'generated');
+    const refused = (async () => { throw new Error('ECONNREFUSED 127.0.0.1:6110'); }) as unknown as typeof fetch;
+    const result = await probeStorybookWatcher({ storybookUrl: 'http://localhost:6110', generatedDir, fetchImpl: refused, timeoutMs: 100, intervalMs: 10 });
+    expect(result).toEqual({ outcome: 'unreachable', error: 'ECONNREFUSED 127.0.0.1:6110' });
+    expect(fs.readdirSync(generatedDir)).toEqual([]);
+  });
+
+  it('skips, without writing, when the stories directory does not exist', async () => {
+    const generatedDir = path.join(project('10.5.6'), 'nowhere');
+    const result = await probeStorybookWatcher({ storybookUrl: 'http://localhost:6110', generatedDir, fetchImpl: frozenStorybook(), timeoutMs: 100, intervalMs: 10 });
+    expect(result.outcome).toBe('skipped');
+  });
+
+  it('the probe is CSF every framework can index: TypeScript, no JSX, hidden from the sidebar', async () => {
+    const generatedDir = path.join(project('10.5.6'), 'src', 'stories', 'generated');
+    let seen = '';
+    const peek = (async () => {
+      for (const name of fs.readdirSync(generatedDir)) seen = fs.readFileSync(path.join(generatedDir, name), 'utf8');
+      return { ok: true, status: 200, json: async () => ({ entries: {} }) };
+    }) as unknown as typeof fetch;
+    await probeStorybookWatcher({ storybookUrl: 'http://localhost:6110', generatedDir, fetchImpl: peek, timeoutMs: 60, intervalMs: 10 });
+    expect(seen).toMatch(/^\/\/ Written by `story-ui check`/);
+    expect(seen).toContain("export default { title: \"Story UI/Watcher Probe ");
+    expect(seen).toContain("tags: ['!dev', '!autodocs']");
+    expect(seen).toContain('export const Probe = {};');
+    expect(seen).not.toContain('<');
+  });
+});
+
+describe('removeStaleProbes', () => {
+  it('removes only probe files an interrupted check left behind', () => {
+    const generatedDir = path.join(project('10.5.6'), 'src', 'stories', 'generated');
+    fs.writeFileSync(path.join(generatedDir, '__story-ui-watcher-probe-dead0.stories.ts'), '');
+    fs.writeFileSync(path.join(generatedDir, 'real-card.stories.tsx'), '');
+    expect(removeStaleProbes(generatedDir)).toEqual(['__story-ui-watcher-probe-dead0.stories.ts']);
+    expect(fs.readdirSync(generatedDir)).toEqual(['real-card.stories.tsx']);
+    expect(removeStaleProbes(path.join(generatedDir, 'missing'))).toEqual([]);
+  });
+});

--- a/__tests__/storybook-watcher.test.ts
+++ b/__tests__/storybook-watcher.test.ts
@@ -18,6 +18,7 @@ import path from 'path';
 import {
   installedVersion, watchpackPolling, storybookWatcherAdvice, storybookWatcherHint,
   probeStorybookWatcher, removeStaleProbes, POLLING_FIX,
+  ensureWatcherPolling, mainConfiguresPolling, WATCHER_POLLING_MARKER,
 } from '../story-generator/verify/storybookWatcher.js';
 
 const project = (storybookVersion: string | null) => {
@@ -162,5 +163,41 @@ describe('removeStaleProbes', () => {
     expect(removeStaleProbes(generatedDir)).toEqual(['__story-ui-watcher-probe-dead0.stories.ts']);
     expect(fs.readdirSync(generatedDir)).toEqual(['real-card.stories.tsx']);
     expect(removeStaleProbes(path.join(generatedDir, 'missing'))).toEqual([]);
+  });
+});
+
+describe('polling preamble in .storybook/main', () => {
+  const main = `import type { StorybookConfig } from '@storybook/react-vite';
+import {
+  mergeConfig,
+} from 'vite';
+
+const config: StorybookConfig = {
+  stories: ['../src/**/*.stories.tsx'],
+};
+export default config;
+`;
+  it('goes after the last import, once, and only on macOS at runtime', () => {
+    const out = ensureWatcherPolling(main)!;
+    expect(out).not.toBeNull();
+    const at = out.indexOf(WATCHER_POLLING_MARKER);
+    expect(at).toBeGreaterThan(out.indexOf("from 'vite';"));
+    expect(at).toBeLessThan(out.indexOf('const config'));
+    expect(out).toContain("if (process.platform === 'darwin' && !process.env.WATCHPACK_POLLING) process.env.WATCHPACK_POLLING = '1000';");
+    expect(ensureWatcherPolling(out)).toBeNull();
+    expect(ensureWatcherPolling("process.env.WATCHPACK_POLLING = '500';\n" + main)).toBeNull();
+  });
+
+  it('goes first in a file without imports', () => {
+    const out = ensureWatcherPolling("module.exports = { stories: [] };\n")!;
+    expect(out.startsWith('// ' + WATCHER_POLLING_MARKER)).toBe(true);
+  });
+
+  it('is read back from the project', () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'sbmain-'));
+    fs.mkdirSync(path.join(dir, '.storybook'));
+    expect(mainConfiguresPolling(dir)).toBe(false);
+    fs.writeFileSync(path.join(dir, '.storybook', 'main.ts'), ensureWatcherPolling(main)!);
+    expect(mainConfiguresPolling(dir)).toBe(true);
   });
 });

--- a/cli/check.ts
+++ b/cli/check.ts
@@ -19,7 +19,7 @@ import { relativeImportResolves, localImportForComponents } from '../story-gener
 import { resolveHostTooling, canLaunchBrowser } from '../story-generator/verify/hostTooling.js';
 import { closeBrowserSession } from '../story-generator/verify/browserSession.js';
 import { describeLaunchFailure } from '../story-generator/verify/verifyStory.js';
-import { storybookWatcherAdvice, watchpackPolling, installedVersion, probeStorybookWatcher, removeStaleProbes } from '../story-generator/verify/storybookWatcher.js';
+import { storybookWatcherAdvice, watchpackPolling, installedVersion, probeStorybookWatcher, removeStaleProbes, mainConfiguresPolling } from '../story-generator/verify/storybookWatcher.js';
 
 /** a < b for dotted versions; prerelease tags ignored. */
 import { semverLt } from '../story-generator/semver.js';
@@ -218,7 +218,7 @@ export async function runChecks(opts: { server?: string; storybook?: string; cwd
     const generatedDir = path.resolve(cwd, config.generatedStoriesPath || './src/stories/generated/');
     const env = { ...readEnv(cwd), ...process.env } as Record<string, string | undefined>;
     const sbVersion = installedVersion(cwd, 'storybook');
-    const advice = storybookWatcherAdvice({ platform: process.platform, storybookVersion: sbVersion, polling: watchpackPolling(env.WATCHPACK_POLLING) });
+    const advice = storybookWatcherAdvice({ platform: process.platform, storybookVersion: sbVersion, polling: watchpackPolling(env.WATCHPACK_POLLING) || (mainConfiguresPolling(cwd) ? 1000 : false) });
     const storybookUrl = opts.storybook || env.STORYBOOK_URL || (env.STORYBOOK_PORT ? `http://localhost:${env.STORYBOOK_PORT}` : undefined);
     if (!storybookUrl || !sbVersion) {
       items.push({

--- a/cli/check.ts
+++ b/cli/check.ts
@@ -19,6 +19,7 @@ import { relativeImportResolves, localImportForComponents } from '../story-gener
 import { resolveHostTooling, canLaunchBrowser } from '../story-generator/verify/hostTooling.js';
 import { closeBrowserSession } from '../story-generator/verify/browserSession.js';
 import { describeLaunchFailure } from '../story-generator/verify/verifyStory.js';
+import { storybookWatcherAdvice, watchpackPolling, installedVersion, probeStorybookWatcher, removeStaleProbes } from '../story-generator/verify/storybookWatcher.js';
 
 /** a < b for dotted versions; prerelease tags ignored. */
 import { semverLt } from '../story-generator/semver.js';
@@ -52,7 +53,7 @@ function readEnv(cwd: string): Record<string, string> {
   return out;
 }
 
-export async function runChecks(opts: { server?: string; cwd?: string } = {}): Promise<CheckReport> {
+export async function runChecks(opts: { server?: string; storybook?: string; cwd?: string } = {}): Promise<CheckReport> {
   const cwd = opts.cwd || process.cwd();
   const items: CheckItem[] = [];
   const summary: CheckReport['summary'] = { components: 0 };
@@ -192,18 +193,57 @@ export async function runChecks(opts: { server?: string; cwd?: string } = {}): P
     let sbVersion = '';
     try { sbVersion = JSON.parse(fs.readFileSync(path.join(cwd, 'node_modules', 'storybook', 'package.json'), 'utf8')).version || ''; } catch { /* not installed here */ }
     const major = Number(sbVersion.split('.')[0]);
+    // No 10.x range is named here: 10.1.2, 10.5.6, 10.5.10 and 10.6.0 (on
+    // Vite 7 and 8) all indexed a new file in ~1s in the same session that
+    // saw 10.5.6 index nothing for ten minutes. The watcher item below tells
+    // the two apart by trying, which a version number cannot.
     items.push({
       id: 'storybook-version',
       ok: sbVersion ? major >= 10 : null,
       detail: sbVersion
         ? (major >= 10
-            ? (semverLt(sbVersion, '10.5.10')
-                ? `Storybook ${sbVersion} — works, but 10.5.5–10.5.6 stopped indexing new stories after a while in testing (a restart fixes it); 10.5.10 did not`
-                : `Storybook ${sbVersion}`)
+            ? `Storybook ${sbVersion}`
             : `Storybook ${sbVersion} — new stories are not picked up live before 10; generated stories appear only after a restart`)
         : 'Storybook is not installed in this project',
       fix: sbVersion && major < 10 ? 'npx storybook@latest upgrade' : undefined,
     });
+  }
+
+  // Storybook's file watcher, live. Whether a new story reaches the index is
+  // a property of the OS's event stream at this moment (macOS drops it; see
+  // storybookWatcher.ts), so it is checked by writing a story and watching
+  // for it — when a Storybook can be reached. Without one, the assessment
+  // is static: platform and WATCHPACK_POLLING.
+  {
+    const generatedDir = path.resolve(cwd, config.generatedStoriesPath || './src/stories/generated/');
+    const env = { ...readEnv(cwd), ...process.env } as Record<string, string | undefined>;
+    const sbVersion = installedVersion(cwd, 'storybook');
+    const advice = storybookWatcherAdvice({ platform: process.platform, storybookVersion: sbVersion, polling: watchpackPolling(env.WATCHPACK_POLLING) });
+    const storybookUrl = opts.storybook || env.STORYBOOK_URL || (env.STORYBOOK_PORT ? `http://localhost:${env.STORYBOOK_PORT}` : undefined);
+    if (!storybookUrl || !sbVersion) {
+      items.push({
+        id: 'storybook-watcher', ok: null,
+        detail: `${advice.detail}${storybookUrl ? '' : ' — pass --storybook <url> (or set STORYBOOK_URL) with Storybook running to test the watcher live'}${advice.fix ? `; to rule it out: ${advice.fix}` : ''}`,
+        fix: advice.fix,
+      });
+    } else {
+      const stale = removeStaleProbes(generatedDir);
+      const probe = await probeStorybookWatcher({ storybookUrl, generatedDir });
+      const left = stale.length ? ` (removed ${stale.length} probe file${stale.length === 1 ? '' : 's'} an earlier check left behind)` : '';
+      if (probe.outcome === 'alive') {
+        items.push({ id: 'storybook-watcher', ok: true, detail: `Storybook at ${storybookUrl} indexed a new story in ${probe.ms}ms — its file watcher is alive${left}` });
+      } else if (probe.outcome === 'dead') {
+        items.push({
+          id: 'storybook-watcher', ok: false,
+          detail: `Storybook at ${storybookUrl} is running but its file watcher is not delivering events: a story written to ${path.relative(cwd, generatedDir)} was not indexed in ${Math.round(probe.ms / 1000)}s. Every generated story is invisible until Storybook restarts. ${advice.risk === 'fsevents' ? 'On macOS this is fs.watch\'s FSEvents stream (rooted at your home directory) having dropped events; it does not recover on its own' : advice.detail}${left}`,
+          fix: advice.risk === 'fsevents' ? `restart Storybook with ${advice.fix}` : 'restart Storybook',
+        });
+      } else if (probe.outcome === 'unreachable') {
+        items.push({ id: 'storybook-watcher', ok: null, detail: `no Storybook at ${storybookUrl} (${probe.error}) — start it to test its file watcher live. ${advice.detail}`, fix: advice.fix });
+      } else {
+        items.push({ id: 'storybook-watcher', ok: null, detail: `watcher probe skipped: ${probe.reason}. ${advice.detail}`, fix: advice.fix });
+      }
+    }
   }
 
   items.push({ id: 'generated-dir', ok: fs.existsSync(generatedDir), detail: fs.existsSync(generatedDir) ? `generated stories go to ${path.relative(cwd, generatedDir)}` : `${path.relative(cwd, generatedDir)} does not exist yet`, fix: fs.existsSync(generatedDir) ? undefined : `mkdir -p ${path.relative(cwd, generatedDir)}` });
@@ -300,7 +340,7 @@ export async function runChecks(opts: { server?: string; cwd?: string } = {}): P
   return { ok, items, summary };
 }
 
-export async function checkCommand(opts: { server?: string; json?: boolean } = {}): Promise<boolean> {
+export async function checkCommand(opts: { server?: string; storybook?: string; json?: boolean } = {}): Promise<boolean> {
   if (opts.json) {
     // Nothing but the report on stdout: the config loader and discovery log
     // freely, and a script parsing this must not have to skip lines.
@@ -308,12 +348,12 @@ export async function checkCommand(opts: { server?: string; json?: boolean } = {
     const saved = { log: console.log, info: console.info, warn: console.warn, debug: console.debug };
     console.log = () => {}; console.info = () => {}; console.warn = () => {}; console.debug = () => {};
     let report: CheckReport;
-    try { report = await runChecks({ server: opts.server }); }
+    try { report = await runChecks({ server: opts.server, storybook: opts.storybook }); }
     finally { Object.assign(console, saved); }
     console.log(JSON.stringify(report, null, 2));
     return report.ok;
   }
-  const report = await runChecks({ server: opts.server });
+  const report = await runChecks({ server: opts.server, storybook: opts.storybook });
   console.log(chalk.bold('\n🩺 Story UI check\n'));
   for (const i of report.items) {
     const mark = i.ok === true ? chalk.green('✔') : i.ok === false ? chalk.red('✖') : chalk.yellow('•');

--- a/cli/index.ts
+++ b/cli/index.ts
@@ -300,6 +300,7 @@ program
   .command('check')
   .description('Verify the installation: config, discovery, Storybook globs, addon wiring, provider key, server')
   .option('--server <url>', 'Story UI server to probe (default: from config port)')
+  .option('--storybook <url>', 'Running Storybook to test the file watcher against, live (default: STORYBOOK_URL or STORYBOOK_PORT)')
   .option('--json', 'Print the report as JSON')
   .action(async (options) => {
     const { checkCommand } = await import('./check.js');

--- a/cli/setup.ts
+++ b/cli/setup.ts
@@ -1,4 +1,5 @@
 import fs from 'fs';
+import { ensureWatcherPolling } from '../story-generator/verify/storybookWatcher.js';
 import path from 'path';
 import inquirer from 'inquirer';
 import chalk from 'chalk';
@@ -2186,6 +2187,14 @@ export default registry;
 
     let mainContent = fs.readFileSync(actualMainPath, 'utf-8');
     let configUpdated = false;
+
+    // Keep Storybook's story-index watcher alive on macOS (storybookWatcher.ts).
+    const polled = ensureWatcherPolling(mainContent);
+    if (polled) {
+      mainContent = polled;
+      configUpdated = true;
+      console.log(chalk.green(`✅ Added WATCHPACK_POLLING to ${path.basename(actualMainPath)} — on macOS Storybook finds new stories by polling`));
+    }
 
     // Check if StoryUI config already exists
     if (mainContent.includes('@tpitre/story-ui') || mainContent.includes('StoryUIPanel')) {

--- a/cli/update.ts
+++ b/cli/update.ts
@@ -5,6 +5,7 @@ import chalk from 'chalk';
 import { fileURLToPath } from 'url';
 import inquirer from 'inquirer';
 import { createRequire } from 'module';
+import { ensureWatcherPolling } from '../story-generator/verify/storybookWatcher.js';
 import { ensureManagerAddonWiring, ensureStoriesGlobCoversMdx, missingReactStorybookDep, ensureManagerHeadPort, readConfiguredPort, ensureScriptPort, viteFinalConfigSnippet, insertConfigProperty, missingViteCjsIncludes } from './setup.js';
 
 const __filename = fileURLToPath(import.meta.url);
@@ -578,6 +579,15 @@ export async function updateCommand(options: UpdateOptions = {}): Promise<Update
       const sbDir = path.join(process.cwd(), '.storybook');
       const mainPath = ['main.ts', 'main.mts', 'main.js', 'main.mjs', 'main.cjs']
         .map(f => path.join(sbDir, f)).find(f => fs.existsSync(f));
+      // Polling keeps the story-index watcher alive on macOS (storybookWatcher.ts);
+      // applies to webpack Storybooks too, which watch through watchpack as well.
+      if (mainPath) {
+        const polled = ensureWatcherPolling(fs.readFileSync(mainPath, 'utf8'));
+        if (polled) {
+          fs.writeFileSync(mainPath, polled);
+          console.log(chalk.green(`   ✅ Added WATCHPACK_POLLING to .storybook/${path.basename(mainPath)} — on macOS Storybook finds new stories by polling (restart it)`));
+        }
+      }
       if (mainPath && !/webpack/i.test(fs.readFileSync(mainPath, 'utf8'))) {
         const mainContent = fs.readFileSync(mainPath, 'utf8');
         if (!mainContent.includes('viteFinal')) {

--- a/story-generator/verify/storybookWatcher.ts
+++ b/story-generator/verify/storybookWatcher.ts
@@ -65,7 +65,55 @@ export function watchpackPolling(value: string | undefined): number | boolean {
   return true;
 }
 
-export const POLLING_FIX = 'WATCHPACK_POLLING=1000 npm run storybook';
+export const POLLING_FIX = 'npx story-ui update (adds WATCHPACK_POLLING to .storybook/main), or start with WATCHPACK_POLLING=1000 npm run storybook';
+
+/** Marks the polling preamble `init`/`update` write into .storybook/main. */
+export const WATCHER_POLLING_MARKER = 'Story UI: keep the story-index watcher alive';
+
+/**
+ * The preamble. Evaluated when Storybook loads its main config, in the same
+ * process and before watchpack creates a single watcher, so the variable is
+ * in place for it — the same effect as the env var, without anyone having
+ * to know it exists. macOS only: the drop is FSEvents'; elsewhere fs.watch
+ * is fine and polling would only cost CPU.
+ */
+export function watcherPollingSnippet(): string {
+  return `// ${WATCHER_POLLING_MARKER}. On macOS, Storybook's story-index watcher (watchpack over
+// fs.watch) shares one FSEvents stream rooted at your home directory, and a burst of file
+// activity anywhere under it drops events silently — a new story then never appears until
+// Storybook restarts. Polling stats the directories instead, so nothing FSEvents does can
+// reach it. Remove this if you set WATCHPACK_POLLING yourself.
+if (process.platform === 'darwin' && !process.env.WATCHPACK_POLLING) process.env.WATCHPACK_POLLING = '1000';
+`;
+}
+
+const IMPORT_RE = /^[ \t]*import\s+(?:type\s+)?(?:[^'";]*?\s+from\s+)?['"][^'"]+['"];?[ \t]*$/gm;
+
+/**
+ * Insert the preamble after the last import (imports are hoisted, so a
+ * statement before them would still run after them — placing it after keeps
+ * the file reading in execution order). Null when it is already there.
+ */
+export function ensureWatcherPolling(mainContent: string): string | null {
+  if (mainContent.includes(WATCHER_POLLING_MARKER) || /WATCHPACK_POLLING/.test(mainContent)) return null;
+  let lastImportEnd = 0;
+  for (const m of mainContent.matchAll(IMPORT_RE)) lastImportEnd = m.index + m[0].length;
+  const snippet = watcherPollingSnippet();
+  if (lastImportEnd === 0) return `${snippet}\n${mainContent}`;
+  const rest = mainContent.slice(lastImportEnd).replace(/^\n+/, '\n');
+  return `${mainContent.slice(0, lastImportEnd)}\n\n${snippet}${rest}`;
+}
+
+/** Does this project's .storybook/main already set polling? */
+export function mainConfiguresPolling(cwd: string): boolean {
+  for (const name of ['main.ts', 'main.mts', 'main.tsx', 'main.js', 'main.mjs', 'main.cjs']) {
+    try {
+      const content = fs.readFileSync(path.join(cwd, '.storybook', name), 'utf8');
+      return content.includes(WATCHER_POLLING_MARKER) || /WATCHPACK_POLLING\s*=/.test(content);
+    } catch { /* try the next name */ }
+  }
+  return false;
+}
 
 export function storybookWatcherAdvice(input: {
   platform: NodeJS.Platform;
@@ -106,9 +154,10 @@ export function storybookWatcherHint(
   platform: NodeJS.Platform = process.platform,
 ): string {
   const version = installedVersion(cwd, 'storybook');
-  const advice = storybookWatcherAdvice({ platform, storybookVersion: version, polling: watchpackPolling(env.WATCHPACK_POLLING) });
+  const polling = watchpackPolling(env.WATCHPACK_POLLING) || (mainConfiguresPolling(cwd) ? 1000 : false);
+  const advice = storybookWatcherAdvice({ platform, storybookVersion: version, polling });
   if (advice.risk !== 'fsevents') return '';
-  return ` Storybook ${version} on macOS watches with fs.watch through one FSEvents stream rooted at your home directory; a burst of file activity anywhere under it drops events silently and the watcher does not recover. Restart Storybook — with WATCHPACK_POLLING=1000 (polling) so this cannot recur.`;
+  return ` Storybook ${version} on macOS watches with fs.watch through one FSEvents stream rooted at your home directory; a burst of file activity anywhere under it drops events silently and the watcher does not recover. Restart Storybook with WATCHPACK_POLLING=1000 (polling, immune to this), and run npx story-ui update so it polls from then on.`;
 }
 
 export type WatcherProbeOutcome =

--- a/story-generator/verify/storybookWatcher.ts
+++ b/story-generator/verify/storybookWatcher.ts
@@ -1,0 +1,194 @@
+/**
+ * Why a generated story can fail to reach Storybook's index, and how to tell.
+ *
+ * Storybook invalidates its story index from watchpack over Node's
+ * `fs.watch` — not from Vite's watcher, and not differently between versions:
+ * 10.1.2, 10.5.6, 10.5.10 and 10.6.0 create the same watch set, on Vite 7 and
+ * Vite 8 alike, and each indexed a new file in about a second on the same
+ * project that, minutes earlier, had lost every event for ten minutes on
+ * 10.5.6. The version is not the variable.
+ *
+ * On macOS the mechanism is this. watchpack watches every ancestor of the
+ * project up to `/Users` (so a renamed parent is noticed), and libuv folds
+ * every `fs.watch` handle in the process into ONE FSEventStream whose roots
+ * are those paths — the stream carries every file event under the home
+ * directory, and libuv drops fseventsd's "events were dropped" flag on the
+ * floor without rescanning. What was traced: a Storybook whose handles on
+ * `/Users/<me>` kept receiving events while its handle on the project's
+ * stories directory received none, for ten minutes, then recovered without a
+ * restart; fresh Node processes watching the same directories in that window
+ * got nothing either. A handle on `/private` (a project under /tmp) silenced
+ * the project's events every time. The trigger for the ten-minute silence
+ * was not isolated; the condition is the OS's, not the process's, and a
+ * version bump does not reach it.
+ *
+ * `WATCHPACK_POLLING=<ms>` makes watchpack stat its directories on a timer
+ * instead of calling `fs.watch` at all (zero calls in the traced run; a new
+ * file indexed in about a second), so nothing FSEvents does or fails to do
+ * can reach the index. It is the one fix that does not depend on the machine
+ * being quiet.
+ *
+ * None of this can be read from a version number, so the only honest check
+ * is a live one: write a story, watch the index, take it back out.
+ */
+
+import fs from 'fs';
+import path from 'path';
+import crypto from 'crypto';
+
+export type WatcherRisk = 'fsevents' | 'none' | 'unknown';
+
+export interface WatcherAdvice {
+  risk: WatcherRisk;
+  /** One line for a check report. */
+  detail: string;
+  /** The command that removes the risk, when there is one. */
+  fix?: string;
+}
+
+/** Read a package's version from the project's node_modules, or '' when absent. */
+export function installedVersion(cwd: string, pkg: string): string {
+  try {
+    return JSON.parse(fs.readFileSync(path.join(cwd, 'node_modules', pkg, 'package.json'), 'utf8')).version || '';
+  } catch {
+    return '';
+  }
+}
+
+/**
+ * watchpack's own reading of WATCHPACK_POLLING: a number is an interval in
+ * ms, "false" or empty is off, anything else is on (its default interval).
+ */
+export function watchpackPolling(value: string | undefined): number | boolean {
+  if (value === undefined || value === '' || value === 'false') return false;
+  if (String(Number(value)) === value) return Number(value);
+  return true;
+}
+
+export const POLLING_FIX = 'WATCHPACK_POLLING=1000 npm run storybook';
+
+export function storybookWatcherAdvice(input: {
+  platform: NodeJS.Platform;
+  storybookVersion: string;
+  polling: number | boolean;
+}): WatcherAdvice {
+  const { platform, storybookVersion, polling } = input;
+  if (!storybookVersion) return { risk: 'unknown', detail: 'Storybook is not installed here, so its file watcher cannot be assessed' };
+  // Measured on 10.1.2 through 10.6.0. Before 10 the index is not refreshed
+  // for a new file at all (the version item says so); nothing here applies.
+  if (Number(storybookVersion.split('.')[0]) < 10) {
+    return { risk: 'unknown', detail: `Storybook ${storybookVersion} does not refresh its index for new files live; the watcher finding was measured on 10.x` };
+  }
+  if (polling) {
+    return {
+      risk: 'none',
+      detail: `Storybook ${storybookVersion} watches by polling (WATCHPACK_POLLING=${polling}) — new stories are found by stat, not by fs.watch, so a dropped FSEvents stream cannot hide them`,
+    };
+  }
+  if (platform === 'darwin') {
+    return {
+      risk: 'fsevents',
+      detail: `Storybook ${storybookVersion} watches with fs.watch; on macOS that is one FSEvents stream rooted at your home directory, and a burst of file activity anywhere under it (an install, a large copy) drops events silently — the watcher then never sees a new story until Storybook restarts`,
+      fix: `${POLLING_FIX}  (polling; immune to dropped events — restart Storybook this way)`,
+    };
+  }
+  return { risk: 'none', detail: `Storybook ${storybookVersion} watches with fs.watch (${platform}; the FSEvents drop measured on macOS does not apply)` };
+}
+
+/**
+ * The sentence verification appends when a story never reached the index.
+ * Version-independent, because the failure is: it names the mechanism and
+ * the two things that help, and stays silent where neither was measured.
+ */
+export function storybookWatcherHint(
+  cwd: string = process.cwd(),
+  env: NodeJS.ProcessEnv = process.env,
+  platform: NodeJS.Platform = process.platform,
+): string {
+  const version = installedVersion(cwd, 'storybook');
+  const advice = storybookWatcherAdvice({ platform, storybookVersion: version, polling: watchpackPolling(env.WATCHPACK_POLLING) });
+  if (advice.risk !== 'fsevents') return '';
+  return ` Storybook ${version} on macOS watches with fs.watch through one FSEvents stream rooted at your home directory; a burst of file activity anywhere under it drops events silently and the watcher does not recover. Restart Storybook — with WATCHPACK_POLLING=1000 (polling) so this cannot recur.`;
+}
+
+export type WatcherProbeOutcome =
+  | { outcome: 'alive'; ms: number; file: string }
+  | { outcome: 'dead'; ms: number; file: string }
+  | { outcome: 'unreachable'; error: string }
+  | { outcome: 'skipped'; reason: string };
+
+export interface WatcherProbeOptions {
+  storybookUrl: string;
+  /** Directory Storybook's stories globs cover; the probe is written here. */
+  generatedDir: string;
+  /** How long a live watcher gets. 10.x indexes in ~1s; 8s is generous. */
+  timeoutMs?: number;
+  intervalMs?: number;
+  fetchImpl?: typeof fetch;
+}
+
+const PROBE_PREFIX = '__story-ui-watcher-probe-';
+
+/**
+ * Write a minimal CSF file into the stories directory, poll `/index.json`
+ * until its title appears, and remove the file. TypeScript without JSX and a
+ * `.stories.ts` name, so every framework's glob matches it and the indexer —
+ * which parses CSF statically — needs nothing to compile.
+ *
+ * "alive" and "dead" are the two answers the check wants; "unreachable" is
+ * kept separate because a Storybook that is down is not one whose watcher
+ * died, and telling the user to restart a server that was never up sends
+ * them the wrong way.
+ */
+export async function probeStorybookWatcher(opts: WatcherProbeOptions): Promise<WatcherProbeOutcome> {
+  const { storybookUrl, generatedDir, timeoutMs = 8000, intervalMs = 250, fetchImpl = fetch } = opts;
+  const url = `${storybookUrl.replace(/\/+$/, '')}/index.json`;
+  const readIndex = async (): Promise<Record<string, { title?: string }>> => {
+    const res = await fetchImpl(url, { signal: AbortSignal.timeout(2000) });
+    if (!res.ok) throw new Error(`${url} answered ${res.status}`);
+    const json = await res.json() as { entries?: Record<string, { title?: string }> };
+    return json.entries || {};
+  };
+
+  try {
+    await readIndex();
+  } catch (err) {
+    return { outcome: 'unreachable', error: err instanceof Error ? err.message : String(err) };
+  }
+  if (!fs.existsSync(generatedDir)) return { outcome: 'skipped', reason: `${generatedDir} does not exist` };
+
+  const token = crypto.randomBytes(4).toString('hex');
+  const title = `Story UI/Watcher Probe ${token}`;
+  const file = path.join(generatedDir, `${PROBE_PREFIX}${token}.stories.ts`);
+  const source = `// Written by \`story-ui check\` to see whether Storybook notices a new file; removed within seconds.\nexport default { title: ${JSON.stringify(title)}, tags: ['!dev', '!autodocs'] };\nexport const Probe = {};\n`;
+  const started = Date.now();
+  try {
+    fs.writeFileSync(file, source);
+    while (Date.now() - started < timeoutMs) {
+      await new Promise(r => setTimeout(r, intervalMs));
+      try {
+        const entries = await readIndex();
+        if (Object.values(entries).some(e => e.title === title)) {
+          return { outcome: 'alive', ms: Date.now() - started, file };
+        }
+      } catch { /* a transient error mid-poll is not an answer; keep polling */ }
+    }
+    return { outcome: 'dead', ms: Date.now() - started, file };
+  } finally {
+    try { fs.unlinkSync(file); } catch { /* already gone */ }
+  }
+}
+
+/** Probe files an interrupted check may have left behind. */
+export function removeStaleProbes(generatedDir: string): string[] {
+  let removed: string[] = [];
+  try {
+    for (const name of fs.readdirSync(generatedDir)) {
+      if (name.startsWith(PROBE_PREFIX)) {
+        fs.unlinkSync(path.join(generatedDir, name));
+        removed.push(name);
+      }
+    }
+  } catch { removed = []; }
+  return removed;
+}

--- a/story-generator/verify/verifyStory.ts
+++ b/story-generator/verify/verifyStory.ts
@@ -13,8 +13,8 @@
 
 import fs from 'fs';
 import path from 'path';
-import { semverLt } from '../semver.js';
 import { logger } from '../logger.js';
+import { storybookWatcherHint } from './storybookWatcher.js';
 import { resolveHostTooling, canLaunchBrowser } from './hostTooling.js';
 import { renderStory, waitForStoryIndexed, indexIsStale, type IndexLookup } from './renderHarness.js';
 import { runDomCensus } from './probes/domCensus.js';
@@ -110,18 +110,12 @@ const notVerified = (
  */
 
 /**
- * Storybook 10.5.5–10.5.6 stopped watching for new story files after a
- * while in testing; 10.5.10 did not. A "not indexed" result on one of those
- * versions is almost always that, so say so where the user is looking —
- * `story-ui check` already does, but nobody runs check when a story fails.
+ * A "not indexed" result on macOS is almost always Storybook's fs.watch
+ * stream having dropped the file (see storybookWatcher.ts — it is not a
+ * version), so say so where the user is looking: `story-ui check` proves it
+ * live, but nobody runs check when a story fails.
  */
-export function storybookWatcherHint(cwd: string = process.cwd()): string {
-  let version = '';
-  try { version = JSON.parse(fs.readFileSync(path.join(cwd, 'node_modules', 'storybook', 'package.json'), 'utf8')).version || ''; } catch { return ''; }
-  // Only the range that showed it: older majors fail the install check outright.
-  if (!version || semverLt(version, '10.5.0') || !semverLt(version, '10.5.10')) return '';
-  return ` Storybook ${version} is installed; 10.5.5–10.5.6 stopped watching for new files in testing and 10.5.10 did not — restart Storybook now, and upgrade to 10.5.10 or newer so this stops recurring.`;
-}
+export { storybookWatcherHint };
 
 export function classifyIndexMiss(
   storybookUrl: string,


### PR DESCRIPTION

Storybook invalidates its story index from watchpack over Node's fs.watch. On
macOS libuv folds every handle into one FSEvents stream rooted at the home
directory and drops its "events dropped" flag, so after a burst of file
activity anywhere under it the watcher silently stops seeing new files — a
generated story then never appears until Storybook restarts. Traced on Sail
Shelf: the handle on the home directory kept receiving events while the
handle on the stories directory got none for ten minutes. Not a version:
10.1.2 through 10.6.0, Vite 7 and 8, all create the same watch set.

`WATCHPACK_POLLING` makes watchpack stat instead (zero fs.watch calls; a new
file indexed in about a second). init and update now write a preamble into
.storybook/main that sets it on macOS before Storybook creates a watcher, so
`npm run storybook` is enough. `check` gains a live `storybook-watcher` item
that writes a story, watches the index, and removes it — ok:false when a
running Storybook does not index it in 8s — and the false 10.5.x version
rule is gone. The "not indexed" verification reason names the mechanism and
the fix.

Verified on Sail Shelf (Storybook 10.5.6, Vite 8.2): without the preamble a
new file was never indexed; with it, 282ms.


https://claude.ai/code/session_0158a8zxX4SKPdxm7DLfgqp4
