### PR TITLE
fix: generated stories keep the imports, deps and prop values the project itself states

### DIFF
--- a/__tests__/a11y-root-environment.test.ts
+++ b/__tests__/a11y-root-environment.test.ts
@@ -1,0 +1,72 @@
+/**
+ * A violation on the story ROOT is the harness's environment, not the story.
+ *
+ * Radix and every `aria-hidden`-based overlay mark `#storybook-root`
+ * aria-hidden while a Select, Dialog or Popover is open. When the interaction
+ * probe's close had not landed by the time axe ran, a correct college-town
+ * form was blocked for "ARIA hidden element must not contain focusable
+ * elements" — filed against Storybook's own root. Set aside and counted,
+ * never dropped silently.
+ */
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+
+import { resolveHostTooling } from '../story-generator/verify/hostTooling.js';
+import { acquireBrowser, closeBrowserSession } from '../story-generator/verify/browserSession.js';
+import { runA11yProbe } from '../story-generator/verify/probes/a11y.js';
+
+const tooling = resolveHostTooling('/Users/tjpitre/Sites/test-storybooks/react-mantine');
+let browser: any;
+
+beforeAll(async () => {
+  if (!tooling) return;
+  browser = await acquireBrowser(tooling).catch(() => undefined);
+}, 60_000);
+
+afterAll(async () => { await closeBrowserSession(); });
+
+describe.runIf(tooling && tooling.axePath)('axe on a root an overlay left hidden', { retry: 2 }, () => {
+  it('waits for Escape to restore the root, then finds nothing wrong with the story', async () => {
+    const page = await browser.newPage();
+    await page.setContent(
+      '<div id="storybook-root" aria-hidden="true">' +
+      '<button>Save draft</button>' +
+      '</div>' +
+      '<script>document.addEventListener("keydown", e => { if (e.key === "Escape") document.getElementById("storybook-root").removeAttribute("aria-hidden"); });</script>'
+    );
+    const r = await runA11yProbe(page, tooling!);
+    await page.close();
+
+    expect(r.ran).toBe(true);
+    expect(r.violations.map(v => v.id)).not.toContain('aria-hidden-focus');
+    expect(r.environmentViolations).toBeUndefined();
+  });
+
+  it('sets aside a root-targeted violation when the overlay will not close, and counts it', async () => {
+    const page = await browser.newPage();
+    await page.setContent(
+      '<div id="storybook-root" aria-hidden="true">' +
+      '<button>Save draft</button>' +
+      '</div>'
+    );
+    const r = await runA11yProbe(page, tooling!);
+    await page.close();
+
+    expect(r.ran).toBe(true);
+    expect(r.violations.map(v => v.id)).not.toContain('aria-hidden-focus');
+    expect((r.environmentViolations || []).map(v => v.id)).toContain('aria-hidden-focus');
+  });
+
+  it('still reports a defect inside the story', async () => {
+    const page = await browser.newPage();
+    await page.setContent(
+      '<div id="storybook-root">' +
+      '<button><svg width="12" height="12"></svg></button>' +
+      '</div>'
+    );
+    const r = await runA11yProbe(page, tooling!);
+    await page.close();
+
+    expect(r.ran).toBe(true);
+    expect(r.violations.map(v => v.id)).toContain('button-name');
+  });
+});

--- a/__tests__/conformance.test.ts
+++ b/__tests__/conformance.test.ts
@@ -61,7 +61,9 @@ describe('enum values', () => {
     // `kind={x}` could be anything; guessing is how a check starts rejecting
     // correct code.
     expect(checkConformance(`const a = <Button kind={variant} />;`, CARBON)).toEqual([]);
-    expect(checkConformance(`const a = <Button kind={cond ? 'a' : 'b'} />;`, CARBON)).toEqual([]);
+    // A conditional of two UNSTATED values is still anything; one of two
+    // literals is judged below, because the file states both.
+    expect(checkConformance(`const a = <Button kind={cond ? a : b} />;`, CARBON)).toEqual([]);
   });
 
   it('says nothing about a prop with no resolved options', () => {
@@ -142,5 +144,56 @@ describe('open value sets', () => {
     ] } } } as any;
     expect(checkConformance(`const a = <Badge color="blue.9">Go</Badge>;`, MANTINE)).toEqual([]);
     expect(checkConformance(`const a = <Badge variant="glow">Go</Badge>;`, MANTINE)).toHaveLength(1);
+  });
+});
+
+/**
+ * Every value the FILE states for a prop is judged, not just a bare literal.
+ * `<Pillbox status={STATE_TONE[row.state] as any}>` with STATE_TONE mapping to
+ * 'success' | 'warning' | 'danger' — another library's names — crashed a house
+ * component whose palette has no such keys, twice, and the repair could not
+ * see why. The cast that hid it is itself the tell.
+ */
+describe('enum values stated by the file', () => {
+  const HOUSE = known({
+    Pillbox: { name: 'Pillbox', props: [{ name: 'status', options: ['neutral', 'live', 'degraded', 'down', 'pending'] }] },
+  });
+
+  it('judges every value of a const lookup table used with a dynamic key', () => {
+    const v = checkConformance(`
+      const STATE_TONE: Record<string, string> = { operational: 'success', degraded: 'degraded', offline: 'danger' };
+      const a = <Pillbox status={STATE_TONE[row.state] as any} dot />;
+    `, HOUSE);
+    expect(v).toHaveLength(1);
+    expect(v[0].kind).toBe('enum_value');
+    expect(v[0].message).toContain('"success"');
+    expect(v[0].message).toContain('"danger"');
+    expect(v[0].message).not.toContain('"degraded"');
+    expect(v[0].message).toContain('neutral');
+  });
+
+  it('accepts a lookup table whose values are all legal', () => {
+    const v = checkConformance(`
+      const TONE = { ok: 'live', bad: 'down' } as const;
+      const a = <Pillbox status={TONE[k]} />;
+    `, HOUSE);
+    expect(v).toEqual([]);
+  });
+
+  it('judges both branches of a conditional', () => {
+    expect(checkConformance(`const a = <Pillbox status={ok ? 'live' : 'error'} />;`, HOUSE)).toHaveLength(1);
+    expect(checkConformance(`const a = <Pillbox status={ok ? 'live' : 'down'} />;`, HOUSE)).toEqual([]);
+  });
+
+  it('flags an `as any` cast that hides the value entirely', () => {
+    const v = checkConformance(`const a = <Pillbox status={row.status as any} />;`, HOUSE);
+    expect(v).toHaveLength(1);
+    expect(v[0].message).toContain('as any');
+    expect(v[0].message).toContain('pending');
+  });
+
+  it('still leaves an unstated expression alone', () => {
+    expect(checkConformance(`const a = <Pillbox status={row.status} />;`, HOUSE)).toEqual([]);
+    expect(checkConformance(`const a = <Pillbox status={toStatus(row)} />;`, HOUSE)).toEqual([]);
   });
 });

--- a/__tests__/deep-import-path-resolves.test.ts
+++ b/__tests__/deep-import-path-resolves.test.ts
@@ -1,0 +1,157 @@
+/**
+ * A per-file import the catalog prescribed must survive validation.
+ *
+ * On a local design system (`importPath: '@/components'`, one module per
+ * component, an incomplete barrel) the validator flagged every
+ * `@/components/<x>/<x>` import as a "deep/incorrect path" and collapsed it
+ * onto `@/components`. Whether the deep path resolves is a fact on disk —
+ * tsconfig `paths`, the declared componentsPath, node_modules — and only a
+ * path that names nothing is wrong.
+ */
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import { validateStoryCode } from '../story-generator/validateStory.js';
+import { resolveSpecifier, readTsconfigPaths } from '../story-generator/knowledge/moduleResolution.js';
+
+let root: string;
+let prevCwd: string;
+
+const write = (rel: string, content: string) => {
+  const abs = path.join(root, rel);
+  fs.mkdirSync(path.dirname(abs), { recursive: true });
+  fs.writeFileSync(abs, content);
+};
+
+beforeAll(() => {
+  root = fs.mkdtempSync(path.join(os.tmpdir(), 'story-ui-deep-import-'));
+  write('tsconfig.json', JSON.stringify({
+    files: [],
+    references: [{ path: './tsconfig.app.json' }],
+    compilerOptions: { baseUrl: '.', paths: { '@/*': ['./src/*'] } },
+  }));
+  write('tsconfig.app.json', '{ "compilerOptions": { "jsx": "react-jsx" } }');
+  write('src/components/index.ts', "export * from './alert'\n");
+  write('src/components/alert/index.ts', "export * from './alert'\n");
+  write('src/components/alert/alert.tsx', 'export const Alert = () => null;\n');
+  // Deliberately NOT in the barrel.
+  write('src/components/data-table/data-table.tsx', 'export const DataTable = () => null;\n');
+  write('src/stories/generated/.keep', '');
+  // A package with an exports map that names only its root and one subpath.
+  write('node_modules/vuetify/package.json', JSON.stringify({
+    name: 'vuetify',
+    exports: { '.': './dist/vuetify.js', './components': './lib/components/index.js', './styles': './lib/styles/main.css' },
+  }));
+  write('node_modules/vuetify/lib/components/index.js', '');
+  // A package with no exports map: files decide.
+  write('node_modules/@mantine/core/package.json', JSON.stringify({ name: '@mantine/core', main: 'index.js' }));
+  write('node_modules/@mantine/core/index.js', '');
+  write('node_modules/@mantine/core/styles.css', '');
+  prevCwd = process.cwd();
+  process.chdir(root);
+});
+
+afterAll(() => {
+  process.chdir(prevCwd);
+  fs.rmSync(root, { recursive: true, force: true });
+});
+
+const localConfig = {
+  importPath: '@/components',
+  componentsPath: './src/components',
+  importStyle: 'individual',
+  componentFramework: 'react',
+  generatedStoriesPath: './src/stories/generated',
+};
+
+describe('resolveSpecifier', () => {
+  it('reads tsconfig paths, following references', () => {
+    const paths = readTsconfigPaths(root);
+    expect(paths?.paths['@/*']).toEqual(['./src/*']);
+  });
+
+  it('resolves an alias through tsconfig paths to the file', () => {
+    const r = resolveSpecifier('@/components/alert/alert', { projectRoot: root, fromDir: path.join(root, 'src/stories/generated') });
+    expect(r.how).toBe('tsconfig-paths');
+    expect(r.file).toBe(path.join(root, 'src/components/alert/alert.tsx'));
+  });
+
+  it('resolves a directory alias to its index', () => {
+    const r = resolveSpecifier('@/components', { projectRoot: root, fromDir: path.join(root, 'src/stories/generated') });
+    expect(r.file).toBe(path.join(root, 'src/components/index.ts'));
+  });
+
+  it('falls back to the declared importPath → componentsPath pairing when tsconfig has no alias', () => {
+    const r = resolveSpecifier('~ui/alert/alert', {
+      projectRoot: root,
+      fromDir: path.join(root, 'src/stories/generated'),
+      importPath: '~ui',
+      componentsPath: './src/components',
+    });
+    expect(r.how).toBe('components-path');
+  });
+
+  it('answers from a package exports map', () => {
+    const opts = { projectRoot: root, fromDir: path.join(root, 'src/stories/generated') };
+    expect(resolveSpecifier('vuetify/components', opts).how).toBe('package-exports');
+    const deep = resolveSpecifier('vuetify/components/lib/components/VAlert', opts);
+    expect(deep.file).toBeNull();
+    expect(deep.detail).toContain('exports does not name');
+  });
+
+  it('answers from files when a package has no exports map', () => {
+    const opts = { projectRoot: root, fromDir: path.join(root, 'src/stories/generated') };
+    expect(resolveSpecifier('@mantine/core/styles.css', opts).how).toBe('package-file');
+    expect(resolveSpecifier('@mantine/core/nope', opts).file).toBeNull();
+  });
+
+  it('names what it checked when nothing resolves', () => {
+    const r = resolveSpecifier('@/components/missing/missing', { projectRoot: root, fromDir: path.join(root, 'src/stories/generated') });
+    expect(r.file).toBeNull();
+    expect(r.how).toBe('unresolved');
+    expect(r.detail).toContain('tsconfig paths');
+  });
+});
+
+describe('validateStoryCode on a local design system', () => {
+  const story = (imports: string) => `import React from 'react';
+import type { Meta, StoryObj } from '@storybook/react-vite';
+${imports}
+
+const meta = { title: 'Generated/X' } satisfies Meta;
+export default meta;
+type Story = StoryObj<typeof meta>;
+export const Default: Story = { render: () => <div><Alert /><DataTable /></div> };
+`;
+
+  it('keeps a per-file import that resolves, exactly as written', () => {
+    const code = story(`import { Alert } from '@/components/alert/alert';\nimport { DataTable } from '@/components/data-table/data-table';`);
+    const result = validateStoryCode(code, 'story.tsx', localConfig);
+    expect(result.errors.filter(e => e.includes('Import path error'))).toEqual([]);
+    expect(result.fixedCode).toBeUndefined();
+    expect(result.isValid).toBe(true);
+  });
+
+  it('still rejects and rewrites a deep path that names nothing', () => {
+    const code = story(`import { Alert } from '@/components/alert/alert';\nimport { DataTable } from '@/components/lib/data-table';`);
+    const result = validateStoryCode(code, 'story.tsx', localConfig);
+    expect(result.errors.some(e => e.includes('Import path error') && e.includes('@/components/lib/data-table'))).toBe(true);
+    expect(result.fixedCode).toContain("import { Alert } from '@/components/alert/alert'");
+    expect(result.fixedCode).toContain("import { DataTable } from '@/components'");
+  });
+
+  it('collapses a non-existent Vuetify deep path onto the barrel, as before', () => {
+    const vueConfig = { importPath: 'vuetify/components', componentFramework: 'vue', generatedStoriesPath: './src/stories/generated' };
+    const code = `import type { Meta, StoryObj } from '@storybook/vue3-vite';
+import { VAlert } from 'vuetify/components/lib/components/VAlert';
+import { VBtn } from 'vuetify/components/lib/components/VBtn';
+const meta = { title: 'Generated/X' } satisfies Meta;
+export default meta;
+export const Default = { render: () => ({ components: { VAlert, VBtn }, template: '<VAlert />' }) };
+`;
+    const result = validateStoryCode(code, 'story.ts', vueConfig);
+    expect(result.fixedCode).toContain("from 'vuetify/components'");
+    expect(result.fixedCode).not.toContain('lib/components');
+  });
+});

--- a/__tests__/interaction-probe.test.ts
+++ b/__tests__/interaction-probe.test.ts
@@ -235,4 +235,27 @@ describe.runIf(tooling)('absent is not a pass', { retry: 2 }, () => {
     // this probe exists to find.
     expect(r.deadControls.length).toBe(1);
   });
+
+  it('presses like a pointer, so a control wired to mousedown is not faulted', async () => {
+    const page = await browser.newPage();
+    // Mantine's PasswordInput visibility toggle: aria-pressed, toggled on
+    // mousedown (and touch and Space) — deliberately never on click, so the
+    // input keeps focus. `el.click()` alone reported it dead on every form.
+    await page.setContent(
+      '<div id="storybook-root">' +
+      '<button id="reveal" aria-pressed="false" aria-label="Show password">eye</button>' +
+      '<button id="plain" aria-pressed="false" aria-label="Bold">B</button>' +
+      '<script>' +
+      'document.getElementById("reveal").addEventListener("mousedown", e => { e.preventDefault(); const b = e.currentTarget; b.setAttribute("aria-pressed", b.getAttribute("aria-pressed") === "true" ? "false" : "true"); });' +
+      'document.getElementById("plain").addEventListener("click", e => { const b = e.currentTarget; b.setAttribute("aria-pressed", b.getAttribute("aria-pressed") === "true" ? "false" : "true"); });' +
+      '</script>' +
+      '</div>'
+    );
+    const r = await runInteractionProbe(page);
+    await page.close();
+
+    expect(r.skipped).toBe(false);
+    expect(r.controlsTested).toBe(2);
+    expect(r.deadControls).toEqual([]);
+  });
 });

--- a/__tests__/library-source-dependencies.test.ts
+++ b/__tests__/library-source-dependencies.test.ts
@@ -1,0 +1,77 @@
+/**
+ * A package the design system's own source imports is part of the design
+ * system. college-town's Form is built on react-hook-form and its own story
+ * imports zod; the isolation check forbade both, so the model was shown a form
+ * built one way and rejected for building it that way.
+ */
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import { librarySourceDependencies, validateImportIsolation } from '../mcp-server/routes/generationCore.js';
+
+let root: string;
+let prevCwd: string;
+let formFile: string;
+
+const write = (rel: string, content: string) => {
+  const abs = path.join(root, rel);
+  fs.mkdirSync(path.dirname(abs), { recursive: true });
+  fs.writeFileSync(abs, content);
+  return abs;
+};
+
+beforeAll(() => {
+  root = fs.mkdtempSync(path.join(os.tmpdir(), 'story-ui-lib-deps-'));
+  write('package.json', JSON.stringify({
+    name: 'consumer',
+    dependencies: { react: '19', 'react-hook-form': '7', zod: '4', '@hookform/resolvers': '5', lodash: '4' },
+  }));
+  formFile = write('src/components/form/form.tsx',
+    `import * as React from "react"\nimport { FormProvider, useFormContext } from "react-hook-form"\nimport { cn } from "@/lib/utils"\nexport const Form = FormProvider\n`);
+  write('src/components/form/form.stories.tsx',
+    `import { useForm } from 'react-hook-form'\nimport { zodResolver } from '@hookform/resolvers/zod'\nimport * as z from 'zod'\nexport default {}\n`);
+  prevCwd = process.cwd();
+  process.chdir(root);
+});
+
+afterAll(() => {
+  process.chdir(prevCwd);
+  fs.rmSync(root, { recursive: true, force: true });
+});
+
+const config = { importPath: '@/components', componentsPath: './src/components', importStyle: 'individual', componentFramework: 'react' };
+
+describe('librarySourceDependencies', () => {
+  it('reads what the component source and its co-located stories import, installed packages only', () => {
+    const installed = new Set(['react', 'react-hook-form', 'zod', '@hookform/resolvers', 'lodash']);
+    const deps = librarySourceDependencies([{ name: 'Form', filePath: formFile }], installed);
+    expect([...deps].sort()).toEqual(['@hookform/resolvers', 'react', 'react-hook-form', 'zod']);
+  });
+
+  it('ignores npm components and unknown files', () => {
+    const installed = new Set(['react-hook-form']);
+    expect(librarySourceDependencies([
+      { name: 'Button', filePath: '/x/node_modules/@mantine/core/Button.js' },
+      { name: 'Ghost', filePath: path.join(root, 'nope.tsx') },
+      { name: 'NoPath' },
+    ], installed).size).toBe(0);
+  });
+});
+
+describe('validateImportIsolation with a local design system', () => {
+  // Read inside each test: formFile is assigned in beforeAll, after collection.
+  const components = () => [{ name: 'Form', filePath: formFile }];
+
+  it('permits packages the design system itself is built on', () => {
+    const code = `import { useForm } from 'react-hook-form';\nimport * as z from 'zod';\nimport { zodResolver } from '@hookform/resolvers/zod';\nimport { Form } from '@/components/form/form';\n`;
+    const errors = validateImportIsolation(code, config, 'react', '', components());
+    expect(errors, errors.join('\n')).toEqual([]);
+  });
+
+  it('still forbids a package nothing in the design system imports', () => {
+    const code = `import debounce from 'lodash';\nimport { Form } from '@/components/form/form';\n`;
+    const errors = validateImportIsolation(code, config, 'react', '', components());
+    expect(errors.some(e => e.includes('Forbidden import "lodash"'))).toBe(true);
+  });
+});

--- a/__tests__/local-prop-facts-conformance.test.ts
+++ b/__tests__/local-prop-facts-conformance.test.ts
@@ -1,0 +1,55 @@
+/**
+ * A local component's declared props are judged, not only shown.
+ *
+ * The interface was read into the catalog line the model saw and never
+ * consulted again: `<Pillbox status={row.status as any}>` passed every static
+ * gate and crashed the house component at render. The facts the model was
+ * given are the facts it is judged against.
+ */
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import { enrichWithSourceFacts, withLocalPropFacts } from '../story-generator/knowledge/sourceFacts.js';
+import { checkConformance } from '../story-generator/knowledge/conformance.js';
+
+let root: string;
+beforeAll(() => {
+  root = fs.mkdtempSync(path.join(os.tmpdir(), 'story-ui-local-facts-'));
+  fs.writeFileSync(path.join(root, 'Pillbox.tsx'), `import React from 'react';
+export interface PillboxProps {
+  /** Semantic status. */
+  status?: 'neutral' | 'live' | 'degraded' | 'down' | 'pending';
+  dot?: boolean;
+  children?: React.ReactNode;
+}
+export const Pillbox: React.FC<PillboxProps> = ({ status = 'neutral', children }) => <span data-status={status}>{children}</span>;
+`);
+});
+afterAll(() => fs.rmSync(root, { recursive: true, force: true }));
+
+describe('withLocalPropFacts', () => {
+  it('joins a local component\'s declared props to the record the conformance check reads', () => {
+    const components: any[] = [{ name: 'Pillbox', filePath: path.join(root, 'Pillbox.tsx'), props: [] }];
+    enrichWithSourceFacts(components);
+    expect(components[0].__propFacts?.find((p: any) => p.name === 'status')?.options).toEqual(['neutral', 'live', 'degraded', 'down', 'pending']);
+
+    const known = withLocalPropFacts(null, components, '../../housekit');
+    expect(known?.components.Pillbox?.props.some(p => p.name === 'status')).toBe(true);
+
+    const v = checkConformance(`const a = <Pillbox status={row.status as any} dot />;`, known);
+    expect(v).toHaveLength(1);
+    expect(v[0].message).toContain('pending');
+    expect(checkConformance(`const a = <Pillbox status="live" />;`, known)).toEqual([]);
+  });
+
+  it('never overwrites a package record with a local one of the same name', () => {
+    const components: any[] = [{ name: 'Pillbox', __propFacts: [{ name: 'status', required: false, options: ['x'] }] }];
+    const pkg: any = { importPath: '@x/y', components: { Pillbox: { name: 'Pillbox', props: [{ name: 'status', required: false, options: ['a'] }] } }, inheritedOnly: [], extractedAt: '' };
+    expect(withLocalPropFacts(pkg, components, '@x/y')!.components.Pillbox.props[0].options).toEqual(['a']);
+  });
+
+  it('returns the input untouched when no local facts exist', () => {
+    expect(withLocalPropFacts(null, [{ name: 'Button' }], '@x/y')).toBeNull();
+  });
+});

--- a/__tests__/storybook-origin.test.ts
+++ b/__tests__/storybook-origin.test.ts
@@ -1,0 +1,51 @@
+/**
+ * The panel's origin names the Storybook the user is looking at; the config's
+ * storybookMcpUrl is a declaration that goes stale when the port changes.
+ * The origin wins when the server can reach it, and the choice is narrated.
+ */
+import { describe, it, expect } from 'vitest';
+import { chooseStorybookUrl } from '../story-generator/storybookOrigin.js';
+
+const answers = (ok: string[]) => async (url: string) => ok.includes(url);
+
+describe('chooseStorybookUrl', () => {
+  it('prefers the reachable caller origin over a differing configured URL, and says so', async () => {
+    const c = await chooseStorybookUrl({
+      callerOrigin: 'http://localhost:6116/',
+      configured: 'http://localhost:6006',
+      reachable: answers(['http://localhost:6116', 'http://localhost:6006']),
+    });
+    expect(c.url).toBe('http://localhost:6116');
+    expect(c.source).toBe('caller');
+    expect(c.note).toContain('6006');
+  });
+
+  it('keeps the configured URL when the caller origin does not answer from the server', async () => {
+    const c = await chooseStorybookUrl({
+      callerOrigin: 'https://app.example.com',
+      configured: 'http://localhost:6006',
+      reachable: answers(['http://localhost:6006']),
+    });
+    expect(c.url).toBe('http://localhost:6006');
+    expect(c.source).toBe('configured');
+    expect(c.note).toContain('did not answer');
+  });
+
+  it('does not probe when caller and configured agree', async () => {
+    let probed = 0;
+    const c = await chooseStorybookUrl({
+      callerOrigin: 'http://localhost:6006',
+      configured: 'http://localhost:6006/',
+      reachable: async () => { probed++; return true; },
+    });
+    expect(c.url).toBe('http://localhost:6006');
+    expect(probed).toBe(0);
+  });
+
+  it('falls through caller → configured → environment → none', async () => {
+    expect((await chooseStorybookUrl({ callerOrigin: 'http://localhost:6103' })).source).toBe('caller');
+    expect((await chooseStorybookUrl({ configured: 'http://localhost:6006' })).source).toBe('configured');
+    expect((await chooseStorybookUrl({ fallback: 'http://localhost:6006' })).source).toBe('environment');
+    expect((await chooseStorybookUrl({})).source).toBe('none');
+  });
+});

--- a/mcp-server/routes/generationCore.ts
+++ b/mcp-server/routes/generationCore.ts
@@ -79,6 +79,8 @@ import { processFileInputs, fileFraming, FileInput } from '../../story-generator
 import { checkTokenUsage, formatTokenErrors } from '../../story-generator/knowledge/tokenConformance.js';
 import { targetComponentFromSelection, repairWithinTarget, scopedCritiqueRequest, repairScopeNote } from '../../story-generator/editing/repairScope.js';
 import { relocateUnresolvableImports, resolveLocalModule, relativeSpecifier } from '../../story-generator/editing/relocateImports.js';
+import { resolveSpecifier } from '../../story-generator/knowledge/moduleResolution.js';
+import { chooseStorybookUrl } from '../../story-generator/storybookOrigin.js';
 import { VisionPromptType, buildVisionAwarePrompt } from '../../story-generator/visionPrompts.js';
 import { ImageContent, MessageContent, TextContent } from '../../story-generator/llm-providers/types.js';
 import {
@@ -104,7 +106,7 @@ import { saysMoreThanName } from '../../story-generator/knowledge/descriptionQua
  */
 const GEOMETRY_PROP = /^(sm|md|lg|xl|xxl|max|xs|span|offset|start|end|gap|columns|narrow|condensed|fullWidth|orientation)$/;
 const LAYOUT_PROSE = /\b(column|columns|grid|breakpoint|gutter|span|spacing|width|row|layout)\b/i;
-import { enrichWithSourceFacts } from '../../story-generator/knowledge/sourceFacts.js';
+import { enrichWithSourceFacts, withLocalPropFacts } from '../../story-generator/knowledge/sourceFacts.js';
 import { readStylingFacts, formatStylingGuidance, readDesignTokens } from '../../story-generator/knowledge/stylingFacts.js';
 import { inheritCompoundExamples } from '../../story-generator/knowledge/storybookCatalog.js';
 import { checkConformance, formatConformanceErrors } from '../../story-generator/knowledge/conformance.js';
@@ -149,8 +151,8 @@ export interface GenerationRequest {
   useStorybookMcp?: boolean;
   /**
    * Storybook origin detected by the panel (it runs inside Storybook, so it
-   * knows). Lets the MCP-context toggle work with zero configuration; an
-   * explicit config.storybookMcpUrl still takes precedence.
+   * knows). Wins over config.storybookMcpUrl whenever this server can reach
+   * it — see chooseStorybookUrl.
    */
   storybookUrl?: string;
   voiceMode?: boolean;
@@ -429,6 +431,21 @@ async function runStoryGenerationPipeline(
   events.onProgress?.(2, totalSteps, 'components_discovered', 'Discovering available components...');
   const discovery = new EnhancedComponentDiscovery(config);
 
+  /**
+   * This request's Storybook, chosen once and used everywhere a URL is needed:
+   * component-directory discovery, the MCP context, runtime validation and
+   * browser verification. The panel's origin wins when this server can reach
+   * it; story-ui.config's storybookMcpUrl otherwise; the environment last.
+   * See storybookOrigin.ts for why the config no longer wins outright.
+   */
+  const storybookChoice = await chooseStorybookUrl({
+    callerOrigin: storybookUrl,
+    configured: config.storybookMcpUrl,
+    fallback: getStorybookUrl(),
+  });
+  const projectStorybookUrl = storybookChoice.url;
+  if (storybookChoice.note) logger.log(`🔭 Storybook: ${storybookChoice.note}`);
+
   // Where Storybook says this project's components are.
   //
   // Discovery otherwise guesses at conventional directory names, so a design
@@ -436,7 +453,7 @@ async function runStoryGenerationPipeline(
   // told about is a component it will not use, however good the rest of the
   // context is.
   try {
-    const sbUrl = config.storybookMcpUrl || storybookUrl || getStorybookUrl();
+    const sbUrl = projectStorybookUrl;
     if (sbUrl) {
       const dirs = await storybookComponentDirs({ storybookUrl: sbUrl, projectRoot: process.cwd() });
       if (dirs.length) discovery.setStorybookComponentDirs(dirs);
@@ -493,7 +510,7 @@ async function runStoryGenerationPipeline(
     // Held for the validation loop below, which checks the generated code
     // against these same facts. Same object, so the catalog the model was given
     // and the catalog it is judged against can never drift apart.
-    knownProps = extracted;
+    knownProps = withLocalPropFacts(extracted, components as any[], config.importPath);
     if (extracted) {
       let enriched = 0;
       let describedFromTypes = 0;
@@ -669,7 +686,7 @@ async function runStoryGenerationPipeline(
   // simply never loaded whenever a caller did not pass storybookUrl, which is
   // every request that is not the panel. The client, the manifest endpoint and
   // the formatter all already worked; nothing ever triggered them.
-  const mcpUrl = config.storybookMcpUrl || storybookUrl || getStorybookUrl() || undefined;
+  const mcpUrl = projectStorybookUrl || undefined;
   if (mcpUrl && shouldUseMcp) {
     // Pass the generated-stories directory so our own prior output is kept out
     // of the exemplar pool it sends back as the house style.
@@ -876,7 +893,7 @@ async function runStoryGenerationPipeline(
       storybookContext,
       selection,
       pins,
-      storybookUrl: config.storybookMcpUrl || storybookUrl || getStorybookUrl() || undefined,
+      storybookUrl: projectStorybookUrl || undefined,
     }
   );
 
@@ -1300,7 +1317,7 @@ async function runStoryGenerationPipeline(
     // A resolving specifier is not an existing binding: verified against the
     // module on disk, for relative imports where that answer is certain.
     const namedImportErrors = validateLocalNamedImports(
-      aiText, path.resolve(process.cwd(), config.generatedStoriesPath || './src/stories/generated'), components as any,
+      aiText, path.resolve(process.cwd(), config.generatedStoriesPath || './src/stories/generated'), components as any, config as any,
     );
     /**
      * Does the output conform to the facts we handed the model?
@@ -1771,7 +1788,7 @@ async function runStoryGenerationPipeline(
       events.onProgress?.(9, totalSteps, 'runtime_check', 'Checking the story renders in Storybook...');
       runtimeResult = await validateStoryRuntime(fixedFileContents, aiTitle, config.storyPrefix,
         { storyId: computeStorybookId(fixedFileContents, storyIdSlug), projectRoot: process.cwd(),
-          storybookUrl: config.storybookMcpUrl || storybookUrl || undefined });
+          storybookUrl: projectStorybookUrl || undefined });
       // Only spend a healing LLM call on genuine in-Storybook failures.
       // Infrastructure problems (Storybook not running, story not indexed
       // yet, timeouts) are not code errors and can't be healed.
@@ -1811,7 +1828,7 @@ async function runStoryGenerationPipeline(
           try {
             runtimeResult = await validateStoryRuntime(fixedFileContents, aiTitle, config.storyPrefix,
               { storyId: computeStorybookId(fixedFileContents, storyIdSlug), projectRoot: process.cwd(),
-                storybookUrl: config.storybookMcpUrl || storybookUrl || undefined });
+                storybookUrl: projectStorybookUrl || undefined });
             runtimeHealed = runtimeResult.success;
           } catch {
             // Leave the last known result in place.
@@ -1878,7 +1895,7 @@ async function runStoryGenerationPipeline(
     );
     verifyBudgetTimer.unref?.();
     try {
-      const verifyUrl = config.storybookMcpUrl || storybookUrl || getStorybookUrl();
+      const verifyUrl = projectStorybookUrl;
       /**
        * Say when the URL was a guess.
        *
@@ -1889,7 +1906,7 @@ async function runStoryGenerationPipeline(
        * story simply is not in that index, and the report describes somebody
        * else's page. Naming it turns a confusing result into an actionable one.
        */
-      if (!config.storybookMcpUrl && !storybookUrl && isGuessedStorybookUrl()) {
+      if (storybookChoice.source === 'environment' && isGuessedStorybookUrl()) {
         logger.log(
           `🔍 No Storybook URL was supplied and STORYBOOK_PORT is unset — verifying against ${verifyUrl} by convention. ` +
           `If this project's Storybook runs elsewhere, set STORYBOOK_PORT so verification reaches it.`,
@@ -3027,7 +3044,7 @@ async function attemptRuntimeHealing(args: {
     );
     const namedImportErrors = validateLocalNamedImports(
       code, path.resolve(process.cwd(), config.generatedStoriesPath || './src/stories/generated'),
-      (discovery?.getDiscoveredComponents?.() ?? []) as any,
+      (discovery?.getDiscoveredComponents?.() ?? []) as any, config as any,
     );
     const errors = aggregateValidationErrors(astResult, patternErrors, [
       ...(importValidation.isValid ? [] : importValidation.errors),
@@ -3339,6 +3356,56 @@ function getConsumerDependencies(): Set<string> {
 }
 
 /**
+ * The packages a local design system's own source depends on.
+ *
+ * college-town's `Form` is built on react-hook-form (form.tsx imports
+ * FormProvider and useFormContext from it) and its own story — one of the
+ * usage examples the prompt hands the model — imports zod and
+ * @hookform/resolvers. The isolation check then forbade all three, so the
+ * model was shown a form built one way, told to build it that way, and
+ * rejected for doing so; a healing retry rebuilt the form without the
+ * project's Form component at all. What a component's source imports is a
+ * fact about the design system, and the allowance is derived from it here.
+ * Only local files are read (npm components carry their own package.json),
+ * and only packages the project actually installs count.
+ */
+const _librarySourceDepsCache = new Map<string, { at: number; deps: Set<string> }>();
+export function librarySourceDependencies(
+  components: Array<{ name: string; filePath?: string }>,
+  installed: Set<string>,
+): Set<string> {
+  const files = new Set<string>();
+  for (const c of components) {
+    const f = c.filePath;
+    if (!f || !path.isAbsolute(f) || f.includes(`${path.sep}node_modules${path.sep}`)) continue;
+    files.add(f);
+    // The component's own co-located stories: documented usage.
+    try {
+      const dir = path.dirname(f);
+      for (const entry of fs.readdirSync(dir)) {
+        if (/\.stories\.(tsx|ts|jsx|js|mjs|vue|svelte)$/.test(entry)) files.add(path.join(dir, entry));
+      }
+    } catch { /* a directory we cannot list adds nothing */ }
+  }
+  const key = [...files].sort().join('\n');
+  const cached = _librarySourceDepsCache.get(key);
+  if (cached && Date.now() - cached.at < 60_000) return cached.deps;
+
+  const deps = new Set<string>();
+  for (const file of files) {
+    let text: string;
+    try { text = fs.readFileSync(file, 'utf-8'); } catch { continue; }
+    for (const m of text.matchAll(/(?:^|\n)\s*(?:import|export)\s[^'"]*?from\s*['"]([^'".][^'"]*)['"]/g)) {
+      const root = importSpecifierRoot(m[1]);
+      if (root && installed.has(root)) deps.add(root);
+    }
+  }
+  _librarySourceDepsCache.clear();
+  _librarySourceDepsCache.set(key, { at: Date.now(), deps });
+  return deps;
+}
+
+/**
  * Is this package provably NOT part of the project?
  *
  * Must answer "no" whenever it cannot see the project, because the caller
@@ -3445,6 +3512,8 @@ export function validateLocalNamedImports(
   generatedDir: string,
   /** Where discovery says each component lives, to name the right module. */
   components: Array<{ name: string; __componentPath?: string; filePath?: string }> = [],
+  /** The declared importPath → componentsPath pairing, so an alias import resolves too. */
+  config?: { importPath?: string; componentsPath?: string },
 ): string[] {
   const errors: string[] = [];
   /**
@@ -3455,7 +3524,8 @@ export function validateLocalNamedImports(
    * "'../../housekit/Datagrid' does not export 'Meta'", and the healing loop
    * could not satisfy it because there was nothing wrong.
    */
-  const importRegex = /import\s+(?:([^'"]*?)\s+from\s+)?['"](\.[^'"]+)['"]/g;
+  const importRegex = /import\s+(?:([^'"]*?)\s+from\s+)?['"]([^'"]+)['"]/g;
+  const aliasOptions = { projectRoot: process.cwd(), fromDir: generatedDir, importPath: config?.importPath, componentsPath: config?.componentsPath };
 
   let match;
   while ((match = importRegex.exec(code)) !== null) {
@@ -3471,7 +3541,23 @@ export function validateLocalNamedImports(
       .filter(s => /^[A-Za-z_$][\w$]*$/.test(s));
     if (bindings.length === 0) continue;
 
-    const file = resolveLocalModule(specifier, generatedDir);
+    /**
+     * Relative specifiers resolve from the generated directory; an ALIAS
+     * (`@/components/data-table/data-table`, through tsconfig `paths` or the
+     * declared importPath → componentsPath pairing) resolves to a local file
+     * too, and is checked the same way. Before this only `./` and `../`
+     * imports were checked, so `import { DataTable } from '@/components'` —
+     * a barrel that does not export it — passed every gate and rendered
+     * blank. A bare npm specifier is not this check's business and is skipped.
+     */
+    let file: string | null;
+    if (specifier.startsWith('.')) {
+      file = resolveLocalModule(specifier, generatedDir);
+    } else {
+      const r = resolveSpecifier(specifier, aliasOptions);
+      if (!r.aliasMatched) continue;
+      file = r.file;
+    }
     if (!file) {
       /**
        * This used to `continue`, on the belief that import validation had
@@ -3542,7 +3628,7 @@ export function validateImportIsolation(
   framework: FrameworkType,
   considerationsText: string,
   /** Discovered components, so a wrong import can be told where the real one lives. */
-  components: Array<{ name: string; __componentPath?: string }> = [],
+  components: Array<{ name: string; __componentPath?: string; filePath?: string }> = [],
 ): string[] {
   const errors: string[] = [];
 
@@ -3578,11 +3664,18 @@ export function validateImportIsolation(
   }
 
   const consumerDeps = getConsumerDependencies();
+  const libraryDeps = librarySourceDependencies(components, consumerDeps);
 
   for (const [specifier, boundNames] of specifiers) {
     // Relative imports can't smuggle in foreign packages.
     if (specifier.startsWith('.') || specifier.startsWith('/')) continue;
     const root = importSpecifierRoot(specifier);
+    // The design system's own source imports it: part of the system, by its
+    // own account.
+    if (libraryDeps.has(root) && !allowedRoots.has(root)) {
+      logger.log(`🔓 Import "${specifier}" permitted — the project's own components import ${root}`);
+      continue;
+    }
 
     /**
      * A SCOPE is not a package.

--- a/story-generator/knowledge/conformance.ts
+++ b/story-generator/knowledge/conformance.ts
@@ -126,18 +126,41 @@ export function checkConformance(
            * `color="blue.9"` on correct code and cost two retries.
            */
           if (fact.options?.length && !fact.optionsOpen && attr.initializer) {
-            let literal: string | null = null;
-            if (ts.isStringLiteral(attr.initializer)) literal = attr.initializer.text;
-            else if (ts.isJsxExpression(attr.initializer)
-              && attr.initializer.expression
-              && ts.isStringLiteral(attr.initializer.expression)) {
-              literal = attr.initializer.expression.text;
-            }
-            if (literal !== null && !fact.options.includes(literal)) {
+            const accepts = `${fact.options.slice(0, 10).join(' | ')}${fact.options.length > 10 ? ' | …' : ''}`;
+            const expr = ts.isStringLiteral(attr.initializer)
+              ? attr.initializer
+              : ts.isJsxExpression(attr.initializer) ? attr.initializer.expression : undefined;
+            if (!expr) continue;
+            const { values, castToAny } = literalValuesOf(expr, source);
+            /**
+             * Every value the expression can take, when the file states them.
+             *
+             * A plain literal, a conditional, or a lookup into a const object
+             * literal written in the same file all have a closed set of string
+             * values, and each is judged. `STATE_TONE[row.state]` where
+             * STATE_TONE maps to 'success' | 'warning' | 'danger' — another
+             * library's names — crashed a house Pillbox whose palette has no
+             * such keys ("undefined is not iterable"), twice, and the repair
+             * could not see why. An expression whose values the file does not
+             * state is left alone, as before.
+             */
+            const bad = values.filter(v => !fact.options!.includes(v));
+            if (bad.length) {
               out.push({
                 kind: 'enum_value', component: tag, prop, line: lineOf(attr),
-                message: `<${tag} ${prop}="${literal}"> is not one of the values this prop accepts: `
-                  + `${fact.options.slice(0, 10).join(' | ')}${fact.options.length > 10 ? ' | …' : ''}.`,
+                message: `<${tag} ${prop}=${values.length === 1 && ts.isStringLiteral(expr) ? `"${bad[0]}"` : `{…}`}> `
+                  + `${values.length === 1 && ts.isStringLiteral(expr) ? 'is' : `can be "${bad.slice(0, 4).join('" | "')}", which is`} `
+                  + `not one of the values this prop accepts: ${accepts}. Map your data to those values.`,
+              });
+            } else if (castToAny && values.length === 0) {
+              /**
+               * `as any` on a closed-enum prop exists only to defeat the type
+               * — the value came from somewhere the type would have rejected.
+               */
+              out.push({
+                kind: 'enum_value', component: tag, prop, line: lineOf(attr),
+                message: `<${tag} ${prop}={… as any}> casts away this prop's type; it accepts only ${accepts}. `
+                  + `Map your data to those values and drop the cast.`,
               });
             }
           }
@@ -148,6 +171,66 @@ export function checkConformance(
   };
   visit(source);
   return out;
+}
+
+/**
+ * The string values an expression can evaluate to, when the file states them:
+ * a literal, a conditional's branches, a lookup into a const object literal
+ * declared in this file, or any of those behind a cast. `castToAny` records
+ * an `as any` / `<any>` anywhere in the chain.
+ */
+function literalValuesOf(expr: ts.Expression, source: ts.SourceFile, depth = 0): { values: string[]; castToAny: boolean } {
+  const none = { values: [] as string[], castToAny: false };
+  if (depth > 4) return none;
+  if (ts.isStringLiteral(expr) || ts.isNoSubstitutionTemplateLiteral(expr)) return { values: [expr.text], castToAny: false };
+  if (ts.isParenthesizedExpression(expr)) return literalValuesOf(expr.expression, source, depth + 1);
+  if (ts.isAsExpression(expr) || ts.isTypeAssertionExpression(expr)) {
+    const inner = literalValuesOf(expr.expression, source, depth + 1);
+    const toAny = expr.type.kind === ts.SyntaxKind.AnyKeyword;
+    return { values: inner.values, castToAny: inner.castToAny || toAny };
+  }
+  if (ts.isConditionalExpression(expr)) {
+    const a = literalValuesOf(expr.whenTrue, source, depth + 1);
+    const b = literalValuesOf(expr.whenFalse, source, depth + 1);
+    if (!a.values.length || !b.values.length) return { values: [], castToAny: a.castToAny || b.castToAny };
+    return { values: [...new Set([...a.values, ...b.values])], castToAny: a.castToAny || b.castToAny };
+  }
+  if ((ts.isElementAccessExpression(expr) || ts.isPropertyAccessExpression(expr)) && ts.isIdentifier(expr.expression)) {
+    const table = objectLiteralNamed(expr.expression.text, source);
+    if (!table) return none;
+    if (ts.isPropertyAccessExpression(expr)) {
+      const member = table.properties.find(p => ts.isPropertyAssignment(p) && p.name.getText(source).replace(/['"]/g, '') === expr.name.text);
+      if (member && ts.isPropertyAssignment(member)) return literalValuesOf(member.initializer, source, depth + 1);
+      return none;
+    }
+    // A dynamic key: every value the table holds is reachable.
+    const values: string[] = [];
+    for (const p of table.properties) {
+      if (!ts.isPropertyAssignment(p)) return none;
+      const v = literalValuesOf(p.initializer, source, depth + 1);
+      if (!v.values.length) return none;
+      values.push(...v.values);
+    }
+    return { values: [...new Set(values)], castToAny: false };
+  }
+  return none;
+}
+
+/** `const NAME = { … }` at any depth of the file, when its initializer is an object literal. */
+function objectLiteralNamed(name: string, source: ts.SourceFile): ts.ObjectLiteralExpression | null {
+  let found: ts.ObjectLiteralExpression | null = null;
+  const visit = (node: ts.Node) => {
+    if (found) return;
+    if (ts.isVariableDeclaration(node) && ts.isIdentifier(node.name) && node.name.text === name && node.initializer) {
+      let init: ts.Expression = node.initializer;
+      while (ts.isAsExpression(init) || ts.isSatisfiesExpression(init) || ts.isParenthesizedExpression(init)) init = init.expression;
+      if (ts.isObjectLiteralExpression(init)) found = init;
+      return;
+    }
+    ts.forEachChild(node, visit);
+  };
+  visit(source);
+  return found;
 }
 
 /** Violations as the self-healing loop consumes them. */

--- a/story-generator/knowledge/moduleResolution.ts
+++ b/story-generator/knowledge/moduleResolution.ts
@@ -1,0 +1,269 @@
+/**
+ * Does an import specifier name a module this project can actually serve?
+ *
+ * Answered from the project's own files: a relative path against the
+ * generated-stories directory, an alias through `tsconfig.json`'s `paths`,
+ * the declared `importPath` → `componentsPath` pairing in story-ui.config,
+ * and a bare package through `node_modules/<pkg>/package.json` (its
+ * `exports` map when it has one, the file on disk when it does not).
+ *
+ * Why this exists: the validator used to treat every specifier that began
+ * with the configured `importPath` plus a slash as a "deep/incorrect path"
+ * and collapse it onto the barrel. That is right for the case it was written
+ * for (`vuetify/components/lib/components/VAlert` is not a module) and wrong
+ * for a local design system whose catalog said, per component, "import from
+ * '@/components/alert/alert'" — a path the project itself declared, which
+ * resolves, and which the barrel does not always cover. The model obeyed the
+ * catalog; the validator undid it; the story imported names the barrel did
+ * not export and rendered blank. Whether a path resolves is a fact on disk,
+ * so ask the disk.
+ */
+
+import fs from 'fs';
+import path from 'path';
+import * as ts from 'typescript';
+import { resolveLocalModule } from '../editing/relocateImports.js';
+
+export interface ResolveOptions {
+  /** The project root: where tsconfig.json and node_modules live. */
+  projectRoot: string;
+  /** The directory the story is written to; relative specifiers resolve from here. */
+  fromDir: string;
+  /** story-ui.config `importPath`, when declared. */
+  importPath?: string;
+  /** story-ui.config `componentsPath`, when declared: the directory `importPath` names. */
+  componentsPath?: string;
+}
+
+export type ResolutionHow =
+  | 'relative'
+  | 'tsconfig-paths'
+  | 'components-path'
+  | 'package-exports'
+  | 'package-file'
+  | 'package-root';
+
+export interface Resolution {
+  /** The file or package directory the specifier names, or null. */
+  file: string | null;
+  /** Which fact answered. `unresolved` names what was looked at and not found. */
+  how: ResolutionHow | 'unresolved';
+  /** For `unresolved`: what was checked, so a log line can say it. */
+  detail?: string;
+  /**
+   * The specifier matched a project alias (tsconfig `paths` or the declared
+   * importPath → componentsPath pairing), so it names a LOCAL module whether
+   * or not the file exists — a bare npm specifier never sets this.
+   */
+  aliasMatched?: boolean;
+}
+
+interface PathsConfig {
+  baseDir: string;
+  paths: Record<string, string[]>;
+}
+
+const pathsCache = new Map<string, { mtime: number; config: PathsConfig | null }>();
+
+/**
+ * `compilerOptions.paths` (with its `baseUrl`) from the project's tsconfig,
+ * following `extends` and project `references` — a root tsconfig that only
+ * lists references still commonly carries the alias itself.
+ */
+export function readTsconfigPaths(projectRoot: string): PathsConfig | null {
+  const rootFile = path.join(projectRoot, 'tsconfig.json');
+  let mtime = 0;
+  try { mtime = fs.statSync(rootFile).mtimeMs; } catch { return null; }
+  const cached = pathsCache.get(rootFile);
+  if (cached && cached.mtime === mtime) return cached.config;
+
+  const seen = new Set<string>();
+  const found: PathsConfig[] = [];
+  const visit = (file: string) => {
+    const abs = path.resolve(file);
+    if (seen.has(abs) || !fs.existsSync(abs)) return;
+    seen.add(abs);
+    const read = ts.readConfigFile(abs, f => fs.readFileSync(f, 'utf-8'));
+    const json = read.config;
+    if (!json || typeof json !== 'object') return;
+    const dir = path.dirname(abs);
+    const co = json.compilerOptions;
+    if (co && co.paths && typeof co.paths === 'object') {
+      found.push({
+        baseDir: co.baseUrl ? path.resolve(dir, co.baseUrl) : dir,
+        paths: co.paths,
+      });
+    }
+    const ext = json.extends;
+    for (const e of Array.isArray(ext) ? ext : ext ? [ext] : []) {
+      if (typeof e === 'string' && (e.startsWith('.') || e.startsWith('/'))) {
+        visit(e.endsWith('.json') ? path.resolve(dir, e) : path.resolve(dir, e + '.json'));
+      }
+    }
+    for (const ref of Array.isArray(json.references) ? json.references : []) {
+      if (ref && typeof ref.path === 'string') {
+        const p = path.resolve(dir, ref.path);
+        visit(p.endsWith('.json') ? p : path.join(p, 'tsconfig.json'));
+      }
+    }
+  };
+  visit(rootFile);
+
+  // The root's own mapping first; a referenced project's mapping fills gaps.
+  const config: PathsConfig | null = found.length
+    ? { baseDir: found[0].baseDir, paths: Object.assign({}, ...found.slice().reverse().map(f => f.paths)) }
+    : null;
+  pathsCache.set(rootFile, { mtime, config });
+  return config;
+}
+
+function matchPathsAlias(specifier: string, cfg: PathsConfig): string[] {
+  const out: string[] = [];
+  for (const [key, targets] of Object.entries(cfg.paths)) {
+    if (!Array.isArray(targets)) continue;
+    const star = key.indexOf('*');
+    let rest: string | null = null;
+    if (star === -1) {
+      if (specifier === key) rest = '';
+    } else {
+      const prefix = key.slice(0, star);
+      const suffix = key.slice(star + 1);
+      if (specifier.startsWith(prefix) && specifier.endsWith(suffix) && specifier.length >= key.length - 1) {
+        rest = specifier.slice(prefix.length, specifier.length - suffix.length);
+      }
+    }
+    if (rest === null) continue;
+    for (const t of targets) {
+      if (typeof t !== 'string') continue;
+      out.push(path.resolve(cfg.baseDir, t.replace('*', rest)));
+    }
+  }
+  return out;
+}
+
+function packageDirFor(pkgName: string, fromDir: string, projectRoot: string): string | null {
+  let dir = path.resolve(fromDir);
+  const stop = path.parse(dir).root;
+  for (;;) {
+    const candidate = path.join(dir, 'node_modules', pkgName);
+    if (fs.existsSync(path.join(candidate, 'package.json'))) return candidate;
+    if (dir === stop) break;
+    const parent = path.dirname(dir);
+    if (parent === dir) break;
+    dir = parent;
+  }
+  const atRoot = path.join(projectRoot, 'node_modules', pkgName);
+  return fs.existsSync(path.join(atRoot, 'package.json')) ? atRoot : null;
+}
+
+/** Does `exports` name `subpath` (`.` for the root)? Undefined when the map is not subpath-keyed. */
+function exportsNames(exportsField: unknown, subpath: string): boolean | undefined {
+  if (exportsField === undefined || exportsField === null) return undefined;
+  if (typeof exportsField === 'string' || Array.isArray(exportsField)) return subpath === '.';
+  if (typeof exportsField !== 'object') return undefined;
+  const keys = Object.keys(exportsField as Record<string, unknown>);
+  const subpathKeyed = keys.some(k => k.startsWith('.'));
+  if (!subpathKeyed) return subpath === '.'; // conditions object: root only
+  for (const key of keys) {
+    if (!key.startsWith('.')) continue;
+    const value = (exportsField as Record<string, unknown>)[key];
+    if (value === null) continue; // an explicit block
+    const star = key.indexOf('*');
+    if (star === -1) {
+      if (key === subpath) return true;
+      continue;
+    }
+    const prefix = key.slice(0, star);
+    const suffix = key.slice(star + 1);
+    if (subpath.startsWith(prefix) && subpath.endsWith(suffix) && subpath.length >= key.length - 1) return true;
+  }
+  return false;
+}
+
+/**
+ * Resolve `specifier` the way the project's tooling would, as far as the
+ * facts on disk allow. Never guesses: an alias with no tsconfig entry, a
+ * package subpath absent from its `exports`, or a file that is not there all
+ * come back `unresolved` with what was checked.
+ */
+export function resolveSpecifier(specifier: string, opts: ResolveOptions): Resolution {
+  const spec = specifier.trim();
+  if (!spec) return { file: null, how: 'unresolved', detail: 'empty specifier' };
+
+  if (spec.startsWith('.') || spec.startsWith('/')) {
+    const file = resolveLocalModule(spec, opts.fromDir);
+    return file
+      ? { file, how: 'relative' }
+      : { file: null, how: 'unresolved', detail: `no file for '${spec}' from ${opts.fromDir}` };
+  }
+
+  const checked: string[] = [];
+  let aliasMatched = false;
+
+  // tsconfig `paths`: the project's own alias table.
+  const paths = readTsconfigPaths(opts.projectRoot);
+  if (paths) {
+    for (const target of matchPathsAlias(spec, paths)) {
+      aliasMatched = true;
+      const file = resolveLocalModule(path.basename(target), path.dirname(target));
+      if (file) return { file, how: 'tsconfig-paths', aliasMatched };
+      checked.push(`tsconfig paths → ${target}`);
+    }
+  }
+
+  // story-ui.config's declared pairing: `importPath` names `componentsPath`.
+  if (opts.importPath && opts.componentsPath && (spec === opts.importPath || spec.startsWith(opts.importPath + '/'))) {
+    aliasMatched = true;
+    const rest = spec.slice(opts.importPath.length).replace(/^\//, '');
+    const base = path.resolve(opts.projectRoot, opts.componentsPath);
+    const target = rest ? path.join(base, rest) : base;
+    const file = resolveLocalModule(path.basename(target), path.dirname(target));
+    if (file) return { file, how: 'components-path', aliasMatched };
+    checked.push(`componentsPath → ${target}`);
+  }
+  // An alias names a local module; do not go looking for it in node_modules.
+  if (aliasMatched) return { file: null, how: 'unresolved', detail: checked.join('; '), aliasMatched };
+
+  // A bare package: node_modules/<pkg>, then its exports map or the file.
+  const m = spec.match(/^(@[^/]+\/[^/]+|[^@][^/]*)(?:\/(.*))?$/);
+  if (m) {
+    const pkgName = m[1];
+    const sub = m[2] ? `./${m[2]}` : '.';
+    const dir = packageDirFor(pkgName, opts.fromDir, opts.projectRoot);
+    if (!dir) {
+      checked.push(`no node_modules/${pkgName}`);
+      return { file: null, how: 'unresolved', detail: checked.join('; ') };
+    }
+    let pkgJson: any = {};
+    try { pkgJson = JSON.parse(fs.readFileSync(path.join(dir, 'package.json'), 'utf-8')); } catch { /* unreadable: fall through to files */ }
+    const named = exportsNames(pkgJson.exports, sub);
+    if (named === true) return { file: sub === '.' ? dir : path.join(dir, sub), how: sub === '.' ? 'package-root' : 'package-exports' };
+    if (named === false) {
+      checked.push(`${pkgName}/package.json exports does not name '${sub}'`);
+      return { file: null, how: 'unresolved', detail: checked.join('; ') };
+    }
+    if (sub === '.') return { file: dir, how: 'package-root' };
+    const target = path.join(dir, sub);
+    const file = resolveLocalModule(path.basename(target), path.dirname(target))
+      || (fs.existsSync(path.join(target, 'package.json')) ? path.join(target, 'package.json') : null);
+    if (file) return { file, how: 'package-file' };
+    checked.push(`no file at ${target}`);
+  }
+
+  return { file: null, how: 'unresolved', detail: checked.join('; ') || `nothing to check for '${spec}'` };
+}
+
+/** True when the specifier names something the project can serve. */
+export function specifierResolves(specifier: string, opts: ResolveOptions): boolean {
+  return resolveSpecifier(specifier, opts).file !== null;
+}
+
+/** The resolver's options from a story-ui config, for callers that only hold the config. */
+export function resolveOptionsFrom(config: any, projectRoot: string = process.cwd()): ResolveOptions {
+  return {
+    projectRoot,
+    fromDir: path.resolve(projectRoot, config?.generatedStoriesPath || './src/stories/generated'),
+    importPath: typeof config?.importPath === 'string' ? config.importPath : undefined,
+    componentsPath: typeof config?.componentsPath === 'string' ? config.componentsPath : undefined,
+  };
+}

--- a/story-generator/knowledge/sourceFacts.ts
+++ b/story-generator/knowledge/sourceFacts.ts
@@ -35,6 +35,7 @@ import ts from 'typescript';
 import { logger } from '../logger.js';
 import { formatPropForCatalog, mergeProps, rankProps, type PropFact } from './propExtractor.js';
 import { readLocalComponent, readLocalComponents } from './localComponentFacts.js';
+import type { ExtractedProps } from './propExtractor.js';
 import { saysMoreThanName } from './descriptionQuality.js';
 
 export interface VariantFacts {
@@ -372,6 +373,8 @@ export function enrichWithSourceFacts(components: any[]): number {
      */
     if (facts.declaredProps?.length) {
       const merged = mergePropFactsFromSource(facts.declaredProps, { variants: facts.variants });
+      // The structured facts, for the conformance check (see withLocalPropFacts).
+      component.__propFacts = merged;
       const declaredNames = new Set(merged.map(p => p.name));
       const live = merged.filter(p => !p.deprecated);
       const extra = (Array.isArray(component.props) ? component.props as string[] : [])
@@ -405,4 +408,35 @@ export function enrichWithSourceFacts(components: any[]): number {
   }
   if (enriched) logger.log(`📖 Read source facts for ${enriched} local component(s)`);
   return enriched;
+}
+
+/**
+ * Local components' declared props, joined to the record the conformance
+ * check judges generated code against.
+ *
+ * `extractProps` reads installed packages, so `knownProps` held npm
+ * components only. A local component's interface was read (above), rendered
+ * into the catalog line the model saw — `status: 'neutral' | 'live' | …` —
+ * and then never consulted again: `<Pillbox status={row.status as any}>`
+ * passed every static gate and crashed the house component at render, twice.
+ * The same facts the model was given are what it is judged against.
+ */
+export function withLocalPropFacts(
+  known: ExtractedProps | null,
+  components: any[],
+  importPath: string,
+): ExtractedProps | null {
+  const locals = components.filter(c => Array.isArray(c.__propFacts) && c.__propFacts.length && c.name);
+  if (!locals.length) return known;
+  const base: ExtractedProps = known ?? {
+    importPath,
+    components: {},
+    inheritedOnly: [],
+    extractedAt: new Date().toISOString(),
+  } as ExtractedProps;
+  for (const c of locals) {
+    if (base.components[c.name]) continue;
+    base.components[c.name] = { name: c.name, props: c.__propFacts as PropFact[] };
+  }
+  return base;
 }

--- a/story-generator/storybookOrigin.ts
+++ b/story-generator/storybookOrigin.ts
@@ -1,0 +1,82 @@
+/**
+ * Which Storybook is THIS request's Storybook?
+ *
+ * Three answers compete: the origin the panel reported (it runs inside
+ * Storybook's docs iframe, so `window.location.origin` is where the user is
+ * looking), `storybookMcpUrl` from story-ui.config.js (written by `init`
+ * with the conventional port, and left there when the port changes), and the
+ * environment's guess. The config used to win outright, so a project whose
+ * Storybook had moved to another port verified — and polled the index —
+ * against whatever answered on the old one: "Story did not appear in the
+ * index" for a story that was indexed within seconds where the user could
+ * see it.
+ *
+ * The panel's origin is a fact about the running session; the config is a
+ * declaration that can go stale. The origin wins when the server can reach
+ * it. When it cannot — a hosted deployment whose public origin is not
+ * routable from the server — the configured URL stands, and the choice is
+ * logged either way so a verification against the wrong Storybook is never
+ * silent.
+ */
+
+export type StorybookUrlSource = 'caller' | 'configured' | 'environment' | 'none';
+
+export interface StorybookUrlChoice {
+  url: string | undefined;
+  source: StorybookUrlSource;
+  /** One line for the log: what was chosen over what, and why. */
+  note?: string;
+}
+
+export interface ChooseStorybookUrlOptions {
+  /** `window.location.origin` as the panel sent it. */
+  callerOrigin?: string;
+  /** `config.storybookMcpUrl`. */
+  configured?: string;
+  /** `getStorybookUrl()` — environment, or the conventional guess. */
+  fallback?: string | null;
+  /** Does `${url}/index.json` answer? Injected for tests. */
+  reachable?: (url: string) => Promise<boolean>;
+}
+
+const trim = (u?: string | null) => (u ? u.replace(/\/+$/, '') : undefined);
+
+/** GET `${url}/index.json` with a short timeout; any HTTP answer counts as reachable. */
+export async function storybookAnswers(url: string, timeoutMs = 2500): Promise<boolean> {
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), timeoutMs);
+  try {
+    const res = await fetch(`${trim(url)}/index.json`, { signal: controller.signal, cache: 'no-store' } as RequestInit);
+    return res.ok;
+  } catch {
+    return false;
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+export async function chooseStorybookUrl(opts: ChooseStorybookUrlOptions): Promise<StorybookUrlChoice> {
+  const caller = trim(opts.callerOrigin);
+  const configured = trim(opts.configured);
+  const fallback = trim(opts.fallback);
+  const reachable = opts.reachable ?? storybookAnswers;
+
+  if (caller && configured && caller !== configured) {
+    if (await reachable(caller)) {
+      return {
+        url: caller,
+        source: 'caller',
+        note: `using the panel's own origin ${caller} over story-ui.config's storybookMcpUrl ${configured}`,
+      };
+    }
+    return {
+      url: configured,
+      source: 'configured',
+      note: `the panel's origin ${caller} did not answer from this server; using story-ui.config's storybookMcpUrl ${configured}`,
+    };
+  }
+  if (caller) return { url: caller, source: 'caller' };
+  if (configured) return { url: configured, source: 'configured' };
+  if (fallback) return { url: fallback, source: 'environment' };
+  return { url: undefined, source: 'none' };
+}

--- a/story-generator/validateStory.ts
+++ b/story-generator/validateStory.ts
@@ -3,6 +3,20 @@ import fs from 'fs';
 import path from 'path';
 import { createRequire } from 'module';
 import { isBlacklistedComponent, validateImports } from './componentBlacklist.js';
+import { resolveSpecifier, resolveOptionsFrom } from './knowledge/moduleResolution.js';
+
+/**
+ * A path deeper than the configured importPath is only wrong when it names
+ * nothing. Answered from disk (tsconfig paths, the declared componentsPath,
+ * node_modules) so a per-file import the catalog itself prescribed survives.
+ */
+function deepPathResolves(specifier: string, config: any): boolean {
+  try {
+    return resolveSpecifier(specifier, resolveOptionsFrom(config)).file !== null;
+  } catch {
+    return false;
+  }
+}
 
 export interface ValidationResult {
   isValid: boolean;
@@ -219,10 +233,20 @@ function performSemanticChecks(sourceFile: ts.SourceFile, config?: any): string[
         if (config && config.importPath && config.componentFramework !== 'web-components' && !scopeRootOnly) {
           const configuredPath = config.importPath;
 
-          // Check if LLM used a deep/incorrect path instead of the configured one
+          // Check if LLM used a deep/incorrect path instead of the configured one.
+          //
+          // Only when the deeper path names NOTHING. A local design system's
+          // catalog says, per component, "import from '@/components/alert/alert'"
+          // — a path the project declared and that resolves through its own
+          // tsconfig alias. Collapsing it onto the barrel is not a fix: the
+          // barrel does not export everything (college-town's leaves out
+          // data-table, date-picker and newsletter-signup), so the rewrite
+          // turned a correct story into one importing names that do not exist.
+          // Whether the path resolves is a fact on disk; it decides.
           if (importPath !== configuredPath &&
               (importPath.startsWith(configuredPath + '/') ||
-               importPath.includes('/' + configuredPath.split('/').pop() + '/'))) {
+               importPath.includes('/' + configuredPath.split('/').pop() + '/')) &&
+              !deepPathResolves(importPath, config)) {
             errors.push(
               `Import path error: Using "${importPath}" but the configured import path is "${configuredPath}". ` +
               `Change the import to: import { ComponentName } from '${configuredPath}';`
@@ -352,9 +376,11 @@ function attemptAutoFix(code: string, errors: string[], config?: any): string {
     fixedCode = fixMissingReactImport(fixedCode);
   }
 
-  // CRITICAL: Fix incorrect import paths
+  // CRITICAL: Fix incorrect import paths — only the ones that name nothing.
+  // A deep path that resolves was never an error (see performSemanticChecks)
+  // and is left exactly as the model wrote it.
   if (config?.importPath && errors.some(e => e.includes('Import path error'))) {
-    fixedCode = fixIncorrectImportPaths(fixedCode, config.importPath);
+    fixedCode = fixIncorrectImportPaths(fixedCode, config.importPath, spec => deepPathResolves(spec, config));
   }
 
   // First, check if the code appears to be truncated
@@ -711,7 +737,12 @@ function fixMissingReactImport(code: string): string {
  * Fixes incorrect import paths by replacing deep/wrong paths with the configured path
  * Catches LLM errors like: vuetify/components/lib/components/VAlert -> vuetify/components
  */
-function fixIncorrectImportPaths(code: string, correctImportPath: string): string {
+function fixIncorrectImportPaths(
+  code: string,
+  correctImportPath: string,
+  /** A deep path to leave alone because it resolves; nothing is kept by default. */
+  keep: (specifier: string) => boolean = () => false,
+): string {
   let fixedCode = code;
 
   // Match import statements and extract the path
@@ -726,7 +757,8 @@ function fixIncorrectImportPaths(code: string, correctImportPath: string): strin
     // e.g., vuetify/components/lib/components/VAlert should be vuetify/components
     if (importPath !== correctImportPath &&
         (importPath.startsWith(correctImportPath + '/') ||
-         importPath.includes('/' + correctImportPath.split('/').pop() + '/'))) {
+         importPath.includes('/' + correctImportPath.split('/').pop() + '/')) &&
+        !keep(importPath)) {
       // Replace the incorrect import with the correct one
       const incorrectImport = match[0];
       const correctedImport = `import {${components}} from '${correctImportPath}'`;
@@ -770,10 +802,14 @@ function fixIncorrectImportPaths(code: string, correctImportPath: string): strin
   );
 
   let wrongMatch;
+  const toRemove: string[] = [];
   while ((wrongMatch = wrongPathPattern.exec(fixedCode)) !== null) {
+    const specifier = wrongMatch[0].match(/from\s*['"]([^'"]+)['"]/)?.[1] ?? '';
+    if (keep(specifier)) continue;
     wrongPathImports.push(wrongMatch[1]);
-    fixedCode = fixedCode.replace(wrongMatch[0], '');
+    toRemove.push(wrongMatch[0]);
   }
+  for (const line of toRemove) fixedCode = fixedCode.replace(line, '');
 
   // If we found wrong imports, add a consolidated correct import
   if (wrongPathImports.length > 0) {

--- a/story-generator/verify/probes/a11y.ts
+++ b/story-generator/verify/probes/a11y.ts
@@ -22,6 +22,7 @@
 
 import path from 'path';
 import type { HostTooling } from '../hostTooling.js';
+import { logger } from '../../logger.js';
 
 export interface A11yViolation {
   id: string;
@@ -39,6 +40,15 @@ export interface A11yResult {
   reason?: string;
   violations: A11yViolation[];
   passCount: number;
+  /**
+   * Violations whose offending element is the story ROOT itself — Storybook's
+   * `#storybook-root`, which no story authors. Only an overlay library's
+   * `hideOthers` puts `aria-hidden` on it, while a Select, Dialog or Popover
+   * is open, and axe then reports "ARIA hidden element must not contain
+   * focusable elements" against the harness, not the composition. Counted
+   * here rather than dropped silently, so a log can say what was set aside.
+   */
+  environmentViolations?: A11yViolation[];
 }
 
 /**
@@ -170,6 +180,26 @@ export async function runA11yProbe(page: any, tooling: HostTooling): Promise<A11
   }
 
   try {
+    /**
+     * Let an overlay the interaction probe opened finish closing first.
+     *
+     * The probes run in order and the interaction probe opens menus, selects
+     * and dialogs before this one runs. Radix (and every `aria-hidden`-based
+     * overlay) marks the story root `aria-hidden="true"` while one is open;
+     * measured on a college-town form, the Select's close had not landed by
+     * the time axe ran, and the story was blocked for a defect in
+     * `#storybook-root`. Escape, then wait for the root to be visible again,
+     * bounded so an overlay that refuses to close cannot hold this up.
+     */
+    await page.evaluate(async () => {
+      const root = document.querySelector('#storybook-root') || document.querySelector('#root');
+      if (!root || root.getAttribute('aria-hidden') !== 'true') return;
+      document.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape', bubbles: true }));
+      for (let i = 0; i < 10 && root.getAttribute('aria-hidden') === 'true'; i++) {
+        await new Promise(r => setTimeout(r, 100));
+      }
+    }).catch(() => { /* a page that cannot be asked is judged as it is */ });
+
     const raw = await page.evaluate(async () => {
       const axe = (window as any).axe;
       if (!axe?.run) return null;
@@ -201,7 +231,19 @@ export async function runA11yProbe(page: any, tooling: HostTooling): Promise<A11
     if (!raw) {
       return { ran: false, reason: 'axe did not initialise in the page', violations: [], passCount: 0 };
     }
-    return { ran: true, violations: raw.violations, passCount: raw.passCount };
+    // The root is Storybook's element, not the story's markup (see A11yResult).
+    const isRoot = (selector?: string) => !!selector && /^#(storybook-root|root)$/.test(selector.trim());
+    const environmentViolations = raw.violations.filter((v: A11yViolation) => isRoot(v.selector));
+    const violations = raw.violations.filter((v: A11yViolation) => !isRoot(v.selector));
+    if (environmentViolations.length) {
+      logger.log(`♿ axe: ${environmentViolations.length} violation(s) on the story root itself set aside as environment (an overlay's aria-hidden), not the story: ${environmentViolations.map((v: A11yViolation) => v.id).join(', ')}`);
+    }
+    return {
+      ran: true,
+      violations,
+      passCount: raw.passCount,
+      ...(environmentViolations.length ? { environmentViolations } : {}),
+    };
   } catch (error) {
     return {
       ran: false,

--- a/story-generator/verify/probes/interaction.ts
+++ b/story-generator/verify/probes/interaction.ts
@@ -138,6 +138,27 @@ export async function runInteractionProbe(
 
       const sleep = (ms: number) => new Promise(r => setTimeout(r, ms));
 
+      /**
+       * A press, the way a pointer delivers one: pointerdown, mousedown,
+       * pointerup, mouseup, click. `el.click()` alone fires only the last of
+       * those, and a control wired to mousedown never sees it — Mantine's
+       * PasswordInput visibility toggle (onMouseDown + onTouchEnd + Space,
+       * deliberately no onClick, so the input keeps focus) was reported
+       * "does not respond to a click" on every form that used one, and a
+       * repair was spent on correct code. A user's click is the whole
+       * sequence; the probe's must be too.
+       */
+      const press = (el: HTMLElement) => {
+        const r = el.getBoundingClientRect();
+        const init = { bubbles: true, cancelable: true, composed: true, clientX: r.left + r.width / 2, clientY: r.top + r.height / 2, button: 0 };
+        const fire = (type: string, Ctor: any) => { try { el.dispatchEvent(new Ctor(type, init)); } catch { /* an engine without PointerEvent */ } };
+        fire('pointerdown', (window as any).PointerEvent || MouseEvent);
+        fire('mousedown', MouseEvent);
+        fire('pointerup', (window as any).PointerEvent || MouseEvent);
+        fire('mouseup', MouseEvent);
+        el.click();
+      };
+
       const nameOf = (el: Element): string => {
         const aria = el.getAttribute('aria-label');
         if (aria) return aria;
@@ -255,7 +276,7 @@ export async function runInteractionProbe(
 
       for (const el of toggles) {
         const before = toggleState(el);
-        try { (el as HTMLElement).click(); } catch { continue; }
+        try { press(el as HTMLElement); } catch { continue; }
         await sleep(120);
         const after = toggleState(el);
         result.controlsTested++;
@@ -271,7 +292,7 @@ export async function runInteractionProbe(
           });
         } else {
           // Put it back. The story may be screenshotted after this.
-          try { (el as HTMLElement).click(); await sleep(60); } catch { /* best effort */ }
+          try { press(el as HTMLElement); await sleep(60); } catch { /* best effort */ }
         }
       }
 
@@ -323,7 +344,7 @@ export async function runInteractionProbe(
           return { n, top: r.top, left: r.left };
         });
 
-        try { el.click(); } catch { continue; }
+        try { press(el); } catch { continue; }
         await sleep(220);   // allow the overlay to mount and position
         result.overlaysTested++;
 
@@ -349,7 +370,7 @@ export async function runInteractionProbe(
         try {
           el.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape', bubbles: true }));
           await sleep(80);
-          if (el.getAttribute('aria-expanded') === 'true') { el.click(); await sleep(80); }
+          if (el.getAttribute('aria-expanded') === 'true') { press(el); await sleep(80); }
         } catch { /* best effort */ }
       }
 

--- a/story-generator/verify/renderHarness.ts
+++ b/story-generator/verify/renderHarness.ts
@@ -148,8 +148,20 @@ export async function renderStory(options: RenderOptions): Promise<RenderResult>
      *  - Nothing is preparing and nothing errored, and the root is still
      *    empty at the timeout: the story rendered nothing. Code failure.
      */
+    /**
+     * The preview reloads itself while a brand-new story is being verified.
+     *
+     * Vite serves the new file with a full reload of the preview iframe (the
+     * panel survives it via sessionStorage for the same reason), and a reload
+     * that lands between two evaluate calls surfaces as "Execution context
+     * was destroyed, most likely because of a navigation". Observed on a
+     * modal-dialog story one second into verification: correct code,
+     * reported as "could not render", and the user shown "not verified".
+     * A reload is not a verdict on the story, so the mount-and-settle phase
+     * is simply run again on the page that came back — twice at most.
+     */
+    const RELOADED = /Execution context was destroyed|because of a navigation|frame was detached/i;
     const prepareCapMs = Math.max(timeoutMs, PREPARING_CAP_MS);
-    const mountStarted = Date.now();
     const isMounted = () => {
       const root = document.querySelector('#storybook-root') || document.querySelector('#root');
       return !!root && root.childElementCount > 0;
@@ -165,40 +177,91 @@ export async function renderStory(options: RenderOptions): Promise<RenderResult>
           return { preparing, errored, errorText: errored ? (errorEl?.textContent || '').trim().slice(0, 500) : '' };
         });
         return r && typeof r === 'object' ? r : { preparing: false, errored: false, errorText: '' };
-      } catch {
+      } catch (error) {
+        if (RELOADED.test(error instanceof Error ? error.message : String(error))) throw error;
         return { preparing: false, errored: false, errorText: '' };
       }
     };
-    let mountState: 'mounted' | 'empty' | 'preparing' | 'errored' = 'empty';
-    let storybookError = '';
-    // First wait: the render timeout, as before.
-    try {
-      await page.waitForFunction(isMounted, { timeout: timeoutMs });
-      mountState = 'mounted';
-    } catch {
-      const state = await classify();
-      if (state.errored) {
-        mountState = 'errored'; storybookError = state.errorText;
-      } else if (state.preparing) {
-        // Storybook is still compiling. Wait it out to the cap, re-checking
-        // that it is still preparing rather than quietly empty.
-        const remaining = prepareCapMs - (Date.now() - mountStarted);
-        try {
-          await page.waitForFunction(isMounted, { timeout: Math.max(1000, remaining) });
-          mountState = 'mounted';
-        } catch {
-          const again = await classify();
-          if (again.errored) { mountState = 'errored'; storybookError = again.errorText; }
-          else mountState = again.preparing ? 'preparing' : 'empty';
+    // An object, not two `let`s: TypeScript narrows a `let` assigned inside
+    // a closure to its initial literal at the use site below.
+    const mount: { state: 'mounted' | 'empty' | 'preparing' | 'errored'; error: string } = { state: 'empty', error: '' };
+
+    const mountAndSettle = async () => {
+      const mountStarted = Date.now();
+      mount.state = 'empty';
+      mount.error = '';
+      // First wait: the render timeout, as before.
+      try {
+        await page.waitForFunction(isMounted, { timeout: timeoutMs });
+        mount.state = 'mounted';
+      } catch (error) {
+        if (RELOADED.test(error instanceof Error ? error.message : String(error))) throw error;
+        const state = await classify();
+        if (state.errored) {
+          mount.state = 'errored'; mount.error = state.errorText;
+        } else if (state.preparing) {
+          // Storybook is still compiling. Wait it out to the cap, re-checking
+          // that it is still preparing rather than quietly empty.
+          const remaining = prepareCapMs - (Date.now() - mountStarted);
+          try {
+            await page.waitForFunction(isMounted, { timeout: Math.max(1000, remaining) });
+            mount.state = 'mounted';
+          } catch (again_error) {
+            if (RELOADED.test(again_error instanceof Error ? again_error.message : String(again_error))) throw again_error;
+            const again = await classify();
+            if (again.errored) { mount.state = 'errored'; mount.error = again.errorText; }
+            else mount.state = again.preparing ? 'preparing' : 'empty';
+          }
+        } else {
+          mount.state = 'empty';
         }
-      } else {
-        mountState = 'empty';
+      }
+      if (mount.state !== 'mounted') return;
+
+      /**
+       * Wait for the DOM to STOP CHANGING, not merely to be non-empty.
+       *
+       * `childElementCount > 0` is the earliest signal that something mounted,
+       * and probing there measures a story mid-render. Carbon reported two
+       * accessibility blockers on correct code: a sort button whose text had not
+       * arrived yet ("Buttons must have discernible text" — it reads
+       * "Deployment" a moment later), and an overflow menu whose
+       * `aria-labelledby` pointed at a tooltip Carbon had not rendered yet (it
+       * resolves to "Options"). Both were false, and a verification system that
+       * fails correct work is worse than none.
+       *
+       * Two consecutive identical samples, then stop. Cheap, framework-agnostic,
+       * and bounded so a story with a live animation or a polling timer cannot
+       * hold verification open.
+       */
+      const settleDeadline = Date.now() + Math.min(3000, timeoutMs);
+      let previous = -1;
+      let stableReadings = 0;
+      while (Date.now() < settleDeadline && stableReadings < 2) {
+        const signature: number = await page.evaluate(
+          () => document.querySelectorAll('*').length + (document.body.innerText || '').length,
+        );
+        stableReadings = signature === previous ? stableReadings + 1 : 0;
+        previous = signature;
+        if (stableReadings < 2) await page.waitForTimeout(120);
+      }
+    };
+
+    for (let reloads = 0; ; reloads++) {
+      try {
+        await mountAndSettle();
+        break;
+      } catch (error) {
+        const message = error instanceof Error ? error.message : String(error);
+        if (!RELOADED.test(message) || reloads >= 2) throw error;
+        logger.log(`🔁 The preview reloaded while ${storyId} was rendering (Vite picked up the new file); waiting for it again`);
+        try { await page.waitForLoadState('domcontentloaded', { timeout: timeoutMs }); } catch { /* the loop re-waits for the mount */ }
       }
     }
 
-    if (mountState !== 'mounted') {
+    if (mount.state !== 'mounted') {
       await dispose();
-      if (mountState === 'preparing') {
+      if (mount.state === 'preparing') {
         return {
           ok: false,
           reason: `Storybook was still preparing the story after ${Math.round(prepareCapMs / 1000)}s (a cold compile of new imports, or a stalled dev server)`,
@@ -209,8 +272,8 @@ export async function renderStory(options: RenderOptions): Promise<RenderResult>
       }
       return {
         ok: false,
-        reason: mountState === 'errored'
-          ? `Storybook showed an error while rendering the story: ${storybookError || 'no message'}`
+        reason: mount.state === 'errored'
+          ? `Storybook showed an error while rendering the story: ${mount.error || 'no message'}`
           : 'Story did not mount — #storybook-root stayed empty and Storybook was not preparing anything',
         failureClass: 'code',
         pageErrors, consoleErrors, isErrorPlaceholder: false,
@@ -218,33 +281,6 @@ export async function renderStory(options: RenderOptions): Promise<RenderResult>
       };
     }
 
-    /**
-     * Wait for the DOM to STOP CHANGING, not merely to be non-empty.
-     *
-     * `childElementCount > 0` is the earliest signal that something mounted,
-     * and probing there measures a story mid-render. Carbon reported two
-     * accessibility blockers on correct code: a sort button whose text had not
-     * arrived yet ("Buttons must have discernible text" — it reads
-     * "Deployment" a moment later), and an overflow menu whose
-     * `aria-labelledby` pointed at a tooltip Carbon had not rendered yet (it
-     * resolves to "Options"). Both were false, and a verification system that
-     * fails correct work is worse than none.
-     *
-     * Two consecutive identical samples, then stop. Cheap, framework-agnostic,
-     * and bounded so a story with a live animation or a polling timer cannot
-     * hold verification open.
-     */
-    const settleDeadline = Date.now() + Math.min(3000, timeoutMs);
-    let previous = -1;
-    let stableReadings = 0;
-    while (Date.now() < settleDeadline && stableReadings < 2) {
-      const signature: number = await page.evaluate(
-        () => document.querySelectorAll('*').length + (document.body.innerText || '').length,
-      );
-      stableReadings = signature === previous ? stableReadings + 1 : 0;
-      previous = signature;
-      if (stableReadings < 2) await page.waitForTimeout(120);
-    }
 
     const bodyText: string = await page.evaluate(() => document.body.innerText || '');
     const isErrorPlaceholder = ERROR_PLACEHOLDER_MARKERS.some(m => bodyText.includes(m));


### PR DESCRIPTION

Measured on ten home-screen prompts against college-town (Radix + Tailwind,
local source, Storybook 10.5.10) and react-mantine (npm barrel). Every story
was written and indexed before and after; what changed is what the pipeline
did to correct code and what it let through.

- validateStory collapsed every `@/components/<x>/<x>` import — the exact path
  the catalog prescribed — onto the barrel as a "deep/incorrect path", on all
  ten college-town prompts. Whether a path resolves is a fact on disk
  (tsconfig paths, the declared importPath → componentsPath pairing,
  node_modules exports); knowledge/moduleResolution.ts answers it and only a
  path that names nothing is rewritten. The same resolver lets
  validateLocalNamedImports check alias imports for missing exports.
- config.storybookMcpUrl beat the panel's own origin, so a project whose
  Storybook moved ports verified against whatever answered on the old one.
  storybookOrigin.ts prefers the caller's origin when this server can reach it.
- The isolation check forbade react-hook-form and zod on a design system whose
  own Form component and story import them; the allowance is now derived from
  the components' source (librarySourceDependencies).
- The interaction probe fired `el.click()` alone, so Mantine's PasswordInput
  toggle (mousedown-wired) blocked every form as a dead control. It presses
  like a pointer now.
- axe ran while an overlay's aria-hidden was still on #storybook-root and
  blocked a form for a defect in Storybook's element; root-targeted violations
  are set aside as environment and counted.
- The render harness gave up when Vite reloaded the preview mid-render
  ("Execution context was destroyed"); it re-waits for the page instead.
- A local component's declared prop values were shown to the model and never
  judged: `<Pillbox status={STATE_TONE[row.state] as any}>` crashed at render
  twice. Local declared props join knownProps, and the conformance check
  judges every value the file states (lookup tables, conditionals, casts).



https://claude.ai/code/session_0158a8zxX4SKPdxm7DLfgqp4
