### PR TITLE
feat(generator): spacing, typography, icons and images are derived from the design system

### DIFF
--- a/__tests__/icon-vocabulary.test.ts
+++ b/__tests__/icon-vocabulary.test.ts
@@ -1,0 +1,123 @@
+/**
+ * Icons and placeholder images come from what the project installs and
+ * catalogues — judged from each package's own manifest and the catalog, not
+ * from a list of package names — and a text glyph is never an icon.
+ */
+
+import { describe, it, expect } from 'vitest';
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import {
+  manifestSaysIcons, readExportNames, derivedIconPackages, deriveIconVocabulary,
+  formatIconRules, formatImageRules, checkIconImports,
+} from '../story-generator/knowledge/iconFacts.js';
+
+function fixtureProject(): string {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'icons-'));
+  const write = (rel: string, text: string) => { fs.mkdirSync(path.dirname(path.join(root, rel)), { recursive: true }); fs.writeFileSync(path.join(root, rel), text); };
+  write('package.json', JSON.stringify({ name: 'app', dependencies: { '@acme/ui': '1.0.0', 'glyphset-react': '2.0.0', 'left-pad': '1.0.0' } }));
+  // The design system depends on its own icon set; the project does not list it.
+  write('node_modules/@acme/ui/package.json', JSON.stringify({ name: '@acme/ui', dependencies: { '@acme/pictograms': '1.0.0' } }));
+  write('node_modules/@acme/pictograms/package.json', JSON.stringify({ name: '@acme/pictograms', description: 'SVG icons for Acme UI', types: 'lib/index.d.ts' }));
+  write('node_modules/@acme/pictograms/lib/index.d.ts', "export { default as Icon } from './Icon';\nexport * from './generated/bucket-0';\n");
+  write('node_modules/@acme/pictograms/lib/generated/bucket-0.d.ts', "declare const _Add: T;\ndeclare const _ChevronDown: T;\ndeclare const _WatsonHealth3D: T;\nexport { _Add as Add, _ChevronDown as ChevronDown, _WatsonHealth3D as WatsonHealth3D };\n");
+  // A project dependency whose name says nothing but whose keywords do (lucide's shape).
+  write('node_modules/glyphset-react/package.json', JSON.stringify({ name: 'glyphset-react', keywords: ['react', 'icons', 'svg'], types: 'dist/index.d.ts' }));
+  write('node_modules/glyphset-react/dist/index.d.ts', "declare const Home: X;\ndeclare const Search: X;\nexport { Home, Home as HomeIcon, Search };\n");
+  write('node_modules/left-pad/package.json', JSON.stringify({ name: 'left-pad', description: 'String left pad' }));
+  return root;
+}
+
+describe('icon packages are judged by their own manifests', () => {
+  it('recognises an icon set from name, keywords or description', () => {
+    expect(manifestSaysIcons({ name: '@carbon/icons-react' })).toBe(true);
+    expect(manifestSaysIcons({ name: 'lucide-react', keywords: ['icons'] })).toBe(true);
+    expect(manifestSaysIcons({ name: 'pictos', description: 'A glyph set' })).toBe(true);
+    expect(manifestSaysIcons({ name: 'left-pad', description: 'String left pad' })).toBe(false);
+    expect(manifestSaysIcons(null)).toBe(false);
+  });
+
+  it('finds the design system\'s own icon dependency and the project\'s, with real export names', () => {
+    const root = fixtureProject();
+    const pkgs = derivedIconPackages(root, '@acme/ui');
+    expect(pkgs.map(p => `${p.name}:${p.via}`).sort()).toEqual(['@acme/pictograms:design-system', 'glyphset-react:project']);
+    const pict = pkgs.find(p => p.name === '@acme/pictograms')!;
+    expect(pict.exports).toEqual(['Add', 'ChevronDown', 'WatsonHealth3D']);   // `Icon` is the wrapper, not an icon
+    expect(pict.examples).toEqual(['Add', 'ChevronDown']);
+    fs.rmSync(root, { recursive: true, force: true });
+  });
+
+  it('reads export names through export * one hop', () => {
+    const root = fixtureProject();
+    expect(readExportNames(path.join(root, 'node_modules/glyphset-react/dist/index.d.ts'))).toEqual(['Home', 'HomeIcon', 'Search']);
+    fs.rmSync(root, { recursive: true, force: true });
+  });
+});
+
+describe('deriveIconVocabulary', () => {
+  it('collects catalog icon components, the icon primitive and placeholder components', () => {
+    const v = deriveIconVocabulary({
+      projectRoot: fs.mkdtempSync(path.join(os.tmpdir(), 'empty-')),
+      components: [
+        { name: 'HeartIcon', filePath: '/p/src/icons/index.tsx', __componentPath: '@sail/ui' },
+        { name: 'Wind', filePath: '/p/src/icons/index.tsx' },
+        { name: 'SvgIcon', filePath: '/p/node_modules/@mui/material/SvgIcon/index.d.ts' },
+        { name: 'ListItemIcon', filePath: '', props: ['children', 'className'] },
+        { name: 'CheckIcon', filePath: '/p/node_modules/x/Check.d.ts', props: ['size', 'color'] },
+        { name: 'MysteryIcon', filePath: '' },
+        { name: 'Skeleton' }, { name: 'DataTableSkeleton' }, { name: 'AspectRatio' }, { name: 'SkeletonText' }, { name: 'Button' },
+      ],
+    });
+    expect(v.packages).toEqual([]);
+    expect(v.iconComponents.map(c => c.name)).toEqual(['HeartIcon', 'Wind', 'CheckIcon']);
+    expect(v.iconPrimitive).toBe('SvgIcon');
+    expect(v.placeholders).toEqual(['Skeleton', 'AspectRatio', 'DataTableSkeleton']);
+  });
+});
+
+describe('prompt text', () => {
+  it('names the installed package and its real exports, and forbids glyphs', () => {
+    const lines = formatIconRules({ packages: [{ name: '@acme/pictograms', via: 'design-system', exports: ['Add', 'ChevronDown'], examples: ['Add', 'ChevronDown'] }], iconComponents: [], placeholders: [], source: '' }).join('\n');
+    expect(lines).toContain("import { Add } from '@acme/pictograms'");
+    expect(lines).toContain("the design system's own icon set");
+    expect(lines).toContain('NEVER an icon');
+    expect(lines).not.toContain('Unicode symbols');
+  });
+
+  it('with nothing installed, asks for an inline SVG — never a glyph', () => {
+    const lines = formatIconRules({ packages: [], iconComponents: [], placeholders: [], source: '' }).join('\n');
+    expect(lines).toContain('inline <svg');
+    expect(lines).toContain('never a text character');
+  });
+
+  it('points at the library\'s icon primitive when it has one', () => {
+    const lines = formatIconRules({ packages: [], iconComponents: [], iconPrimitive: 'SvgIcon', placeholders: [], source: '' }).join('\n');
+    expect(lines).toContain('<SvgIcon> primitive with an inline SVG path');
+  });
+
+  it('image rules: placeholder from the catalog or a data URI; picsum only for a real photo', () => {
+    const withPh = formatImageRules({ packages: [], iconComponents: [], placeholders: ['Skeleton', 'AspectRatio'], source: '' });
+    expect(withPh).toContain('<Skeleton>, <AspectRatio>');
+    expect(withPh).toContain('data:image/svg+xml');
+    expect(withPh.indexOf('REAL PHOTO')).toBeGreaterThan(withPh.indexOf('PLACEHOLDER'));
+    const without = formatImageRules(null, 'html');
+    expect(without).toContain('no skeleton/placeholder component');
+    expect(without).toContain('picsum.photos');
+  });
+});
+
+describe('checkIconImports', () => {
+  const vocab = { packages: [{ name: '@carbon/icons-react', via: 'design-system' as const, exports: ['Add', 'Close', 'ChevronDown', 'OverflowMenuVertical'], examples: ['Add', 'Close'] }], iconComponents: [], placeholders: [], source: '' };
+  it('rejects a name the package does not export and suggests the nearest real one', () => {
+    const code = "import React from 'react';\nimport { Add, Chevrondown, MoreVertical } from '@carbon/icons-react';";
+    const out = checkIconImports(code, vocab);
+    expect(out.map(v => v.name)).toEqual(['Chevrondown', 'MoreVertical']);
+    expect(out[0].message).toContain('did you mean "ChevronDown"');
+    expect(out[0].line).toBe(2);
+  });
+  it('is silent for real exports and for packages whose exports are unknown', () => {
+    expect(checkIconImports("import { Add, Close } from '@carbon/icons-react';", vocab)).toEqual([]);
+    expect(checkIconImports("import { Whatever } from 'unknown-icons';", { ...vocab, packages: [{ name: 'unknown-icons', via: 'project', exports: [], examples: [] }] })).toEqual([]);
+  });
+});

--- a/__tests__/spacing-vocabulary.test.ts
+++ b/__tests__/spacing-vocabulary.test.ts
@@ -1,0 +1,284 @@
+/**
+ * Spacing guidance is DERIVED from the design system, never prescribed.
+ *
+ * A gap primitive in the catalog, a spacing scale in the stylesheet, or the
+ * utility steps in the team's own stories become the rules; only a system
+ * with none of them gets the inline pixel examples, and the prompt says so.
+ * The same vocabulary judges the output: an inline `padding: 24px` is an
+ * error where a scale exists and is nothing where none does.
+ */
+
+import { describe, it, expect } from 'vitest';
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import {
+  deriveSpacingVocabulary, formatSpacingRules, checkInlineSpacing, checkTokenTiers,
+  spacingScaleFrom, aliasesFrom, exampleElement,
+} from '../story-generator/knowledge/spacingFacts.js';
+import { readStylingIdiom, formatStylingGuidance } from '../story-generator/knowledge/stylingFacts.js';
+import { generateLayoutInstructions } from '../story-generator/promptGenerator.js';
+import type { StylingFacts } from '../story-generator/knowledge/stylingFacts.js';
+
+const fallback = {
+  wrapper: 'render: () => <div style={{ padding: "24px" }}>...content...</div>',
+  formGap: '<div style={{ display: "flex", flexDirection: "column", gap: "16px" }}>',
+  buttonMargin: '<div style={{ marginTop: "24px" }}><Button>Submit</Button></div>',
+};
+
+const component = (name: string, category: any, props: Array<{ name: string; type?: string; options?: string[]; optionsOpen?: boolean; doc?: string }>) => ({
+  name, filePath: '', description: '', category, props: props.map(p => p.name), slots: [], examples: [],
+});
+
+const facts = (entries: Record<string, Array<{ name: string; type?: string; options?: string[]; optionsOpen?: boolean; doc?: string; deprecated?: string }>>) => ({
+  importPath: 'x', inheritedOnly: [], extractedAt: '', components: Object.fromEntries(Object.entries(entries).map(([name, props]) => [name, { name, props: props.map(p => ({ required: false, ...p })) }])),
+});
+
+const styling = (tokens: StylingFacts['tokens'], idiom: StylingFacts['idiom'] = { attributes: [], sampled: 0 }): StylingFacts => ({
+  tokens, idiom, sources: { projectFiles: 1, packageFiles: 0, declaredFiles: 0, tokens: tokens.reduce((n, g) => n + g.names.length, 0), lookedAtNothing: false },
+});
+
+describe('deriveSpacingVocabulary', () => {
+  it('finds gap primitives with their declared values and orientation (Mantine shape)', () => {
+    const v = deriveSpacingVocabulary({
+      components: [component('Stack', 'layout', []), component('Group', 'layout', []), component('Button', 'form', [])],
+      facts: facts({
+        Stack: [{ name: 'gap', type: 'MantineSpacing', options: ['xs', 'sm', 'md', 'lg', 'xl'], optionsOpen: true }, { name: 'align', type: 'string' }],
+        Group: [{ name: 'gap', type: 'MantineSpacing', options: ['xs', 'sm', 'md', 'lg', 'xl'], optionsOpen: true }],
+        Button: [{ name: 'onClick', type: '() => void' }],
+      }),
+    });
+    expect(v.hasScale).toBe(true);
+    expect(v.gapPrimitives.map(p => p.name)).toEqual(['Group', 'Stack']);
+    expect(v.gapPrimitives[1].values).toEqual(['xs', 'sm', 'md', 'lg', 'xl']);
+    expect(v.gapPrimitives[1].open).toBe(true);
+  });
+
+  it('keeps a gap prop whose scale the type does not enumerate (Carbon: (typeof SPACING_STEPS)[number])', () => {
+    const v = deriveSpacingVocabulary({
+      components: [component('Stack', 'layout', [])],
+      facts: facts({ Stack: [
+        { name: 'gap', type: 'string | (typeof SPACING_STEPS)[number]', doc: 'Provide either a custom value or a step from the spacing scale' },
+        { name: 'orientation', type: "'horizontal' | 'vertical'", options: ['horizontal', 'vertical'] },
+      ] }),
+    });
+    expect(v.gapPrimitives).toHaveLength(1);
+    expect(v.gapPrimitives[0].values).toEqual([]);
+    expect(v.gapPrimitives[0].open).toBe(true);
+    expect(v.gapPrimitives[0].orientation).toEqual({ prop: 'orientation', values: ['horizontal', 'vertical'] });
+    const rules = formatSpacingRules(v, 'jsx', fallback);
+    expect(rules).toContain('<Stack gap=');
+    expect(rules).toContain('a step from the spacing scale');
+    expect(rules).not.toContain('padding: "24px"');
+  });
+
+  it('reads the spacing scale from tokens whose name says spacing AND whose value is a length, sorted by size', () => {
+    const scale = spacingScaleFrom(styling([
+      { category: 'spacing', names: ['ss-space-16', 'ss-space-4', 'cds-grid-margin', 'layout--size-lg', 'ss-comp-button-gap-xs', 'ss-space-64'],
+        values: { 'ss-space-16': '16px', 'ss-space-4': '4px', 'cds-grid-margin': '0', 'layout--size-lg': 'where(.x)', 'ss-comp-button-gap-xs': 'var(--ss-space-4)', 'ss-space-64': '4rem' } },
+    ]));
+    expect(scale.map(t => t.name)).toEqual(['ss-space-4', 'ss-space-16', 'ss-space-64']);
+    expect(scale.find(t => t.name === 'ss-space-64')?.value).toBe('4rem');
+    // One stray `gap` token is a component's internals, not a scale.
+    expect(spacingScaleFrom(styling([{ category: 'spacing', names: ['cds-stack-gap'], values: { 'cds-stack-gap': '0.125rem' } }]))).toEqual([]);
+  });
+
+  it('with tokens and no layout component the prompt gives ONE recipe in the scale, border-box, and no pixel literal', () => {
+    const v = deriveSpacingVocabulary({
+      components: [component('Button', 'form', [{ name: 'variant', type: "'primary' | 'ghost'" }]), component('Heading', 'content', [{ name: 'level', type: '1 | 2 | 3' }])],
+      facts: facts({ Heading: [{ name: 'level', type: '1 | 2 | 3' }] }),
+      styling: styling([{ category: 'spacing', names: ['ss-space-8', 'ss-space-16', 'ss-space-24', 'ss-space-32'], values: { 'ss-space-8': '8px', 'ss-space-16': '16px', 'ss-space-24': '24px', 'ss-space-32': '32px' } }]),
+      layoutRules: { multiColumnWrapper: 'Grid', columnComponent: 'Grid', containerComponent: 'div', layoutExamples: { twoColumn: "<div style={{display: 'grid', gap: '1rem'}}>…</div>" } },
+    });
+    expect(v.hasScale).toBe(true);
+    expect(v.gapPrimitives).toEqual([]);
+    expect(v.columns).toBeUndefined();          // `Grid` is not in the catalog
+    expect(v.layoutExamples).toEqual([]);       // the config example teaches `gap: '1rem'`
+    const rules = formatSpacingRules(v, 'jsx', fallback);
+    expect(rules).toContain('repeat(3, minmax(0, 1fr))');
+    expect(rules).toContain('boxSizing: "border-box"');
+    expect(rules).toContain('var(--ss-space-');
+    expect(rules).toMatch(/gap: "var\(--ss-space-\d+\)"/);
+    // The scale lists its values (`--ss-space-8 (8px)`); no style property may carry a literal.
+    expect(rules).not.toMatch(/(padding|gap|margin\w*):\s*"?\d+(px|rem)/);
+    expect(rules).not.toContain('1rem');
+    expect(rules).toContain('<Heading level=[1|2|3]>');
+  });
+
+  it('uses the team\'s own utility steps when the idiom is className', () => {
+    const v = deriveSpacingVocabulary({
+      components: [component('Card', 'layout', [{ name: 'className', type: 'string' }])],
+      styling: styling([], { attributes: [{ name: 'className', uses: 1767 }, { name: 'style', uses: 3 }], sampled: 50, spacingClasses: [{ name: 'gap-4', uses: 31 }, { name: 'p-6', uses: 12 }, { name: 'space-y-2', uses: 8 }] }),
+      layoutRules: { multiColumnWrapper: 'div', columnComponent: 'div', layoutExamples: { twoColumn: '<div className="grid grid-cols-2 gap-4">…</div>' } },
+    });
+    expect(v.hasScale).toBe(true);
+    expect(v.utilities?.attribute).toBe('className');
+    expect(v.layoutExamples).toHaveLength(1);
+    const rules = formatSpacingRules(v, 'jsx', fallback);
+    expect(rules).toContain('gap-4 (31)');
+    expect(rules).toContain('className="p-6"');
+    expect(rules).toContain('grid grid-cols-2 gap-4');
+    expect(rules).not.toContain('24px');
+  });
+
+  it('honours config wrapper/column names only when the catalog has them', () => {
+    const v = deriveSpacingVocabulary({
+      components: [component('Grid', 'layout', [{ name: 'withRowGap', type: 'boolean' }]), component('Column', 'layout', [{ name: 'lg', type: 'ColumnSpan' }]), component('Stack', 'layout', [{ name: 'gap', type: 'string | number' }])],
+      layoutRules: { multiColumnWrapper: 'Grid', columnComponent: 'Column', containerComponent: 'Grid' },
+    });
+    expect(v.columns).toEqual({ wrapper: 'Grid', column: 'Column', container: 'Grid' });
+    const rules = formatSpacingRules(v, 'jsx', fallback);
+    expect(rules).toContain('<Grid> with each column in <Column>');
+  });
+
+  it('falls back to the inline examples, and says why, when nothing is derivable', () => {
+    const v = deriveSpacingVocabulary({ components: [component('Button', 'form', [{ name: 'label', type: 'string' }])] });
+    expect(v.hasScale).toBe(false);
+    const rules = formatSpacingRules(v, 'jsx', fallback);
+    expect(rules).toContain('declares no layout primitive with a gap prop, no spacing tokens');
+    expect(rules).toContain(fallback.wrapper);
+    expect(formatSpacingRules(null, 'html', fallback)).toContain(fallback.formGap);
+  });
+
+  it('writes examples in template syntax for non-React frameworks', () => {
+    expect(exampleElement('Stack', { gap: 4 }, 'jsx')).toBe('<Stack gap={4}>…</Stack>');
+    expect(exampleElement('v-stack', { gap: 4 }, 'html')).toBe('<v-stack gap="4">…</v-stack>');
+    const v = deriveSpacingVocabulary({
+      components: [component('Button', 'form', [])],
+      styling: styling([{ category: 'spacing', names: ['sl-spacing-small', 'sl-spacing-medium', 'sl-spacing-large'], values: { 'sl-spacing-small': '0.5rem', 'sl-spacing-medium': '1rem', 'sl-spacing-large': '1.5rem' } }]),
+    });
+    const rules = formatSpacingRules(v, 'html', fallback);
+    expect(rules).toContain('style="display: flex; flex-direction: column; gap: var(--sl-spacing-medium)"');
+    expect(rules).not.toContain('style={{');
+  });
+});
+
+describe('token tiers', () => {
+  const tiered = styling([{
+    category: 'color',
+    names: ['ss-navy-50', 'ss-navy-900', 'ss-color-surface', 'ss-color-background-brand', 'ss-comp-card-background'],
+    values: { 'ss-navy-50': '#F2F5F9', 'ss-navy-900': '#0B1F3A', 'ss-color-surface': 'var(--ss-navy-50)', 'ss-color-background-brand': 'var(--ss-navy-900)', 'ss-comp-card-background': 'var(--ss-color-surface)' },
+  }]);
+
+  it('derives primitive → aliases from the value chains, not from names', () => {
+    expect(aliasesFrom(tiered)).toEqual({ 'ss-navy-50': ['ss-color-surface'], 'ss-navy-900': ['ss-color-background-brand'] });
+  });
+
+  it('reports a primitive used where an alias exists, naming the alias', () => {
+    const v = deriveSpacingVocabulary({ components: [], styling: tiered });
+    const out = checkTokenTiers('const a = 1;\nconst s = { background: "var(--ss-navy-50)", color: "var(--ss-color-surface)" };', v);
+    expect(out).toHaveLength(1);
+    expect(out[0].line).toBe(2);
+    expect(out[0].message).toContain('--ss-color-surface');
+    expect(checkTokenTiers('var(--ss-color-surface)', v)).toEqual([]);
+  });
+
+  it('lists semantic colours before primitives in the styling guidance', () => {
+    const text = formatStylingGuidance(tiered);
+    expect(text.indexOf('--ss-color-surface')).toBeLessThan(text.indexOf('--ss-navy-50'));
+    expect(text).toContain('semantic — use these');
+    expect(text).toContain('primitive — only where no semantic token');
+  });
+});
+
+describe('checkInlineSpacing', () => {
+  const carbon = deriveSpacingVocabulary({
+    components: [component('Stack', 'layout', []), component('Heading', 'content', [])],
+    facts: facts({ Stack: [{ name: 'gap', type: 'string | (typeof SPACING_STEPS)[number]' }], Heading: [{ name: 'children' }] }),
+  });
+
+  it('flags px, rem and bare-number spacing in JSX style objects, with the primitive to use', () => {
+    const code = [
+      'const A = () => (',
+      '  <div style={{ padding: "24px", maxWidth: 400 }}>',
+      '    <div style={{ marginTop: "1rem" }} />',
+      '    <div style={{ gap: 16, display: "flex" }} />',
+      '    <div style={{ margin: 0, padding: "0 auto", gap: "var(--cds-spacing-05)" }} />',
+      '  </div>',
+      ');',
+    ].join('\n');
+    const out = checkInlineSpacing(code, carbon);
+    expect(out.map(v => `${v.line}:${v.property}=${v.value}`)).toEqual(['2:padding=24px', '3:marginTop=1rem', '4:gap=16']);
+    expect(out[1].message).toContain('<Stack gap=');
+  });
+
+  it('flags inline font overrides only when the catalog has a typography component', () => {
+    const code = '<Heading style={{ fontSize: "1.5rem", fontWeight: 600 }}>Hi</Heading>';
+    expect(checkInlineSpacing(code, carbon)).toHaveLength(2);
+    expect(checkInlineSpacing(code, carbon)[0].message).toContain('<Heading>');
+    const noTypo = deriveSpacingVocabulary({ components: [component('Stack', 'layout', [{ name: 'gap', type: 'number' }])] });
+    expect(checkInlineSpacing(code, noTypo)).toEqual([]);
+  });
+
+  it('reads template style strings for the non-React frameworks', () => {
+    const v = deriveSpacingVocabulary({ components: [], styling: styling([{ category: 'spacing', names: ['sl-spacing-small', 'sl-spacing-medium', 'sl-spacing-large'], values: { 'sl-spacing-small': '0.5rem', 'sl-spacing-medium': '1rem', 'sl-spacing-large': '1.5rem' } }]) });
+    const out = checkInlineSpacing('<div style="padding: 24px; gap: var(--sl-spacing-medium)">', v);
+    expect(out).toHaveLength(1);
+    expect(out[0].message).toContain('var(--sl-spacing-small)');
+  });
+
+  it('flags arbitrary utility values where the team uses a utility scale', () => {
+    const v = deriveSpacingVocabulary({ components: [], styling: styling([], { attributes: [{ name: 'className', uses: 9 }], sampled: 3, spacingClasses: [{ name: 'gap-4', uses: 5 }] }) });
+    const out = checkInlineSpacing('<div className="flex p-[24px] gap-4" />', v);
+    expect(out).toHaveLength(1);
+    expect(out[0].message).toContain('gap-4');
+  });
+
+  it('is absent, not zero, without a scale', () => {
+    const none = deriveSpacingVocabulary({ components: [] });
+    expect(none.hasScale).toBe(false);
+    expect(checkInlineSpacing('<div style={{ padding: "24px" }} />', none)).toEqual([]);
+  });
+});
+
+describe('readStylingIdiom spacing utilities', () => {
+  it('counts the spacing steps the team writes in className, skipping expressions', () => {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), 'idiom-'));
+    fs.mkdirSync(path.join(root, 'src', 'components', 'card'), { recursive: true });
+    fs.writeFileSync(path.join(root, 'src', 'components', 'card', 'card.stories.tsx'), [
+      'export const A = () => <div className="flex flex-col gap-4 p-6 md:p-8"><span className={cn("gap-2", x)} /></div>;',
+      'export const B = () => <div className="grid gap-4"><i className={"space-y-2"} /></div>;',
+    ].join('\n'));
+    const idiom = readStylingIdiom(root);
+    expect(idiom.attributes[0].name).toBe('className');
+    expect(idiom.spacingClasses).toEqual([{ name: 'gap-4', uses: 2 }, { name: 'p-6', uses: 1 }, { name: 'p-8', uses: 1 }, { name: 'space-y-2', uses: 1 }]);
+    fs.rmSync(root, { recursive: true, force: true });
+  });
+});
+
+describe('generateLayoutInstructions', () => {
+  const config: any = { layoutRules: { multiColumnWrapper: 'Grid', columnComponent: 'Column', containerComponent: 'Grid' } };
+  it('withholds the pixel doctrine when the vocabulary has a scale', () => {
+    const v = deriveSpacingVocabulary({ components: [component('Grid', 'layout', [{ name: 'withRowGap', type: 'boolean' }]), component('Column', 'layout', [{ name: 'lg', type: 'ColumnSpan' }]), component('Stack', 'layout', [{ name: 'gap', type: 'number' }])], layoutRules: config.layoutRules });
+    const text = generateLayoutInstructions(config, { spacing: v }).join('\n');
+    expect(text).not.toContain('16px');
+    expect(text).not.toContain('marginTop');
+    expect(text).toContain('DERIVED FROM THIS DESIGN SYSTEM');
+    expect(text).toContain('<Grid><Column>');
+  });
+  it('keeps the doctrine when nothing was derived', () => {
+    const text = generateLayoutInstructions(config).join('\n');
+    expect(text).toContain('MINIMUM 16px gap');
+  });
+  it('does not name a config wrapper the catalog lacks', () => {
+    const v = deriveSpacingVocabulary({ components: [component('Button', 'form', [])], styling: styling([{ category: 'spacing', names: ['space-4', 'space-8', 'space-16'], values: { 'space-4': '4px', 'space-8': '8px', 'space-16': '16px' } }]), layoutRules: config.layoutRules });
+    const text = generateLayoutInstructions(config, { spacing: v }).join('\n');
+    expect(text).not.toContain('<Grid>');
+  });
+});
+
+describe('repairSpacingNote', () => {
+  it('names the primitive, padding owner, tokens or utilities in one paragraph, and is absent without a scale', async () => {
+    const { repairSpacingNote } = await import('../story-generator/knowledge/spacingFacts.js');
+    const v = deriveSpacingVocabulary({
+      components: [component('Stack', 'layout', [])],
+      facts: facts({ Stack: [{ name: 'gap', type: 'MantineSpacing', options: ['xs', 'sm', 'md'], optionsOpen: true }] }),
+      styling: styling([{ category: 'spacing', names: ['space-4', 'space-8', 'space-16'], values: { 'space-4': '4px', 'space-8': '8px', 'space-16': '16px' } }]),
+    });
+    const note = repairSpacingNote(v)!;
+    expect(note).toContain('<Stack gap=…> (xs | sm | md)');
+    expect(note).toContain('var(--space-4)');
+    expect(note).toContain('a repair that adds one is rejected');
+    expect(repairSpacingNote(deriveSpacingVocabulary({ components: [] }))).toBeNull();
+  });
+});

--- a/bench/fidelity-rescore.mjs
+++ b/bench/fidelity-rescore.mjs
@@ -32,6 +32,17 @@ if (generic && summary?.generic?.catalog?.names?.length) {
   catalog = { source: g.source, names: new Set(g.names), importPaths: g.importPaths ? new Map(Object.entries(g.importPaths)) : null };
 }
 let tokens = null;
+// Icon packages the engine derives; recomputed from dist so a run scored
+// before the derivation existed is judged the same way as a new one.
+let icons = summary?.generic?.icons ?? null;
+if (generic) {
+  try {
+    const { pathToFileURL } = await import('node:url');
+    const root = path.resolve(path.dirname(new URL(import.meta.url).pathname), '..');
+    const { derivedIconPackages } = await import(pathToFileURL(path.join(root, 'dist', 'story-generator', 'knowledge', 'iconFacts.js')).href);
+    icons = { packages: derivedIconPackages(summary.opts.project, importPath).map(p => p.name) };
+  } catch (e) { console.error(`icons not recomputed: ${e.message}`); }
+}
 if (generic && summary?.opts?.project) {
   try {
     const { pathToFileURL } = await import('node:url');
@@ -62,7 +73,7 @@ for (const f of fs.readdirSync(dir).filter(f => f.endsWith('.json')).sort()) {
     const storedPins = st.score?.checks?.pins;
     const errorEvent = st.events?.find(e => e.type === 'error') || (st.transportError ? { data: { code: 'TRANSPORT', message: st.transportError } } : undefined);
     const stored = st.score?.checks || {};
-    st.score = scoreStep({ code: st.code, expect, events: st.events || [], completion: st.completion, errorEvent, importPath, previousCode: st.previousCode, divergence: st.divergence ?? undefined, pins: st.pins, generic, catalog, tokens });
+    st.score = scoreStep({ code: st.code, expect, events: st.events || [], completion: st.completion, errorEvent, importPath, previousCode: st.previousCode, divergence: st.divergence ?? undefined, pins: st.pins, generic, catalog, tokens, icons });
     // A generic check that could not be recomputed keeps the verdict the run
     // recorded; it was computed against the live server at the time.
     if (generic && !catalog && stored.catalog && stored.catalog.pass != null) st.score.checks.catalog = stored.catalog;

--- a/bench/fidelity.mjs
+++ b/bench/fidelity.mjs
@@ -202,7 +202,7 @@ try {
  * Every field carries its provenance; a missing catalog or an empty token set
  * makes the check n/a, and the report says which.
  */
-const genericKnowledge = { catalog: null, tokens: null };
+const genericKnowledge = { catalog: null, tokens: null, icons: null };
 
 async function loadGenericKnowledge() {
   // Catalog
@@ -257,6 +257,19 @@ async function loadGenericKnowledge() {
   } catch (e) {
     genericKnowledge.tokens = { known: null, check: null, error: e.message };
     log(`tokens: dist knowledge modules not importable (${e.message}); token conformance will be n/a`);
+  }
+
+  // Icon packages the engine derives and allows (project or design-system
+  // dependency whose manifest says icons). Imports from them are icons, not
+  // catalog components.
+  try {
+    const { derivedIconPackages } = await import(pathToFileURL(path.join(STORY_UI_ROOT, 'dist', 'story-generator', 'knowledge', 'iconFacts.js')).href);
+    const pkgs = derivedIconPackages(opts.project, importPath, projectConfig.iconImports?.package);
+    genericKnowledge.icons = { packages: pkgs.map(p => p.name), exports: Object.fromEntries(pkgs.map(p => [p.name, p.exports.length])) };
+    log(pkgs.length ? `icons: ${pkgs.map(p => `${p.name} (${p.via}, ${p.exports.length} exports)`).join(', ')} — imports from these are not judged against the catalog` : 'icons: no installed icon package derived');
+  } catch (e) {
+    genericKnowledge.icons = { packages: [], error: e.message };
+    log(`icons: dist iconFacts not importable (${e.message})`);
   }
 }
 
@@ -347,7 +360,7 @@ async function generationStep({ label, prompt, expect, update, images, pins, tag
     code, expect, events: stream.events, completion,
     errorEvent: stream.errorEvent || (stream.transportError ? { data: { code: 'TRANSPORT', message: stream.transportError } } : undefined),
     importPath, previousCode, divergence, pins,
-    generic: opts.generic, catalog: genericKnowledge.catalog, tokens: genericKnowledge.tokens,
+    generic: opts.generic, catalog: genericKnowledge.catalog, tokens: genericKnowledge.tokens, icons: genericKnowledge.icons,
   });
 
   const shot = await captureScreenshot({ tag, fileName, storybookId: completion?.storybookId, title });
@@ -608,6 +621,7 @@ function writeReport() {
       // Names and import paths are stored so bench/fidelity-rescore.mjs can re-judge the run without the server.
       catalog: genericKnowledge.catalog ? { source: genericKnowledge.catalog.source, size: genericKnowledge.catalog.names.size, byOrigin: genericKnowledge.catalog.byOrigin ?? null, reason: genericKnowledge.catalog.reason ?? null, names: [...genericKnowledge.catalog.names], importPaths: genericKnowledge.catalog.importPaths ? Object.fromEntries(genericKnowledge.catalog.importPaths) : null } : null,
       tokens: genericKnowledge.tokens ? { known: genericKnowledge.tokens.known?.size ?? 0, groups: genericKnowledge.tokens.groups ?? null, sources: genericKnowledge.tokens.sources ?? null, error: genericKnowledge.tokens.error ?? null } : null,
+      icons: genericKnowledge.icons ?? null,
     } : null,
     results: results.map(r => ({ scenario: r.scenario, kind: r.kind, round: r.round, pass: r.pass, skipped: r.skipped, error: r.error ? e2(r.error) : null, durationMs: r.durationMs, steps: r.steps.map(st => stepSummary(st)) })),
   }, null, 2));

--- a/bench/fidelity/score.mjs
+++ b/bench/fidelity/score.mjs
@@ -247,11 +247,18 @@ export function forbiddenPatterns(code, patterns = []) {
  *
  * Returns `pass: null` when there is no catalog to check against.
  */
-export function catalogConformance(code, { importPath, catalog, minDistinct = 3 }) {
+export function catalogConformance(code, { importPath, catalog, minDistinct = 3, iconPackages = [] }) {
   if (!catalog || !catalog.names || catalog.names.size === 0) {
     return { pass: null, reason: catalog?.reason || 'no component catalog available', source: catalog?.source ?? null };
   }
-  const imports = parseImports(code).filter(i => classifySource(i.source, importPath) === 'design-system');
+  // An installed icon set the engine derives (knowledge/iconFacts.ts) is offered
+  // to the model and allowed by isolation; its exports are icons, not catalog
+  // components, and are reported rather than judged. `@carbon/icons-react`
+  // shares a scope with `@carbon/react` and was failing every Carbon story.
+  const iconRoot = (source) => iconPackages.find(p => source === p || source.startsWith(p + '/'));
+  const allImports = parseImports(code);
+  const iconImports = allImports.filter(i => iconRoot(i.source)).flatMap(i => i.named.map(n => ({ name: n.exported, source: i.source })));
+  const imports = allImports.filter(i => !iconRoot(i.source) && classifySource(i.source, importPath) === 'design-system');
   const rows = catalog.importPaths || null;
   const specifierRows = rows ? [...rows.entries()] : [];
   const servedBy = (source) => specifierRows.filter(([, p]) => p && (source === p || source.startsWith(p + '/'))).map(([n]) => n);
@@ -291,6 +298,7 @@ export function catalogConformance(code, { importPath, catalog, minDistinct = 3 
   }
 
   const roots = new Set(jsxTags(code).map(t => t.root));
+  void iconImports;
   const used = [...new Set([...inCatalog.entries()].filter(([local]) => roots.has(local)).map(([, name]) => name))];
   const imported = [...new Set(inCatalog.values())];
 
@@ -306,6 +314,7 @@ export function catalogConformance(code, { importPath, catalog, minDistinct = 3 
     reason = `${unverifiable.length} design-system import(s) could not be verified (${unverifiable.map(u => u.reason).filter((v, i, a) => a.indexOf(v) === i).join('; ')}); only ${used.length} verified catalog component(s) used, floor ${minDistinct} undecidable`;
   }
   return {
+    iconImports,
     pass,
     ...(reason ? { reason } : {}),
     catalogSize: catalog.names.size,
@@ -478,7 +487,7 @@ export function completionCheck(completion, errorEvent) {
  * One step's scorecard. A step is a generation (new or follow-up) plus its
  * expectations; `previousCode` and `divergence` are present only for updates.
  */
-export function scoreStep({ code, expect = {}, events = [], completion, errorEvent, importPath, previousCode, divergence, pins, generic = false, catalog = null, tokens = null }) {
+export function scoreStep({ code, expect = {}, events = [], completion, errorEvent, importPath, previousCode, divergence, pins, generic = false, catalog = null, tokens = null, icons = null }) {
   const forbidden = expect.forbiddenPatterns || [];
   const hasNameExpectations = Boolean(expect.mustUseComponents?.length || expect.mustUseAnyOf?.length || expect.mustNotUseComponents?.length);
   const checks = {
@@ -496,7 +505,7 @@ export function scoreStep({ code, expect = {}, events = [], completion, errorEve
         mustNot: expect.mustNotUseComponents || [],
       }) : { pass: null, reason: 'no code returned' },
     catalog: !generic ? { pass: null, reason: 'not in --generic mode' }
-      : code ? catalogConformance(code, { importPath, catalog }) : { pass: null, reason: 'no code returned' },
+      : code ? catalogConformance(code, { importPath, catalog, iconPackages: icons?.packages || [] }) : { pass: null, reason: 'no code returned' },
     tokens: !generic ? { pass: null, reason: 'not in --generic mode' }
       : code ? tokenConformance(code, tokens || {}) : { pass: null, reason: 'no code returned' },
     forbidden: code ? forbiddenPatterns(code, forbidden) : { pass: null, reason: 'no code returned' },

--- a/mcp-server/routes/generationCore.ts
+++ b/mcp-server/routes/generationCore.ts
@@ -108,8 +108,20 @@ const GEOMETRY_PROP = /^(sm|md|lg|xl|xxl|max|xs|span|offset|start|end|gap|column
 const LAYOUT_PROSE = /\b(column|columns|grid|breakpoint|gutter|span|spacing|width|row|layout)\b/i;
 import { enrichWithSourceFacts, withLocalPropFacts } from '../../story-generator/knowledge/sourceFacts.js';
 import { readStylingFacts, formatStylingGuidance, readDesignTokens } from '../../story-generator/knowledge/stylingFacts.js';
+import type { StylingFacts } from '../../story-generator/knowledge/stylingFacts.js';
+import {
+  deriveSpacingVocabulary, checkInlineSpacing, checkTokenTiers, formatSpacingErrors, formatTierErrors, repairSpacingNote,
+  type SpacingVocabulary,
+} from '../../story-generator/knowledge/spacingFacts.js';
+import {
+  deriveIconVocabulary, derivedIconPackages, checkIconImports, formatIconImportErrors,
+  type IconVocabulary,
+} from '../../story-generator/knowledge/iconFacts.js';
 import { inheritCompoundExamples } from '../../story-generator/knowledge/storybookCatalog.js';
 import { checkConformance, formatConformanceErrors } from '../../story-generator/knowledge/conformance.js';
+import {
+  checkPropConformance, formatPropConformanceErrors, summarisePropConformance, rewriteGlobalJsxNamespace,
+} from '../../story-generator/knowledge/propConformance.js';
 import { isSafeStoryFileName,
   writeStoryArtifacts,
   extractStylesheet,
@@ -325,6 +337,14 @@ async function runStoryGenerationPipeline(
    */
   let knownProps: Awaited<ReturnType<typeof extractProps>> = null;
   let knownTokens: Set<string> | null = null;
+  /**
+   * How this design system spaces things, derived once from the catalog and
+   * stylesheets: the prompt is written from it and the output is checked
+   * against it, so the two can never disagree.
+   */
+  let stylingFacts: StylingFacts | null = null;
+  let spacingVocab: SpacingVocabulary | null = null;
+  let iconVocab: IconVocabulary | null = null;
 
   const {
     prompt,
@@ -669,6 +689,37 @@ async function runStoryGenerationPipeline(
     // must not look like a library with no types.
     logger.warn(`⚠️ Component enrichment failed; the catalog carries names only: ${enrichError instanceof Error ? enrichError.message : String(enrichError)}`);
   }
+  // The spacing vocabulary: gap primitives and padding owners from the
+  // catalog (with the values their types declare), the spacing scale and
+  // colour tiers from the stylesheets, the utility steps from the team's own
+  // stories. The prompt's spacing rules are written from it; the validation
+  // loop judges the output against the same object.
+  try {
+    stylingFacts = readStylingFacts(process.cwd(), (config.generatedStoriesPath || '')
+      .replace(/^\.\//, '').replace(/\/+$/, '').split('/').pop() || 'generated',
+      config.importPath);
+    spacingVocab = deriveSpacingVocabulary({
+      components: components as any[], facts: knownProps, styling: stylingFacts, layoutRules: config.layoutRules,
+    });
+    logger.log(spacingVocab.hasScale
+      ? `📏 Spacing vocabulary: ${spacingVocab.source}${Object.keys(spacingVocab.aliasesOf).length ? `; ${Object.keys(spacingVocab.aliasesOf).length} primitive colour(s) with a semantic alias` : ''}`
+      : `📏 Spacing vocabulary: ${spacingVocab.source} — the prompt falls back to inline spacing examples and says so`);
+  } catch (spacingError) {
+    logger.warn(`⚠️ Could not derive the spacing vocabulary: ${spacingError instanceof Error ? spacingError.message : String(spacingError)} — prompt uses the inline fallback; spacing check will be skipped, not passed`);
+  }
+  // Icons and placeholder images: installed icon packages (the project's or
+  // the design system's own), the catalog's icon components and primitive,
+  // and its placeholder components. Named in the prompt, allowed by the
+  // isolation check, and import names verified against the package's exports.
+  try {
+    iconVocab = deriveIconVocabulary({
+      projectRoot: process.cwd(), importPath: config.importPath, configuredPackage: config.iconImports?.package, components: components as any[],
+    });
+    logger.log(`🖼️ Icon vocabulary: ${iconVocab.source}`);
+  } catch (iconError) {
+    logger.warn(`⚠️ Could not derive the icon vocabulary: ${iconError instanceof Error ? iconError.message : String(iconError)}`);
+  }
+
   events.onProgress?.(2, totalSteps, 'components_discovered',
     `Found ${components.length} components from ${config.importPath}`,
     { componentCount: components.length });
@@ -894,6 +945,9 @@ async function runStoryGenerationPipeline(
       selection,
       pins,
       storybookUrl: projectStorybookUrl || undefined,
+      spacing: spacingVocab,
+      styling: stylingFacts,
+      icons: iconVocab,
     }
   );
 
@@ -1330,11 +1384,36 @@ async function runStoryGenerationPipeline(
      */
     // JSX only: the checker walks JSX attributes, so on a Vue, Svelte, Angular
     // or Lit story it found nothing and looked like a pass.
+    if (detectedFramework === 'react') {
+      // `(): JSX.Element` is TS2503 under React 19 — deterministic, so fixed
+      // here rather than sent back to the model.
+      const jsxFix = rewriteGlobalJsxNamespace(aiText);
+      if (jsxFix.removed || jsxFix.qualified) {
+        logger.log(`🔧 JSX namespace: removed ${jsxFix.removed} \`: JSX.Element\` return annotation(s), qualified ${jsxFix.qualified} other JSX.* reference(s)`);
+        aiText = jsxFix.code;
+      }
+    }
     const conformanceErrors = detectedFramework === 'react'
       ? formatConformanceErrors(checkConformance(aiText, knownProps))
       : (logger.log(`📐 Conformance: not applicable to ${detectedFramework} (JSX-only check) — skipped, not passed`), []);
     if (conformanceErrors.length) {
       logger.log(`📐 Conformance: ${conformanceErrors.length} violation(s) of the catalog we supplied`);
+    }
+    /**
+     * Every prop must be one the receiving component declares.
+     *
+     * Judged against the attributes type the project's own TypeScript computes
+     * for the element — the ceiling, where the extracted catalog is a floor —
+     * and only where that set is closed. A component whose props are `any` or
+     * carry an index signature is skipped and named in the log, so absent and
+     * zero look different; see propConformance.ts.
+     */
+    if (detectedFramework === 'react') {
+      const propReport = checkPropConformance(aiText, {
+        storiesDir: path.resolve(process.cwd(), config.generatedStoriesPath || './src/stories/generated'),
+      });
+      logger.log(`🧷 Prop check: ${summarisePropConformance(propReport)}`);
+      conformanceErrors.push(...formatPropConformanceErrors(propReport));
     }
     // Every var(--x) must be a token the project declares. Skipped, and said
     // so, when the project declares none — absent and zero look different.
@@ -1351,6 +1430,47 @@ async function runStoryGenerationPipeline(
       // Say it ran: a silent pass is indistinguishable from a check that never
       // looked (the first CBDS re-run went to a stale server and looked the same).
       logger.log(`🎨 Token check: ${(aiText.match(/var\(\s*--/g) || []).length} var() use(s), all declared by the project (${knownTokens.size} tokens)`);
+    }
+
+    /**
+     * Inline spacing literals and primitive-for-semantic colours, judged
+     * against the same vocabulary the prompt was written from. Three states,
+     * each said out loud: not derived (skipped), derived with no scale
+     * (skipped — the fallback prompt allowed inline spacing), and checked.
+     */
+    if (!spacingVocab) {
+      logger.log('📏 Spacing check: vocabulary not derived — skipped, not passed');
+    } else if (!spacingVocab.hasScale) {
+      logger.log('📏 Spacing check: design system declares no gap primitive, no spacing tokens and no utility scale — skipped, not passed');
+    } else {
+      const spacingViolations = checkInlineSpacing(aiText, spacingVocab);
+      if (spacingViolations.length) {
+        logger.log(`📏 Spacing check: ${spacingViolations.length} inline spacing/typography literal(s): ${spacingViolations.slice(0, 6).map(v => `L${v.line} ${v.property}=${v.value}`).join(', ')}`);
+        conformanceErrors.push(...formatSpacingErrors(spacingViolations));
+      } else {
+        logger.log(`📏 Spacing check: 0 inline spacing literals (${spacingVocab.source})`);
+      }
+    }
+    if (spacingVocab && Object.keys(spacingVocab.aliasesOf).length) {
+      const tierViolations = checkTokenTiers(aiText, spacingVocab);
+      if (tierViolations.length) {
+        logger.log(`🎨 Token tiers: ${tierViolations.length} primitive colour(s) used where a semantic alias exists: ${tierViolations.slice(0, 6).map(v => `--${v.primitive}→--${v.aliases[0]}`).join(', ')}`);
+        conformanceErrors.push(...formatTierErrors(tierViolations));
+      } else {
+        logger.log(`🎨 Token tiers: no primitive colour used where an alias exists (${Object.keys(spacingVocab.aliasesOf).length} aliased primitives)`);
+      }
+    } else if (spacingVocab) {
+      logger.log('🎨 Token tiers: project declares no colour aliases — skipped, not passed');
+    }
+    // Names imported from a derived icon package must be names it exports.
+    if (iconVocab?.packages.some(p => p.exports.length)) {
+      const iconErrors = checkIconImports(aiText, iconVocab);
+      if (iconErrors.length) {
+        logger.log(`🖼️ Icon imports: ${iconErrors.length} name(s) the package does not export: ${iconErrors.slice(0, 6).map(v => v.name).join(', ')}`);
+        conformanceErrors.push(...formatIconImportErrors(iconErrors));
+      } else if (iconVocab.packages.some(p => new RegExp(`from\\s*['"]${p.name.replace(/[.*+?^${}()|[\]\\/]/g, '\\$&')}`).test(aiText))) {
+        logger.log('🖼️ Icon imports: every imported icon name is exported by its package');
+      }
     }
 
     const importErrors = [
@@ -2018,16 +2138,30 @@ async function runStoryGenerationPipeline(
             `Verification found ${blockerCount} issue${blockerCount === 1 ? '' : 's'} — repairing`);
           try {
           const repairTarget = selection ? targetComponentFromSelection(selection) : null;
+          // A repair must not undo the spacing discipline: it gets the one-
+          // paragraph note, and a candidate that adds inline spacing literals
+          // or primitive-colour uses the original did not have is discarded.
+          const spacingNote = repairSpacingNote(spacingVocab);
+          const repairContext = [selection ? repairScopeNote(selection) : null, spacingNote].filter(Boolean).join('\n\n') || undefined;
+          const baselineSpacing = checkInlineSpacing(fixedFileContents, spacingVocab).length;
+          const baselineTiers = checkTokenTiers(fixedFileContents, spacingVocab).length;
           const repair = await attemptVerificationRepair({
             code: fixedFileContents,
             report: verification,
-            context: selection ? repairScopeNote(selection) : undefined,
+            context: repairContext,
             signal: verifyBudget.signal,
             deadline: verifyDeadline,
             staticallyValid: (candidate) => {
               const patternErrors = validateStory(candidate);
               const ast = validateStoryCode(candidate, finalFileName, config);
-              return patternErrors.length === 0 && ast.isValid;
+              if (patternErrors.length > 0 || !ast.isValid) return false;
+              const spacing = checkInlineSpacing(candidate, spacingVocab);
+              const tiers = checkTokenTiers(candidate, spacingVocab);
+              if (spacing.length > baselineSpacing || tiers.length > baselineTiers) {
+                logger.warn(`✂️ Repair rejected: it introduced ${Math.max(0, spacing.length - baselineSpacing)} inline spacing literal(s) and ${Math.max(0, tiers.length - baselineTiers)} primitive colour use(s) the story did not have (${[...spacing.slice(0, 3).map(v => `L${v.line} ${v.property}=${v.value}`), ...tiers.slice(0, 3).map(v => `L${v.line} --${v.primitive}`)].join(', ')})`);
+                return false;
+              }
+              return true;
             },
             callModel: async (prompt, currentCode) => {
               events.onLLMCall?.();
@@ -2630,6 +2764,12 @@ async function buildClaudePromptWithContext(
     pins?: PropPin[];
     /** Where this project's Storybook is served, so its own stories can be read. */
     storybookUrl?: string;
+    /** The derived spacing vocabulary; the adapter writes its spacing rules from it. */
+    spacing?: SpacingVocabulary | null;
+    /** The styling facts already read for the vocabulary, so they are not read twice. */
+    styling?: StylingFacts | null;
+    /** The derived icon/placeholder vocabulary. */
+    icons?: IconVocabulary | null;
   }
 ): Promise<string> {
   // What the previous code already uses must stay fully described, or an
@@ -2640,6 +2780,8 @@ async function buildClaudePromptWithContext(
   const frameworkOptions: StoryGenerationOptions = {
     framework: options.framework,
     catalogFocus: { prompt: userPrompt, mustInclude: usedBefore },
+    spacing: options.spacing ?? null,
+    icons: options.icons ?? null,
   };
   let prompt = await buildFrameworkAwarePrompt(userPrompt, config, components, frameworkOptions);
 
@@ -2740,7 +2882,7 @@ async function buildClaudePromptWithContext(
   // exactly where a hardcoded number marks a composition as foreign to the
   // design system that owns it.
   try {
-    const styling = readStylingFacts(process.cwd(), (config.generatedStoriesPath || '')
+    const styling = options.styling ?? readStylingFacts(process.cwd(), (config.generatedStoriesPath || '')
       .replace(/^\.\//, '').replace(/\/+$/, '').split('/').pop() || 'generated',
       config.importPath);
     const guidance = formatStylingGuidance(styling);
@@ -3642,6 +3784,9 @@ export function validateImportIsolation(
 
   allow(config.importPath);
   allow(config.iconImports?.package);
+  // An installed icon set — the project's dependency or the design system's
+  // own — is part of what the model was told to use (see iconFacts.ts).
+  for (const pkg of derivedIconPackages(process.cwd(), config.importPath, config.iconImports?.package)) allow(pkg.name);
   for (const extra of config.additionalImports || []) allow(extra.path);
   for (const extra of (config.allowedImports || [])) allow(extra);
   for (const pkg of FRAMEWORK_RUNTIME_ALLOWLIST[framework] || []) allowedRoots.add(pkg);

--- a/story-generator/framework-adapters/angular-adapter.ts
+++ b/story-generator/framework-adapters/angular-adapter.ts
@@ -237,7 +237,7 @@ MATERIAL ICONS (CRITICAL - If using @angular/material):
 - For filled variants: favorite, star, check_circle
 - For outlined variants: favorite_border, star_border, check_circle_outline
 
-${this.getCommonRules()}`;
+${this.getCommonRules(options)}`;
   }
 
   generateExamples(config: StoryUIConfig): string {

--- a/story-generator/framework-adapters/base-adapter.ts
+++ b/story-generator/framework-adapters/base-adapter.ts
@@ -16,6 +16,8 @@ import { DiscoveredComponent } from '../componentDiscovery.js';
 import { logger } from '../logger.js';
 import { saysMoreThanName } from '../knowledge/descriptionQuality.js';
 import { importSpecifierFor, localImportSpecifier } from '../knowledge/importSpecifier.js';
+import { formatSpacingRules } from '../knowledge/spacingFacts.js';
+import { formatImageRules } from '../knowledge/iconFacts.js';
 
 /**
  * Abstract Base Framework Adapter
@@ -530,7 +532,7 @@ export abstract class BaseFrameworkAdapter implements FrameworkAdapter {
   /**
    * Get common story structure rules including MANDATORY spacing
    */
-  protected getCommonRules(): string {
+  protected getCommonRules(options?: StoryGenerationOptions): string {
     return `
 GENERAL RULES:
 - Follow the component library's design patterns
@@ -587,13 +589,9 @@ and any design-system considerations provided below).
    inert? is any icon unaligned or standing in for a button? is any hover/active appearance
    being faked with a static style? Fix all three before you output.
 
-IMAGE RULES:
-- Use Lorem Picsum for placeholder images: https://picsum.photos/[width]/[height]
-- Always include alt text for images
-- Example: https://picsum.photos/400/300?random=1
+${formatImageRules(options?.icons, this.type === 'react' ? 'jsx' : 'html')}
 
-MANDATORY SPACING & LAYOUT RULES (NON-NEGOTIABLE):
-** CRITICAL: Every generated component MUST have professional-quality spacing. Components without proper spacing look broken and unprofessional. **
+SPACING & LAYOUT:
 
 ** SCOPE LIMIT — READ BEFORE COPYING THE EXAMPLES BELOW **
 The inline style objects shown in this section are for STATIC LAYOUT SPACING ONLY.
@@ -623,51 +621,20 @@ better answer, and a stylesheet that merely restates what a prop already does is
 than not writing one. Reference design-system tokens/CSS variables inside it rather than
 hardcoded colors, so the result still inherits theming and dark mode.
 
-1. STORY WRAPPER (REQUIRED for every story):
-   - The rendered story MUST have a wrapper element with padding
-   - Pattern: ${this.getSpacingExample('wrapper')}
-   - This ensures content has breathing room within the Storybook canvas
-
-2. FORM FIELD SPACING (CRITICAL):
-   - ALWAYS wrap form fields in a container with vertical spacing
-   - Use flexbox column with gap: ${this.getSpacingExample('formGap')}
-   - Or use design system spacing tokens if available
-   - MINIMUM 16px gap between form fields
-
-3. BUTTON SPACING:
-   - Submit/action buttons: 24px margin-top from form fields above
-   - Pattern: ${this.getSpacingExample('buttonMargin')}
-   - Button groups should be wrapped with margin-top from content
-
-4. SECTION SPACING:
-   - Between major sections: 32-48px
-   - Between related content groups: 24px
-   - Use dividers or significant whitespace between unrelated content
-
-5. HEADING SPACING:
-   - More space ABOVE headings (24-32px) than below (8-16px)
-
-6. CARD/CONTAINER PADDING:
-   - Internal padding: minimum 16px, preferred 24px
-
-7. SPECIFIC VALUES TO USE:
-   - Tight spacing (icons, inline): 4-8px
-   - Related items: 8-12px
-   - Form fields: 16px gap
-   - Buttons from content: 24px margin-top
-   - Sections: 32-48px
-   - Major divisions: 48-64px
-
-SPACING VALIDATION (Self-check before generating):
-Ask yourself: "Does every element have adequate breathing room from its neighbors?"
-If any elements appear cramped or touching, add appropriate spacing.
+${formatSpacingRules(options?.spacing, this.type === 'react' ? 'jsx' : 'html', {
+  wrapper: this.getSpacingExample('wrapper'),
+  formGap: this.getSpacingExample('formGap'),
+  buttonMargin: this.getSpacingExample('buttonMargin'),
+})}
 `;
   }
 
   /**
-   * Framework-appropriate syntax for the spacing examples embedded in the
-   * common rules. JSX style objects only make sense for React; the other
-   * frameworks get examples in their own template syntax.
+   * Framework-appropriate syntax for the FALLBACK spacing examples — used only
+   * when the design system declares no gap primitive, no spacing tokens and no
+   * utility scale (see knowledge/spacingFacts.ts). JSX style objects only make
+   * sense for React; the other frameworks get examples in their own template
+   * syntax.
    */
   protected getSpacingExample(kind: 'wrapper' | 'formGap' | 'buttonMargin'): string {
     switch (this.type) {

--- a/story-generator/framework-adapters/index.ts
+++ b/story-generator/framework-adapters/index.ts
@@ -192,7 +192,7 @@ class AdapterRegistry {
     logger.debug('Generating prompt with adapter', { adapter: adapter.type });
 
     // Generate layout instructions including mandatory spacing rules
-    const layoutInstructionsArray = generateLayoutInstructions(config);
+    const layoutInstructionsArray = generateLayoutInstructions(config, options);
     const layoutInstructionsString = layoutInstructionsArray.join('\n');
 
     return {

--- a/story-generator/framework-adapters/react-adapter.ts
+++ b/story-generator/framework-adapters/react-adapter.ts
@@ -256,7 +256,7 @@ export const WithIcon: Story = {
 };
 \`\`\`
 
-${this.getCommonRules()}`;
+${this.getCommonRules(options)}`;
   }
 
   /**

--- a/story-generator/framework-adapters/svelte-adapter.ts
+++ b/story-generator/framework-adapters/svelte-adapter.ts
@@ -231,7 +231,7 @@ SVELTE 5 TEMPLATE SYNTAX:
 - Classes: class="flex gap-2" (use Tailwind classes)
 - Snippets: {#snippet name(args)}...{/snippet}
 
-${this.getCommonRules()}`;
+${this.getCommonRules(options)}`;
   }
 
   generateExamples(config: StoryUIConfig): string {

--- a/story-generator/framework-adapters/types.ts
+++ b/story-generator/framework-adapters/types.ts
@@ -109,6 +109,16 @@ export interface StoryGenerationOptions {
    * entry (65k chars on Mantine, 97k on college-town).
    */
   catalogFocus?: CatalogFocus;
+  /**
+   * How this design system spaces things — its gap primitives, padding
+   * owners, spacing tokens and utility scale — derived from the catalog and
+   * stylesheets. The spacing rules in the prompt are written from it; without
+   * it (or when the system declares no scale) the inline examples are used and
+   * the prompt says so.
+   */
+  spacing?: import('../knowledge/spacingFacts.js').SpacingVocabulary | null;
+  /** Where icons and placeholder images come from in this project, derived from what is installed and catalogued. */
+  icons?: import('../knowledge/iconFacts.js').IconVocabulary | null;
 }
 
 export interface CatalogFocus {

--- a/story-generator/framework-adapters/vue-adapter.ts
+++ b/story-generator/framework-adapters/vue-adapter.ts
@@ -197,7 +197,7 @@ EVENT HANDLING:
 - Use @event or v-on:event syntax
 - Use action argTypes to log events in Storybook
 
-${this.getCommonRules()}`;
+${this.getCommonRules(options)}`;
   }
 
   generateExamples(config: StoryUIConfig): string {

--- a/story-generator/framework-adapters/web-components-adapter.ts
+++ b/story-generator/framework-adapters/web-components-adapter.ts
@@ -232,7 +232,7 @@ SLOTS:
 - Named slots: Use slot="name" attribute
 - Example: <my-card><span slot="header">Title</span>Content</my-card>
 
-${this.getCommonRules()}`;
+${this.getCommonRules(options)}`;
   }
 
   generateExamples(config: StoryUIConfig): string {

--- a/story-generator/knowledge/iconFacts.ts
+++ b/story-generator/knowledge/iconFacts.ts
@@ -1,0 +1,282 @@
+/**
+ * Where icons and placeholder images come from in THIS project — derived
+ * from what is installed and what the catalog offers, never from a list of
+ * package names.
+ *
+ * A review of MUI stories found six using text glyphs (⋯ × ✓) as icons and
+ * eight pulling remote photographs, one where the prompt asked for a
+ * placeholder. The prompt had told the model to "use Unicode symbols" when it
+ * knew of no icon package, and its idea of an icon package was a hard-coded
+ * list of four — so `@carbon/icons-react`, a dependency of `@carbon/react`
+ * itself, was neither offered nor allowed, and a local `src/icons` module was
+ * only found when its exports happened to be named `*Icon`.
+ *
+ * Three facts, each read from the project:
+ *
+ *   PACKAGES    a dependency of the project or of the design system whose own
+ *               package.json says it is an icon set (name, keywords or
+ *               description), installed, with its export names read from its
+ *               declarations
+ *   CATALOG     components the catalog already holds that are icons, and the
+ *               library's icon primitive (a component that renders an SVG)
+ *   PLACEHOLDER components the catalog holds for the "image not yet chosen"
+ *               case — skeletons, aspect-ratio boxes, avatar fallbacks
+ */
+
+import fs from 'fs';
+import path from 'path';
+
+export interface IconPackage {
+  name: string;
+  /** Who depends on it: the project, or the design system's own manifest. */
+  via: 'project' | 'design-system' | 'config';
+  /** Export names read from the package's declarations; empty when unreadable. */
+  exports: string[];
+  /** A handful of exports that name common UI affordances, for the prompt. */
+  examples: string[];
+}
+
+export interface IconVocabulary {
+  packages: IconPackage[];
+  /** Catalog components that are icons themselves. */
+  iconComponents: Array<{ name: string; importPath?: string }>;
+  /** The library's icon wrapper, when it has one (Icon, SvgIcon, IconButton is NOT one). */
+  iconPrimitive?: string;
+  /** Catalog components for an image that is not yet chosen. */
+  placeholders: string[];
+  source: string;
+}
+
+const AFFORDANCE = /^(?:Icon)?(Add|Plus|Close|X|Xmark|Check|Checkmark|Search|Menu|Bars|Chevron(Down|Up|Left|Right)?|Arrow(Down|Up|Left|Right)?|Edit|Pencil|Delete|Trash|Settings|Gear|Cog|User|Person|Bell|Notification|Overflow|More|Dots|Ellipsis|Filter|Download|Upload|Star|Heart|Mail|Envelope|Calendar|Warning|Error|Info|Information|Home|Copy|Share|Eye|Lock|Refresh|Save|Send|Logout|Login)([A-Z][a-z]*)?(Icon)?$/;
+
+const _cache = new Map<string, { at: number; value: IconPackage[] }>();
+
+function readJson(file: string): any | null {
+  try { return JSON.parse(fs.readFileSync(file, 'utf8')); } catch { return null; }
+}
+
+/** Does this manifest describe an icon set? Judged from what it says about itself. */
+export function manifestSaysIcons(pkg: { name?: string; keywords?: string[]; description?: string } | null): boolean {
+  if (!pkg) return false;
+  const text = [pkg.name, pkg.description, ...(pkg.keywords || [])].filter(Boolean).join(' ');
+  return /\bicons?\b|\bicon-|-icons?\b|\bglyphs?\b/i.test(text);
+}
+
+/** The declaration file a package points at, if any. */
+function typesEntry(root: string, pkg: any): string | null {
+  const candidates: string[] = [];
+  const push = (v: unknown) => { if (typeof v === 'string' && /\.d\.(ts|mts|cts)$/.test(v)) candidates.push(v); };
+  push(pkg?.types); push(pkg?.typings);
+  const walk = (node: unknown, depth = 0) => {
+    if (depth > 4 || node == null) return;
+    if (typeof node === 'string') return push(node);
+    if (Array.isArray(node)) return node.forEach(n => walk(n, depth + 1));
+    if (typeof node === 'object') for (const [k, v] of Object.entries(node as any)) if (k === 'types' || k === 'typings' || k === 'import' || k === 'default' || k === 'require' || k === '.') walk(v, depth + 1);
+  };
+  walk(pkg?.exports?.['.'] ?? pkg?.exports);
+  for (const rel of ['index.d.ts', 'lib/index.d.ts', 'dist/index.d.ts', 'types/index.d.ts']) candidates.push(rel);
+  for (const c of candidates) {
+    const full = path.join(root, c);
+    if (fs.existsSync(full)) return full;
+  }
+  return null;
+}
+
+/**
+ * Export names from a declaration file, following `export * from` one hop.
+ * Textual on purpose — an icon set is thousands of one-line exports, and a
+ * TypeScript program over it costs more than the generation.
+ */
+export function readExportNames(file: string, limitFiles = 40): string[] {
+  const names = new Set<string>();
+  const seen = new Set<string>();
+  const queue = [file];
+  while (queue.length && seen.size < limitFiles) {
+    const f = queue.shift()!;
+    if (seen.has(f)) continue;
+    seen.add(f);
+    let text: string;
+    try {
+      const stat = fs.statSync(f);
+      if (stat.size > 4_000_000) continue;
+      text = fs.readFileSync(f, 'utf8');
+    } catch { continue; }
+    for (const m of text.matchAll(/export\s+(?:declare\s+)?(?:const|let|var|function|class)\s+([A-Za-z_$][\w$]*)/g)) names.add(m[1]);
+    for (const m of text.matchAll(/export\s*\{([^}]*)\}/g)) {
+      for (const part of m[1].split(',')) {
+        const alias = part.trim().split(/\s+as\s+/).pop()?.trim();
+        if (alias && /^[A-Za-z_$][\w$]*$/.test(alias) && alias !== 'default' && alias !== 'type') names.add(alias);
+      }
+    }
+    // `declare const _X: T;` paired with `export { _X as X }` is covered above;
+    // a bare `declare const X` exported nowhere is not an export.
+    for (const m of text.matchAll(/export\s+\*\s+from\s+['"](\.[^'"]+)['"]/g)) {
+      const base = path.resolve(path.dirname(f), m[1]);
+      for (const cand of [base + '.d.ts', path.join(base, 'index.d.ts'), base.replace(/\.js$/, '.d.ts')]) {
+        if (fs.existsSync(cand)) { queue.push(cand); break; }
+      }
+    }
+  }
+  names.delete('Icon');
+  return [...names].sort();
+}
+
+function packageRoot(projectRoot: string, name: string): string | null {
+  const root = path.join(projectRoot, 'node_modules', ...name.split('/'));
+  return fs.existsSync(path.join(root, 'package.json')) ? root : null;
+}
+
+function designSystemPackageName(importPath?: string): string | null {
+  if (!importPath || importPath.startsWith('.') || importPath.startsWith('/') || importPath.startsWith('@/')) return null;
+  return importPath.startsWith('@') ? importPath.split('/').slice(0, 2).join('/') : importPath.split('/')[0];
+}
+
+/**
+ * Installed icon packages, judged by their own manifests: the project's
+ * dependencies and the design system's, since a library's icon set is often
+ * a dependency of the library rather than of the project.
+ */
+export function derivedIconPackages(projectRoot: string, importPath?: string, configured?: string): IconPackage[] {
+  const key = `${projectRoot}\n${importPath ?? ''}\n${configured ?? ''}`;
+  const cached = _cache.get(key);
+  if (cached && Date.now() - cached.at < 60_000) return cached.value;
+
+  const out: IconPackage[] = [];
+  const consider = (name: string, via: IconPackage['via']) => {
+    if (out.some(p => p.name === name)) return;
+    const root = packageRoot(projectRoot, name);
+    if (!root) return;
+    const pkg = readJson(path.join(root, 'package.json'));
+    if (via !== 'config' && !manifestSaysIcons(pkg)) return;
+    const entry = typesEntry(root, pkg);
+    const exports = entry ? readExportNames(entry) : [];
+    const examples = exports.filter(n => AFFORDANCE.test(n)).slice(0, 24);
+    out.push({ name, via, exports, examples: examples.length ? examples : exports.slice(0, 16) });
+  };
+
+  if (configured) consider(configured, 'config');
+  const project = readJson(path.join(projectRoot, 'package.json'));
+  const dsName = designSystemPackageName(importPath);
+  for (const dep of Object.keys({ ...(project?.dependencies || {}), ...(project?.devDependencies || {}) })) {
+    if (dep === dsName) continue;
+    consider(dep, 'project');
+  }
+  if (dsName) {
+    const dsRoot = packageRoot(projectRoot, dsName);
+    const dsPkg = dsRoot ? readJson(path.join(dsRoot, 'package.json')) : null;
+    for (const dep of Object.keys({ ...(dsPkg?.dependencies || {}), ...(dsPkg?.peerDependencies || {}) })) {
+      if (dep === dsName) continue;
+      consider(dep, 'design-system');
+    }
+  }
+  _cache.set(key, { at: Date.now(), value: out });
+  return out;
+}
+
+export function deriveIconVocabulary(input: {
+  projectRoot: string;
+  importPath?: string;
+  configuredPackage?: string;
+  components: Array<{ name: string; filePath?: string; description?: string; __componentPath?: string; props?: string[] }>;
+}): IconVocabulary {
+  const packages = derivedIconPackages(input.projectRoot, input.importPath, input.configuredPackage);
+  const iconComponents: IconVocabulary['iconComponents'] = [];
+  let iconPrimitive: string | undefined;
+  const placeholders: string[] = [];
+  for (const c of input.components) {
+    const file = (c.filePath || '').split(path.sep).join('/');
+    const fromIconsModule = /\/icons?\//i.test(file) || /\/icons?\.[jt]sx?$/i.test(file);
+    if (/^(Icon|SvgIcon)$/.test(c.name)) { iconPrimitive = iconPrimitive || c.name; continue; }
+    // An icon is a leaf: it comes from the icons module, or it is named
+    // *Icon AND its known props have no children slot. `ListItemIcon`,
+    // `StepIcon` and `SideNavIcon` all take children — they are slots that
+    // HOLD an icon, and the name alone cannot tell them apart.
+    const props = Array.isArray(c.props) ? c.props.map(String) : [];
+    const leaf = props.length > 0 && !props.some(p => /^children\b/.test(p));
+    if ((fromIconsModule && /^[A-Z]/.test(c.name)) || (/^[A-Z]\w*Icon$/.test(c.name) && leaf)) {
+      iconComponents.push({ name: c.name, importPath: c.__componentPath });
+    }
+    if (/Skeleton|Placeholder|AspectRatio|AvatarFallback/.test(c.name) && !/Skeleton(Icon|Text)$/.test(c.name)) placeholders.push(c.name);
+  }
+  // The generic ones first — a placeholder by name, then the bare Skeleton /
+  // AspectRatio / AvatarFallback, then per-component skeletons.
+  const rank = (n: string) => /Placeholder/.test(n) ? 0 : /^(Skeleton|AspectRatio|AvatarFallback)$/.test(n) ? 1 : /^Skeleton/.test(n) ? 2 : 3;
+  placeholders.sort((a, b) => rank(a) - rank(b) || a.length - b.length || a.localeCompare(b));
+  const parts: string[] = [];
+  if (packages.length) parts.push(`icon package(s): ${packages.map(p => `${p.name} (${p.via}, ${p.exports.length} exports)`).join(', ')}`);
+  if (iconComponents.length) parts.push(`${iconComponents.length} icon component(s) in the catalog`);
+  if (iconPrimitive) parts.push(`icon primitive <${iconPrimitive}>`);
+  if (placeholders.length) parts.push(`placeholders: ${placeholders.slice(0, 3).join(', ')}`);
+  return { packages, iconComponents, iconPrimitive, placeholders, source: parts.length ? parts.join('; ') : 'no icon package, no icon component, no placeholder component' };
+}
+
+export type Syntax = 'jsx' | 'html';
+
+/** The icon section of the prompt. Text glyphs are never icons, whatever exists. */
+export function formatIconRules(vocab: IconVocabulary | null | undefined, syntax: Syntax = 'jsx'): string[] {
+  const lines: string[] = ['', 'ICON RULES (derived from this project):'];
+  const pkgs = vocab?.packages ?? [];
+  const comps = vocab?.iconComponents ?? [];
+  if (pkgs.length) {
+    for (const p of pkgs.slice(0, 2)) {
+      lines.push(`- Icons come from \`${p.name}\` (installed; ${p.via === 'design-system' ? 'the design system\'s own icon set' : p.via === 'config' ? 'configured for this project' : 'a dependency of this project'}).`);
+      if (p.examples.length) lines.push(`  Real export names include: ${p.examples.join(', ')}${p.exports.length > p.examples.length ? ` …${p.exports.length - p.examples.length} more, all named like these` : ''}`);
+      lines.push(`  ${syntax === 'jsx' ? `import { ${p.examples[0] || 'IconName'} } from '${p.name}';` : `Import each icon from '${p.name}'.`} Only names the package exports exist; validation checks them.`);
+    }
+  }
+  if (comps.length) {
+    lines.push(`- This design system ships its own icon components: ${comps.slice(0, 16).map(c => c.name).join(', ')}${comps.length > 16 ? ` …${comps.length - 16} more` : ''} — import them exactly as the catalog states.`);
+  }
+  if (vocab?.iconPrimitive) {
+    lines.push(`- For an icon neither of the above provides, use the library's <${vocab.iconPrimitive}> primitive with an inline SVG path — never a text character.`);
+  } else if (!pkgs.length && !comps.length) {
+    lines.push('- No icon package and no icon component is available. Where an icon is needed, write an inline <svg viewBox="0 0 24 24" aria-hidden="true"> with a simple path (a chevron, a cross, a check) sized by the surrounding component — never a text character.');
+  }
+  lines.push('- A text glyph (⋯ × ✓ ↑ ↓ → ← ☰ • ★ ▸ ✕) is NEVER an icon. It renders in the text font at the wrong size and weight and is invisible to assistive technology. If no icon exists, an inline SVG or a text label ("More", "Close") is the answer.');
+  lines.push('- An icon is decorative (aria-hidden), the leading/trailing slot of a control, or the child of an icon button — never interactive on its own.');
+  return lines;
+}
+
+/** The image section: placeholders from the catalog; a remote photo only for a real image. */
+export function formatImageRules(vocab: IconVocabulary | null | undefined, syntax: Syntax = 'jsx'): string {
+  const ph = vocab?.placeholders ?? [];
+  const svg = "data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' width='400' height='300'><rect width='100%' height='100%' fill='%23e5e7eb'/></svg>";
+  const lines = ['IMAGE RULES (derived from this project):'];
+  if (ph.length) {
+    lines.push(`- PLACEHOLDER (the request says "placeholder", or the image is not the point): render the design system's own placeholder — ${ph.slice(0, 4).map(n => `<${n}>`).join(', ')} — or an inline SVG data URI. Never a remote URL for a placeholder.`);
+  } else {
+    lines.push('- PLACEHOLDER (the request says "placeholder", or the image is not the point): this catalog has no skeleton/placeholder component, so use an inline SVG data URI as the src — never a remote URL.');
+  }
+  lines.push(`  ${syntax === 'jsx' ? `<img src="${svg}" alt="" />` : `<img src="${svg}" alt="">`}`);
+  lines.push('- REAL PHOTO (only when the request asks for an actual picture): https://picsum.photos/[width]/[height]?random=N, always with descriptive alt text.');
+  return lines.join('\n');
+}
+
+export interface IconImportViolation { line: number; name: string; pkg: string; message: string }
+
+/** Names imported from a derived icon package that the package does not export. */
+export function checkIconImports(code: string, vocab: IconVocabulary | null | undefined): IconImportViolation[] {
+  if (!vocab?.packages.length) return [];
+  const out: IconImportViolation[] = [];
+  const lines = code.split('\n');
+  for (const p of vocab.packages) {
+    if (!p.exports.length) continue;
+    const set = new Set(p.exports);
+    const re = new RegExp(`import\\s*\\{([^}]*)\\}\\s*from\\s*['"]${p.name.replace(/[.*+?^${}()|[\]\\/]/g, '\\$&')}(?:/[^'"]*)?['"]`, 'g');
+    for (const m of code.matchAll(re)) {
+      const line = code.slice(0, m.index).split('\n').length;
+      for (const part of m[1].split(',')) {
+        const name = part.trim().split(/\s+as\s+/)[0].trim().replace(/^type\s+/, '');
+        if (!name || set.has(name)) continue;
+        const near = p.exports.find(e => e.toLowerCase() === name.toLowerCase()) || p.exports.find(e => e.toLowerCase().includes(name.toLowerCase().replace(/icon$/, '')) && name.length > 3);
+        out.push({ line, name, pkg: p.name, message: `"${name}" is not exported by ${p.name}${near ? ` — did you mean "${near}"?` : `. Use one of its real exports (e.g. ${p.examples.slice(0, 6).join(', ')}).`}` });
+      }
+    }
+  }
+  void lines;
+  return out;
+}
+
+export function formatIconImportErrors(v: IconImportViolation[]): string[] {
+  return v.map(x => `Line ${x.line}: ${x.message}`);
+}

--- a/story-generator/knowledge/spacingFacts.ts
+++ b/story-generator/knowledge/spacingFacts.ts
@@ -1,0 +1,834 @@
+/**
+ * How THIS design system spaces, pads, aligns and sizes text — derived from
+ * what the project already states, never from a pixel doctrine.
+ *
+ * A design review of 22 Carbon stories scored spacing 1.6/3 while component
+ * choice, props and colour were largely right: inline `marginTop: '1rem'` on
+ * one field of a pair, `padding: '24px'` wrappers, `Heading style={{fontSize}}`.
+ * The reviewer traced it to the prompt, which taught `style={{ padding:
+ * "24px" }}` and "MINIMUM 16px gap" to every design system — including one
+ * whose catalog already carried `Stack.gap` with a documented scale. The model
+ * had the primitive and was told to reach past it.
+ *
+ * Three sources, all already read by the pipeline:
+ *
+ *   CATALOG   components that own a gap/spacing prop, a padding prop, or a
+ *             heading/text size prop — with the values their types declare
+ *   TOKENS    the project's spacing scale as CSS custom properties, with values
+ *   IDIOM     the spacing utility classes the team's own stories use
+ *
+ * Whichever exist become the rules. Only a system with none of them gets the
+ * inline pixel examples, and the prompt says so.
+ */
+
+import fs from 'fs';
+import type { DiscoveredComponent, PropInfo } from '../componentDiscovery.js';
+import type { ExtractedProps, PropFact } from './propExtractor.js';
+import type { StylingFacts } from './stylingFacts.js';
+import { resolveTokenValue, valueKind } from './stylingFacts.js';
+
+export interface GapPrimitive {
+  name: string;
+  /** The prop that sets the gap: `gap`, `spacing`, `space`, `gutter`. */
+  prop: string;
+  /** Values the prop's type declares, when it declares any. */
+  values: string[];
+  /** True when the type also admits arbitrary strings/numbers. */
+  open: boolean;
+  /** One-line doc for the gap prop, when the library wrote one. */
+  doc?: string;
+  /** The prop (and values) that picks direction, when the primitive has one. */
+  orientation?: { prop: string; values: string[] };
+  /** True when the catalog files it under layout. */
+  layoutCategory: boolean;
+}
+
+export interface PaddingOwner {
+  name: string;
+  props: string[];
+  values: string[];
+  open: boolean;
+}
+
+export interface TypographyPrimitive {
+  name: string;
+  /** Size/level/weight props with the values they accept. */
+  props: Array<{ name: string; values: string[] }>;
+}
+
+export interface SpacingToken {
+  /** Without the leading `--`. */
+  name: string;
+  /** The resolved literal, e.g. `16px`. */
+  value: string;
+}
+
+export interface UtilityScale {
+  /** The attribute the team writes them in: `className` or `class`. */
+  attribute: string;
+  /** Spacing utilities counted from the team's own stories, most-used first. */
+  classes: Array<{ name: string; uses: number }>;
+}
+
+export interface SpacingVocabulary {
+  gapPrimitives: GapPrimitive[];
+  paddingOwners: PaddingOwner[];
+  typography: TypographyPrimitive[];
+  /** `config.layoutRules` names that actually exist in the catalog. */
+  columns?: { wrapper: string; column?: string; container?: string };
+  /** Config layout examples that carry no raw pixel/rem literal. */
+  layoutExamples: string[];
+  spacingTokens: SpacingToken[];
+  utilities: UtilityScale | null;
+  /** The team's dominant styling attribute, from their own stories. */
+  idiom: string | null;
+  /**
+   * Colour token tiers, from the alias chains the stylesheet declares.
+   * `aliasesOf` maps a PRIMITIVE (literal value) to the semantic tokens that
+   * point at it. A primitive with an alias is single-mode by construction:
+   * only the alias is redeclared under a dark theme.
+   */
+  aliasesOf: Record<string, string[]>;
+  /** A gap primitive, a spacing token scale, or a utility scale exists. */
+  hasScale: boolean;
+  /** One line saying where the scale came from, for the log. */
+  source: string;
+}
+
+const GAP_PROP = /^(gap|spacing|space|gutter)$/;
+const PADDING_PROP = /^(p|px|py|padding|paddingX|paddingY|paddingInline|paddingBlock|pad)$/;
+const ORIENTATION_PROP = /^(orientation|direction)$/;
+const TYPO_SIZE_PROP = /^(order|level|size|variant|fz|fw|weight|as|tone)$/;
+const TYPO_NAME = /(^|[a-z])(Heading|Title|Text|Typography|Display|Paragraph|Label|Caption|Kicker)$/;
+const SPACING_TOKEN_SEGMENT = /^(space|spacing|gap|inset)$/;
+const RAW_LITERAL = /-?\d*\.?\d+(px|rem|em)\b/;
+/** Tailwind (`gap-4`, `space-y-2`, `p-6`) and Vuetify (`ga-4`, `pa-4`) spacing utilities. */
+export const SPACING_UTILITY = /^(?:gap|gap-[xy]|space-[xy]|p|px|py|pt|pb|pl|pr|ps|pe|m|mx|my|mt|mb|ml|mr|ms|me|ga|gr|gc|pa|ma)-(?:\d+(?:\.\d+)?|px)$/;
+
+type AnyProp = { name: string; type?: string; options?: string[]; optionsOpen?: boolean; doc?: string; deprecated?: string };
+
+function propsOf(component: DiscoveredComponent, facts: ExtractedProps | null | undefined): AnyProp[] {
+  const fromFacts: PropFact[] | undefined = facts?.components?.[component.name]?.props;
+  if (fromFacts?.length) return fromFacts.filter(p => !p.deprecated);
+  const fromTypes: PropInfo[] | undefined = component.propTypes;
+  if (fromTypes?.length) {
+    return fromTypes.map(p => ({ name: p.name, type: p.type === 'select' ? undefined : p.type, options: p.options, doc: p.description }));
+  }
+  return (component.props || []).map(p => ({ name: String(p).match(/^([A-Za-z_$][\w$]*)/)?.[1] || String(p) }));
+}
+
+/** The string values a prop admits, from its options or a plain literal union. */
+function valuesOf(p: AnyProp): { values: string[]; open: boolean } {
+  if (p.options?.length) return { values: p.options, open: p.optionsOpen === true };
+  const t = p.type || '';
+  const literals = [...t.matchAll(/'([^']*)'/g)].map(m => m[1]);
+  if (literals.length) {
+    // A union that is only literals is closed; anything else beside them is open.
+    const rest = t.replace(/'[^']*'/g, '').replace(/[|\s()]/g, '');
+    return { values: literals, open: rest.length > 0 };
+  }
+  // A numeric union (`1 | 2 | 3`, a heading level) is closed too.
+  if (/^\s*\d+(\s*\|\s*\d+)+\s*$/.test(t)) return { values: t.split('|').map(x => x.trim()), open: false };
+  return { values: [], open: true };
+}
+
+/** Is this prop's type something a length or scale step could go in? */
+function takesValue(p: AnyProp): boolean {
+  const t = (p.type || '').trim();
+  if (!t) return true;
+  if (/^boolean$/.test(t) || /=>/.test(t) || /^\(/.test(t) && /\)\s*=>/.test(t)) return false;
+  return true;
+}
+
+function segmentsOf(name: string): string[] {
+  return name.replace(/([a-z0-9])([A-Z])/g, '$1-$2').toLowerCase().split(/[-_.]/);
+}
+
+function lengthOrder(value: string): number {
+  const m = value.match(/^(?:calc\(\s*)?(-?\d*\.?\d+)(px|rem|em)?/);
+  if (!m) return Number.POSITIVE_INFINITY;
+  const n = parseFloat(m[1]);
+  return m[2] === 'rem' || m[2] === 'em' ? n * 16 : n;
+}
+
+/**
+ * The project's spacing scale, as tokens whose NAME says spacing and whose
+ * VALUE is a length. Both are required: Carbon's stylesheet declares
+ * `--cds-grid-margin: 0` and `--layout--size-lg: where(...)` under the same
+ * name shapes, and a scale made of those would teach nothing. Aliases into the
+ * scale (`--comp-button-gap-xs: var(--space-4)`) are component tokens and are
+ * left to the component that owns them.
+ */
+export function spacingScaleFrom(styling: StylingFacts | null | undefined): SpacingToken[] {
+  if (!styling) return [];
+  const all = new Map<string, string>();
+  for (const g of styling.tokens) for (const [n, v] of Object.entries(g.values || {})) all.set(n, v);
+  const lookup = (n: string) => all.get(n);
+  const out: SpacingToken[] = [];
+  for (const g of styling.tokens) {
+    for (const name of g.names) {
+      if (!segmentsOf(name).some(s => SPACING_TOKEN_SEGMENT.test(s))) continue;
+      const raw = g.values?.[name];
+      if (!raw || /^var\(/.test(raw.trim())) continue;
+      const literal = resolveTokenValue(raw, lookup);
+      if (!literal) continue;
+      // `calc(1rem * var(--mantine-scale))` is a length the browser computes;
+      // its first term orders it. A plain literal is taken as is.
+      const calc = literal.match(/^calc\(\s*(-?\d*\.?\d+(?:px|rem|em))\b/);
+      const plain = /^-?\d*\.?\d+(px|rem|em)?$/.test(literal) && (valueKind(literal) === 'length' || valueKind(literal) === 'number');
+      if (!calc && !plain) continue;
+      out.push({ name, value: literal.length > 28 ? (calc ? calc[1] + ' ×scale' : literal.slice(0, 28)) : literal });
+    }
+  }
+  const unique = out.filter((t, i, arr) => arr.findIndex(o => o.name === t.name) === i);
+  /**
+   * One FAMILY is the scale: the tokens that share a name minus its last
+   * segment. Mantine declares `--mantine-spacing-{xs…xl}` beside a
+   * component's `--pg-gap-{xs…xl}`; both say "spacing" and both are lengths,
+   * and only the family a whole system shares is the scale a composition
+   * should use. The largest family wins, `spacing`/`space` over `gap` on a
+   * tie; a family under three members is a component's internals (Carbon's
+   * `--cds-stack-gap`), not a series.
+   */
+  const families = new Map<string, SpacingToken[]>();
+  for (const t of unique) {
+    const segs = segmentsOf(t.name);
+    const key = segs.length > 1 ? segs.slice(0, -1).join('-') : t.name;
+    (families.get(key) || families.set(key, []).get(key)!).push(t);
+  }
+  // The system's own namespace breaks a tie: `--mantine-spacing-*` and
+  // `--chip-spacing-*` are both five lengths, and `mantine-` prefixes nine
+  // hundred other tokens where `chip-` prefixes a handful.
+  const allNames = styling.tokens.flatMap(g => g.names);
+  const prefixCount = (key: string) => { const first = key.split('-')[0]; return allNames.filter(n => n === first || n.startsWith(first + '-')).length; };
+  let best: SpacingToken[] = [];
+  let bestScore = -1;
+  for (const [key, members] of families) {
+    const score = members.length * 1000 + (/(^|-)(spacing|space)(-|$)/.test(key) ? 100_000 : 0) + Math.min(999, prefixCount(key));
+    if (score > bestScore) { bestScore = score; best = members; }
+  }
+  const scale = best.sort((a, b) => lengthOrder(a.value) - lengthOrder(b.value) || a.name.localeCompare(b.name));
+  return scale.length >= 3 ? scale : [];
+}
+
+/**
+ * Colour tiers from the alias chains: `--x: var(--y)` makes `--x` semantic and
+ * `--y` a primitive. Only colours are tiered — a spacing scale is used
+ * directly, and its aliases are component tokens.
+ */
+export function aliasesFrom(styling: StylingFacts | null | undefined): Record<string, string[]> {
+  const out: Record<string, string[]> = {};
+  if (!styling) return out;
+  const colourGroup = styling.tokens.find(g => g.category === 'color');
+  if (!colourGroup?.values) return out;
+  const colourNames = new Set(colourGroup.names);
+  for (const [name, value] of Object.entries(colourGroup.values)) {
+    const ref = value.trim().match(/^var\(\s*--([a-zA-Z][\w-]*)\s*(?:,[^)]*)?\)$/);
+    if (!ref || !colourNames.has(ref[1])) continue;
+    // Only a LITERAL is a primitive; an alias of an alias is still semantic.
+    const targetValue = colourGroup.values[ref[1]];
+    if (!targetValue || /^var\(/.test(targetValue.trim())) continue;
+    (out[ref[1]] ||= []).push(name);
+  }
+  return out;
+}
+
+
+/** Values that read as steps of a scale: numbers, t-shirt sizes, density words. */
+export function looksLikeScale(values: string[]): boolean {
+  if (!values.length) return true;
+  return values.every(v => /^\d/.test(v) || /^(xs|sm|md|lg|xl|\d?xl|xxs|xxl|small|medium|large|none|tight|loose|compact|comfortable|dense)$/i.test(v));
+}
+
+/**
+ * The steps a design system states ONLY as class names.
+ *
+ * Carbon's `Stack.gap` is typed `(typeof SPACING_STEPS)[number]` with
+ * `SPACING_STEPS: number[]` — no literal anywhere in the declarations — while
+ * its stylesheet declares `.cds--stack-scale-1` … `-13`, one class per legal
+ * step, and Stack.js builds exactly that class from the prop. The stylesheet
+ * is the library's own enumeration; this reads it for the component's class
+ * family, bounded to the files the token reader already opened.
+ */
+export function scaleStepsFromStylesheets(componentName: string, files: string[] | undefined): string[] {
+  if (!files?.length) return [];
+  const kebab = componentName.replace(/([a-z0-9])([A-Z])/g, '$1-$2').toLowerCase();
+  const re = new RegExp(`\\.[a-z0-9]+(?:--?)${kebab}(?:--?|-)(?:scale|gap|spacing|space)-([a-z0-9]+)(?![\\w-])`, 'g');
+  const steps = new Set<string>();
+  for (const file of files.slice(0, 8)) {
+    let css: string;
+    try { css = fs.readFileSync(file, 'utf8'); } catch { continue; }
+    for (const m of css.matchAll(re)) steps.add(m[1]);
+    if (steps.size) break;
+  }
+  const out = [...steps];
+  const numeric = out.every(v => /^\d+$/.test(v));
+  return numeric ? out.map(Number).sort((a, b) => a - b).map(String) : out.sort();
+}
+
+export function deriveSpacingVocabulary(input: {
+  components: DiscoveredComponent[];
+  facts?: ExtractedProps | null;
+  styling?: StylingFacts | null;
+  layoutRules?: { multiColumnWrapper?: string; columnComponent?: string; containerComponent?: string; layoutExamples?: Record<string, string | undefined> };
+}): SpacingVocabulary {
+  const { components, facts, styling, layoutRules } = input;
+  const byName = new Map(components.map(c => [c.name, c]));
+
+  const gapPrimitives: GapPrimitive[] = [];
+  const paddingOwners: PaddingOwner[] = [];
+  const typography: TypographyPrimitive[] = [];
+
+  for (const c of components) {
+    const props = propsOf(c, facts);
+    if (!props.length) continue;
+    const gap = props.find(p => GAP_PROP.test(p.name) && takesValue(p));
+    if (gap) {
+      let { values, open } = valuesOf(gap);
+      if (!values.length) {
+        const fromCss = scaleStepsFromStylesheets(c.name, styling?.stylesheetFiles);
+        if (fromCss.length) { values = fromCss; open = true; }
+      }
+      if (looksLikeScale(values)) {
+        const orient = props.find(p => ORIENTATION_PROP.test(p.name));
+        let orientation: GapPrimitive['orientation'];
+        if (orient) {
+          const ov = valuesOf(orient).values;
+          // `direction` with no declared values is CSS flex-direction — the
+          // values are CSS's, not a guess about the library.
+          orientation = { prop: orient.name, values: ov.length ? ov : (orient.name === 'direction' ? ['row', 'column'] : []) };
+        }
+        gapPrimitives.push({
+          name: c.name, prop: gap.name, values, open, doc: gap.doc?.split('\n')[0],
+          orientation,
+          layoutCategory: c.category === 'layout',
+        });
+      }
+    }
+    const pads = props.filter(p => PADDING_PROP.test(p.name) && takesValue(p));
+    if (pads.length) {
+      const { values, open } = valuesOf(pads[0]);
+      // `padding: 'checkbox' | 'none' | 'normal'` (MUI's TableCell) is a
+      // density switch, not a place to put a spacing step.
+      if (looksLikeScale(values)) paddingOwners.push({ name: c.name, props: pads.map(p => p.name), values, open });
+    }
+    if ((TYPO_NAME.test(c.name) || /\b(heading|typograph)/i.test(c.description || '')) && !/Skeleton/.test(c.name)) {
+      const sizeProps = props.filter(p => TYPO_SIZE_PROP.test(p.name) && takesValue(p));
+      typography.push({ name: c.name, props: sizeProps.map(p => ({ name: p.name, values: valuesOf(p).values })) });
+    }
+  }
+  // Layout-category primitives first, then the shortest name — `Stack` before
+  // `TableToolbarContent`, both of which may declare a gap.
+  gapPrimitives.sort((a, b) => Number(b.layoutCategory) - Number(a.layoutCategory) || a.name.length - b.name.length || a.name.localeCompare(b.name));
+  paddingOwners.sort((a, b) => a.name.length - b.name.length || a.name.localeCompare(b.name));
+  // The plain typography components first (`Heading`, `Text`, `Title`), then
+  // compound titles, then labels — the order a reader would reach for them.
+  const typoRank = (n: string) => /^(Heading|Title|Text|Typography|Display|Paragraph)$/.test(n) ? 0 : /(Heading|Title|Text)$/.test(n) ? 1 : 2;
+  typography.sort((a, b) => typoRank(a.name) - typoRank(b.name) || b.props.length - a.props.length || a.name.length - b.name.length || a.name.localeCompare(b.name));
+
+  // Config names are honoured only where the catalog confirms them: Sail
+  // Shelf's config names `Grid` as its wrapper and no such export exists.
+  let columns: SpacingVocabulary['columns'];
+  const isReal = (n?: string) => !!n && /^[A-Z]/.test(n) && byName.has(n);
+  if (isReal(layoutRules?.multiColumnWrapper)) {
+    columns = {
+      wrapper: layoutRules!.multiColumnWrapper!,
+      column: isReal(layoutRules?.columnComponent) && layoutRules!.columnComponent !== layoutRules!.multiColumnWrapper ? layoutRules!.columnComponent : undefined,
+      container: isReal(layoutRules?.containerComponent) ? layoutRules!.containerComponent : undefined,
+    };
+  }
+  // An example that carries a raw literal teaches the very habit this
+  // replaces; it is dropped whenever the project has anything better.
+  const layoutExamples = Object.values(layoutRules?.layoutExamples || {}).filter((ex): ex is string => typeof ex === 'string' && ex.trim().length > 0);
+
+  const spacingTokens = spacingScaleFrom(styling);
+  const idiomAttrs = styling?.idiom.attributes || [];
+  const idiom = idiomAttrs.find(a => !/^(style|css)$/.test(a.name))?.name ?? null;
+  const spacingClasses = styling?.idiom.spacingClasses || [];
+  const utilities: UtilityScale | null = spacingClasses.length && idiom && /^(className|class)$/.test(idiom)
+    ? { attribute: idiom, classes: spacingClasses }
+    : null;
+
+  const hasScale = gapPrimitives.length > 0 || spacingTokens.length > 0 || utilities !== null;
+  const cleanExamples = hasScale ? layoutExamples.filter(ex => !RAW_LITERAL.test(ex)) : layoutExamples;
+
+  const parts: string[] = [];
+  if (gapPrimitives.length) parts.push(`${gapPrimitives.length} gap primitive(s): ${gapPrimitives.slice(0, 4).map(p => `${p.name}.${p.prop}`).join(', ')}`);
+  if (paddingOwners.length) parts.push(`${paddingOwners.length} padding owner(s)`);
+  if (spacingTokens.length) parts.push(`${spacingTokens.length} spacing token(s)`);
+  if (utilities) parts.push(`${utilities.classes.length} spacing utilit(ies) in ${utilities.attribute}`);
+  if (typography.length) parts.push(`${typography.length} typography component(s)`);
+
+  return {
+    gapPrimitives, paddingOwners, typography, columns, layoutExamples: cleanExamples,
+    spacingTokens, utilities, idiom, aliasesOf: aliasesFrom(styling), hasScale,
+    source: parts.length ? parts.join('; ') : 'no gap primitive, no spacing tokens, no utility scale',
+  };
+}
+
+/* ------------------------------------------------------------------------ */
+/* Prompt                                                                    */
+/* ------------------------------------------------------------------------ */
+
+export type ExampleSyntax = 'jsx' | 'html';
+
+/** `<Stack gap="md">` in JSX or template syntax; numbers are braced only in JSX. */
+export function exampleElement(name: string, attrs: Record<string, string | number>, syntax: ExampleSyntax, children = '…'): string {
+  const attr = Object.entries(attrs).map(([k, v]) => {
+    if (typeof v === 'number') return syntax === 'jsx' ? `${k}={${v}}` : `${k}="${v}"`;
+    // A JSX expression (`{/* a step of the scale */}`) is written raw.
+    if (syntax === 'jsx' && /^\{/.test(v)) return `${k}=${v}`;
+    return `${k}="${v}"`;
+  }).join(' ');
+  return `<${name}${attr ? ' ' + attr : ''}>${children}</${name}>`;
+}
+
+function pickValue(values: string[], position: 'small' | 'medium' | 'large'): string | number | undefined {
+  if (!values.length) return undefined;
+  const idx = position === 'small' ? Math.max(0, Math.floor(values.length * 0.3))
+    : position === 'medium' ? Math.floor(values.length / 2)
+    : Math.min(values.length - 1, Math.floor(values.length * 0.6));
+  const v = values[idx];
+  return /^\d+$/.test(v) ? Number(v) : v;
+}
+
+function listValues(values: string[], open: boolean, max = 13): string {
+  if (!values.length) return open ? 'a step of the spacing scale as documented on the prop' : '';
+  const shown = values.slice(0, max).join(' | ');
+  return `${shown}${values.length > max ? ` | …${values.length - max} more` : ''}${open ? ' (other values also accepted)' : ''}`;
+}
+
+/**
+ * The spacing section of the prompt, written from the vocabulary.
+ *
+ * `fallback` is the framework's inline examples, used ONLY when the design
+ * system offers no scale at all — and the prompt says that is why.
+ */
+export function formatSpacingRules(
+  vocab: SpacingVocabulary | null | undefined,
+  syntax: ExampleSyntax,
+  fallback: { wrapper: string; formGap: string; buttonMargin: string },
+): string {
+  if (!vocab || !vocab.hasScale) return fallbackSpacingRules(fallback, vocab?.typography ?? []);
+
+  const lines: string[] = [];
+  lines.push('MANDATORY SPACING & LAYOUT RULES — DERIVED FROM THIS DESIGN SYSTEM (NON-NEGOTIABLE):');
+  lines.push('This design system states how things are spaced. Every rule below names the mechanism');
+  lines.push('the project itself provides; there is no case where an inline pixel or rem margin,');
+  lines.push('padding or gap is the right answer. Inline `style` is reserved for what nothing below');
+  lines.push('can express (a max-width, a background from a colour token), and never for spacing.');
+  lines.push('');
+
+  // Which primitive carries the examples. A layout-category primitive with an
+  // orientation is the ideal (Carbon Stack, MUI Stack, Mantine Flex); a
+  // non-layout component that merely has a `spacing` prop (a ToggleGroup) is
+  // listed but never used as the pattern, and a utility-styled project keeps
+  // its utilities as the pattern.
+  const layoutPrims = vocab.gapPrimitives.filter(p => p.layoutCategory);
+  // Known values beat unknown ones (the example can then show a real step),
+  // an orientation prop beats none (one primitive covers column and row),
+  // and a stack/flex/inline-shaped name breaks the tie among catalog entries.
+  // A prop literally named `gap` is CSS's own name for the concept and beats
+  // `spacing` on a List whose doc says "between items".
+  const rankPrim = (p: GapPrimitive) => (p.values.length ? 0 : 2) + (p.orientation?.values.length ? 0 : 1) + (/^(V|H)?Stack$|^Flex$|^Inline$/.test(p.name) ? 0 : 0.5) + (p.prop === 'gap' ? 0 : 0.3);
+  const candidates = layoutPrims.length ? layoutPrims : (vocab.utilities ? [] : vocab.gapPrimitives);
+  const stackLike = [...candidates].sort((a, b) => rankPrim(a) - rankPrim(b))[0];
+  const listed = layoutPrims.length ? layoutPrims : (vocab.utilities ? [] : vocab.gapPrimitives);
+
+  if (listed.length) {
+    lines.push('SPACING PRIMITIVES (the catalog owns the gaps — children never carry their own margins):');
+    for (const p of listed.slice(0, 6)) {
+      const vals = listValues(p.values, p.open);
+      const orient = p.orientation ? `; ${p.orientation.prop}: ${p.orientation.values.join(' | ') || 'see catalog'}` : '';
+      lines.push(`  - <${p.name} ${p.prop}=…>${vals ? ` — ${p.prop} accepts ${vals}` : ''}${orient}${p.doc ? ` — ${p.doc}` : ''}`);
+    }
+    lines.push('');
+  }
+  if (vocab.paddingOwners.length) {
+    lines.push('PADDING OWNERS (put padding on these props, not in a style object):');
+    for (const o of vocab.paddingOwners.slice(0, 4)) {
+      lines.push(`  - <${o.name}> — ${o.props.slice(0, 6).join(', ')}${o.values.length ? ` (${listValues(o.values, o.open, 8)})` : ''}`);
+    }
+    lines.push('');
+  }
+  if (vocab.spacingTokens.length) {
+    const shown = vocab.spacingTokens.slice(0, 16);
+    lines.push('SPACING SCALE (the only lengths this project uses between elements):');
+    lines.push(`  ${shown.map(t => `--${t.name} (${t.value})`).join(', ')}${vocab.spacingTokens.length > shown.length ? `, …${vocab.spacingTokens.length - shown.length} more` : ''}`);
+    lines.push('  Write them as var(--name). A length that is not one of these is not on the scale.');
+    lines.push('');
+  }
+  if (vocab.utilities) {
+    const top = vocab.utilities.classes.slice(0, 10);
+    lines.push(`HOUSE SPACING UTILITIES (counted from this team's own stories, written in \`${vocab.utilities.attribute}\`):`);
+    lines.push(`  ${top.map(c => `${c.name} (${c.uses})`).join(', ')}`);
+    lines.push('  Spacing is a utility class on the parent (gap-*, space-y-*, p-*), never an inline style.');
+    lines.push('');
+  }
+
+  const attrs = vocab.utilities?.attribute || 'className';
+  const util = (kind: 'gap' | 'pad', size: 'small' | 'medium' | 'large') => {
+    // All-sides padding for a wrapper; `gap-*` for a flex/grid parent (with
+    // `space-y-*` only when the team writes no gap at all).
+    const all = vocab.utilities!.classes;
+    const pool = kind === 'pad'
+      ? all.filter(c => /^p-\d/.test(c.name))
+      : (all.some(c => /^gap-\d/.test(c.name)) ? all.filter(c => /^gap-\d/.test(c.name)) : all.filter(c => /^space-y-/.test(c.name)));
+    // The team's most-used step for the medium case; one step either side for small/large when they use them.
+    const names = pool.map(c => c.name);
+    const byStep = (n: string) => parseFloat(n.split('-').pop() || '0');
+    const sorted = [...new Set(names)].sort((a, b) => byStep(a) - byStep(b));
+    if (!sorted.length) return kind === 'gap' ? 'gap-4' : 'p-6';
+    const mid = names[0];
+    const idx = sorted.indexOf(mid);
+    return size === 'medium' ? mid : size === 'small' ? sorted[Math.max(0, idx - 1)] : sorted[Math.min(sorted.length - 1, idx + 1)];
+  };
+  const tok = (size: 'small' | 'medium' | 'large') => {
+    const v = pickValue(vocab.spacingTokens.map(x => x.name), size);
+    return v !== undefined ? `var(--${v})` : undefined;
+  };
+  const step = (p: GapPrimitive, size: 'small' | 'medium' | 'large'): string | number => {
+    const v = pickValue(p.values, size);
+    if (v !== undefined) return v;
+    // No values known at all: the prop's own documentation is the model's
+    // guide, and the example must not invent a scale word.
+    return syntax === 'jsx' ? '{/* a step of the spacing scale */}' : '…';
+  };
+
+  let wrapperExample: string;
+  let stackExample: string;
+  let rowExample: string;
+  let recipe: string | null = null;
+
+  if (stackLike) {
+    const vertical = stackLike.orientation?.values.find(v => /vert|column/i.test(v));
+    const horizontal = stackLike.orientation?.values.find(v => /horiz|row/i.test(v));
+    const stackAttrs: Record<string, string | number> = { [stackLike.prop]: step(stackLike, 'medium') };
+    if (vertical && stackLike.orientation) stackAttrs[stackLike.orientation.prop] = vertical;
+    stackExample = exampleElement(stackLike.name, stackAttrs, syntax, ' <Field /> <Field /> <Field /> ');
+    if (horizontal && stackLike.orientation) {
+      rowExample = exampleElement(stackLike.name, { [stackLike.prop]: step(stackLike, 'small'), [stackLike.orientation.prop]: horizontal }, syntax, ' <Button>Cancel</Button> <Button>Save</Button> ');
+    } else {
+      // A second layout primitive without an orientation is a row by
+      // construction (Group, Inline); failing that the same primitive, and the
+      // model reads its orientation prop from the catalog.
+      // Any gap primitive without an orientation is a row by construction
+      // (Group, Inline); known values first, layout category as a tiebreak.
+      const row = vocab.gapPrimitives.filter(p => p !== stackLike && !p.orientation)
+        .sort((a, b) => (rankPrim(a) + (a.layoutCategory ? 0 : 0.25)) - (rankPrim(b) + (b.layoutCategory ? 0 : 0.25)))[0] || stackLike;
+      rowExample = exampleElement(row.name, { [row.prop]: step(row, 'small') }, syntax, ' <Button>Cancel</Button> <Button>Save</Button> ');
+    }
+    const pad = vocab.paddingOwners[0];
+    if (pad) {
+      wrapperExample = exampleElement(pad.name, { [pad.props[0]]: pickValue(pad.values, 'large') ?? (syntax === 'jsx' ? '{/* a step of the scale */}' : '…') }, syntax);
+    } else if (tok('large')) {
+      wrapperExample = syntax === 'jsx' ? `<div style={{ padding: "${tok('large')}" }}>…</div>` : `<div style="padding: ${tok('large')}">…</div>`;
+    } else if (vocab.columns?.container) {
+      wrapperExample = exampleElement(vocab.columns.container, {}, syntax);
+    } else {
+      // No padding prop, no token, no container: Storybook's own canvas
+      // padding is the breathing room. Adding an inline padding here is the
+      // exact defect this section exists to prevent.
+      wrapperExample = `${exampleElement(stackLike.name, { [stackLike.prop]: step(stackLike, 'large') }, syntax)} with parameters: { layout: 'padded' } (Storybook's canvas padding) — no inline padding`;
+    }
+  } else if (vocab.utilities) {
+    wrapperExample = `<div ${attrs}="${util('pad', 'large')}">…</div>`;
+    stackExample = `<div ${attrs}="flex flex-col ${util('gap', 'medium')}"> <Field /> <Field /> </div>`;
+    rowExample = `<div ${attrs}="flex items-center ${util('gap', 'small')}"> <Button>Cancel</Button> <Button>Save</Button> </div>`;
+  } else {
+    // Tokens only: one recipe, in the project's scale, border-box so padding
+    // and borders cannot break the column arithmetic (measured: a three-column
+    // grid rendered two because `calc((100% - 2*gap)/3)` met content-box).
+    const g = tok('medium') || 'var(--spacing)';
+    const s = tok('small') || g;
+    const l = tok('large') || g;
+    wrapperExample = syntax === 'jsx' ? `<div style={{ padding: "${l}", boxSizing: "border-box" }}>…</div>` : `<div style="padding: ${l}; box-sizing: border-box">…</div>`;
+    stackExample = syntax === 'jsx' ? `<div style={{ display: "flex", flexDirection: "column", gap: "${g}" }}> <Field /> <Field /> </div>` : `<div style="display: flex; flex-direction: column; gap: ${g}"> <Field /> <Field /> </div>`;
+    rowExample = syntax === 'jsx' ? `<div style={{ display: "flex", alignItems: "center", gap: "${s}" }}> <Button>Cancel</Button> <Button>Save</Button> </div>` : `<div style="display: flex; align-items: center; gap: ${s}"> <Button>Cancel</Button> <Button>Save</Button> </div>`;
+    recipe = syntax === 'jsx'
+      ? `<div style={{ display: "grid", gridTemplateColumns: "repeat(3, minmax(0, 1fr))", gap: "${g}", boxSizing: "border-box" }}>…</div>`
+      : `<div style="display: grid; grid-template-columns: repeat(3, minmax(0, 1fr)); gap: ${g}; box-sizing: border-box">…</div>`;
+  }
+
+  lines.push('1. STORY WRAPPER (REQUIRED): one outer container gives the story its breathing room.');
+  lines.push(`   Pattern: ${wrapperExample}`);
+  lines.push('2. FORM FIELDS & VERTICAL GROUPS: siblings are spaced by their PARENT. Put the gap on the');
+  lines.push('   container and give no child a margin — a one-sided margin on one field of a pair is');
+  lines.push('   the most common misalignment in generated code.');
+  lines.push(`   Pattern: ${stackExample}`);
+  lines.push('3. BUTTONS & ACTION ROWS: a row primitive with a small gap; actions sit in the same parent');
+  lines.push('   stack as the fields, so the space above them is that stack\'s gap, not a marginTop.');
+  lines.push(`   Pattern: ${rowExample}`);
+  if (recipe) {
+    lines.push('4. MULTI-COLUMN LAYOUT: this catalog has no grid component, so use this recipe with the');
+    lines.push('   spacing scale — minmax(0, 1fr) and border-box keep every column the same width:');
+    lines.push(`   ${recipe}`);
+  } else if (vocab.columns?.column) {
+    lines.push(`4. MULTI-COLUMN LAYOUT: <${vocab.columns.wrapper}> with each column in <${vocab.columns.column}>. Column spans must`);
+    lines.push('   add up to the grid\'s full width; a row that comes up short reads as broken.');
+  } else if (vocab.columns) {
+    lines.push(`4. MULTI-COLUMN LAYOUT: <${vocab.columns.wrapper}> with its own column and gap props (see the catalog); children carry no widths.`);
+  } else if (vocab.utilities) {
+    lines.push(`4. MULTI-COLUMN LAYOUT: a grid utility on the parent (grid grid-cols-N ${util('gap', 'medium')}); children carry no widths.`);
+  } else if (stackLike) {
+    lines.push('4. MULTI-COLUMN LAYOUT: the catalog\'s grid/row primitive with its own gap prop; never a hand-rolled CSS grid with a pixel gap.');
+  }
+  if (vocab.layoutExamples.length) {
+    lines.push('   The project\'s own layout examples:');
+    for (const ex of vocab.layoutExamples.slice(0, 3)) lines.push(`   ${ex.replace(/\n\s*/g, ' ')}`);
+  }
+  lines.push('5. SECTIONS: nest the same primitives — a larger step between sections than within one.');
+  lines.push('   Never a margin on a heading or a divider to "push" content apart.');
+  lines.push('6. SIZE-HUGGING ELEMENTS (tags, badges, buttons): a vertical stack stretches its children to');
+  lines.push('   its width. Wrap such an element in a row primitive or a plain inline container so it');
+  lines.push('   keeps its own width; never set width or maxWidth on the element to compensate.');
+  lines.push(typographyRule(vocab.typography, true));
+  lines.push('');
+  lines.push('SPACING SELF-CHECK before emitting: search your output for `px`, `rem` and bare numbers in');
+  lines.push('margin, padding and gap properties. Each one is a defect — replace it with the primitive,');
+  lines.push('utility or token above. Validation rejects them.');
+  return lines.join('\n');
+}
+
+function typographyRule(typography: TypographyPrimitive[], hasScale: boolean): string {
+  if (typography.length) {
+    const shown = typography.slice(0, 4).map(t => {
+      // Only the props that pick a SIZE or LEVEL are worth showing here.
+      const props = t.props.filter(p => /^(order|level|size|as|fz|fw|weight)$/.test(p.name)).slice(0, 2);
+      return `<${t.name}${props.length ? ` ${props.map(p => `${p.name}=${p.values.length ? `[${p.values.slice(0, 8).join('|')}]` : '…'}`).join(' ')}` : ''}>`;
+    });
+    return `7. HEADINGS & TEXT: ${shown.join(', ')} own size, weight and line-height. Never set fontSize,\n   fontWeight or lineHeight inline, and never restyle a heading with a style object — pick the\n   component and prop that already produces that size.`;
+  }
+  return hasScale
+    ? '7. HEADINGS & TEXT: this catalog has no typography component, so use semantic h1–h6 / p with the\n   house styling mechanism (utilities or typography tokens); never fontSize/fontWeight/lineHeight inline.'
+    : '7. HEADINGS & TEXT: use semantic h1–h6 / p elements; avoid inline font overrides.';
+}
+
+/** The pre-derivation rules, kept verbatim for a system that declares no scale. */
+function fallbackSpacingRules(ex: { wrapper: string; formGap: string; buttonMargin: string }, typography: TypographyPrimitive[]): string {
+  return `MANDATORY SPACING & LAYOUT RULES (NON-NEGOTIABLE):
+** This design system declares no layout primitive with a gap prop, no spacing tokens and no
+spacing utility scale, so inline spacing values are acceptable here — and only here. **
+** CRITICAL: Every generated component MUST have professional-quality spacing. Components without proper spacing look broken and unprofessional. **
+
+1. STORY WRAPPER (REQUIRED for every story):
+   - The rendered story MUST have a wrapper element with padding
+   - Pattern: ${ex.wrapper}
+   - This ensures content has breathing room within the Storybook canvas
+
+2. FORM FIELD SPACING (CRITICAL):
+   - ALWAYS wrap form fields in a container with vertical spacing
+   - Use flexbox column with gap: ${ex.formGap}
+   - MINIMUM 16px gap between form fields
+
+3. BUTTON SPACING:
+   - Submit/action buttons: 24px margin-top from form fields above
+   - Pattern: ${ex.buttonMargin}
+   - Button groups should be wrapped with margin-top from content
+
+4. SECTION SPACING:
+   - Between major sections: 32-48px
+   - Between related content groups: 24px
+   - Use dividers or significant whitespace between unrelated content
+
+5. HEADING SPACING:
+   - More space ABOVE headings (24-32px) than below (8-16px)
+
+6. CARD/CONTAINER PADDING:
+   - Internal padding: minimum 16px, preferred 24px
+
+${typographyRule(typography, false)}
+
+SPACING VALIDATION (Self-check before generating):
+Ask yourself: "Does every element have adequate breathing room from its neighbors?"
+If any elements appear cramped or touching, add appropriate spacing.`;
+}
+
+/* ------------------------------------------------------------------------ */
+/* Validation                                                                */
+/* ------------------------------------------------------------------------ */
+
+export interface SpacingViolation {
+  line: number;
+  property: string;
+  value: string;
+  message: string;
+}
+
+const SPACING_KEY = /^(margin|padding|gap|row-?gap|column-?gap|inset|margin-?(top|bottom|left|right|block|inline)(-?(start|end))?|padding-?(top|bottom|left|right|block|inline)(-?(start|end))?)$/i;
+const TYPO_KEY = /^(font-?size|font-?weight|line-?height)$/i;
+
+interface StyleBody { kind: 'object' | 'string'; body: string; line: number }
+
+/** Every inline style attribute: a JSX object (`style={{…}}`) or a template string (`style="…"`). */
+function styleBodies(code: string): StyleBody[] {
+  const out: StyleBody[] = [];
+  const re = /\bstyle\s*=\s*(\{\{|"|')/g;
+  let m: RegExpExecArray | null;
+  while ((m = re.exec(code))) {
+    const start = m.index + m[0].length;
+    const line = code.slice(0, m.index).split('\n').length;
+    if (m[1] === '{{') {
+      let depth = 2;
+      let i = start;
+      for (; i < code.length && depth > 0; i++) {
+        if (code[i] === '{') depth++;
+        else if (code[i] === '}') depth--;
+      }
+      out.push({ kind: 'object', body: code.slice(start, Math.max(start, i - 2)), line });
+      re.lastIndex = i;
+    } else {
+      const end = code.indexOf(m[1], start);
+      out.push({ kind: 'string', body: code.slice(start, end < 0 ? code.length : end), line });
+      if (end > 0) re.lastIndex = end + 1;
+    }
+  }
+  return out;
+}
+
+function declarationsOf(style: StyleBody): Array<{ key: string; value: string; offset: number }> {
+  const out: Array<{ key: string; value: string; offset: number }> = [];
+  if (style.kind === 'object') {
+    for (const dm of style.body.matchAll(/(?:^|[,{\s])(?:'([^']+)'|"([^"]+)"|([A-Za-z_$][\w$]*))\s*:\s*('[^']*'|"[^"]*"|`[^`]*`|-?\d*\.?\d+(?![\w.])|[^,}\n]+)/g)) {
+      const key = dm[1] ?? dm[2] ?? dm[3];
+      const value = dm[4].trim().replace(/^['"`]|['"`]$/g, '');
+      out.push({ key, value, offset: dm.index ?? 0 });
+    }
+  } else {
+    for (const dm of style.body.matchAll(/([A-Za-z-]+)\s*:\s*([^;]+)/g)) out.push({ key: dm[1].trim(), value: dm[2].trim(), offset: dm.index ?? 0 });
+  }
+  return out;
+}
+
+/**
+ * A raw spacing literal: `24px`, `1.5rem`, or (JSX only) a bare number, which
+ * React renders as pixels. `0`, `auto` and anything computed from a token,
+ * a theme or a variable is not raw.
+ */
+function isRawSpacing(value: string, kind: 'object' | 'string'): boolean {
+  const v = value.trim();
+  if (!v) return false;
+  if (/var\(|calc\(|theme|\$\{|rem\(|spacing\(/i.test(v) && !/^\s*-?\d*\.?\d+(px|rem|em)?\s*$/.test(v)) {
+    // A shorthand mixing a token with a literal (`0 var(--x)`) is fine; a
+    // literal beside a token (`var(--x) 12px`) is still a literal.
+    return /(?:^|\s)-?\d*\.?\d+(px|rem|em)\b/.test(v.replace(/var\([^)]*\)|calc\([^)]*\)/g, ''));
+  }
+  const parts = v.split(/\s+/);
+  const raw = parts.some(p => /^-?\d*\.?\d+(px|rem|em)$/.test(p) && parseFloat(p) !== 0);
+  if (raw) return true;
+  if (kind === 'object' && /^-?\d*\.?\d+$/.test(v) && parseFloat(v) !== 0) return true;
+  return false;
+}
+
+function fixFor(vocab: SpacingVocabulary, property: string): string {
+  const gap = vocab.gapPrimitives[0];
+  const pad = vocab.paddingOwners[0];
+  const isPad = /padding/i.test(property);
+  const isGap = /gap/i.test(property);
+  const tokens = vocab.spacingTokens.slice(0, 4).map(t => `var(--${t.name})`).join(', ');
+  if (vocab.utilities) {
+    const pool = vocab.utilities.classes.filter(c => isPad ? /^p/.test(c.name) : /^(gap|space|m)/.test(c.name)).slice(0, 3).map(c => c.name);
+    return `use a ${vocab.utilities.attribute} utility from this project's scale (${(pool.length ? pool : vocab.utilities.classes.slice(0, 3).map(c => c.name)).join(', ')}) and drop the style property`;
+  }
+  if (isPad && pad) return `put the padding on <${pad.name} ${pad.props[0]}=…>${pad.values.length ? ` (${pad.values.slice(0, 6).join(' | ')})` : ''}${tokens ? `, or use a spacing token (${tokens})` : ''}`;
+  if (gap && (isGap || !isPad)) return `let the parent <${gap.name} ${gap.prop}=…>${gap.values.length ? ` (${gap.values.slice(0, 8).join(' | ')})` : ''} own the spacing between siblings and remove the ${property}`;
+  if (tokens) return `use a token from this project's spacing scale (${tokens})`;
+  if (gap) return `space siblings with <${gap.name} ${gap.prop}=…> instead`;
+  return 'use the design system\'s spacing mechanism';
+}
+
+/**
+ * Inline pixel/rem margins, paddings and gaps, and inline font overrides, in
+ * a design system that has a scale for them. Framework-agnostic: JSX style
+ * objects and template `style="…"` strings are both read.
+ */
+export function checkInlineSpacing(code: string, vocab: SpacingVocabulary | null | undefined): SpacingViolation[] {
+  if (!vocab || !vocab.hasScale) return [];
+  const out: SpacingViolation[] = [];
+  for (const st of styleBodies(code)) {
+    for (const d of declarationsOf(st)) {
+      if (SPACING_KEY.test(d.key) && isRawSpacing(d.value, st.kind)) {
+        out.push({
+          line: st.line, property: d.key, value: d.value,
+          message: `inline ${d.key}: "${d.value}" is a raw spacing value in a design system that has a spacing scale — ${fixFor(vocab, d.key)}.`,
+        });
+      } else if (TYPO_KEY.test(d.key) && vocab.typography.length) {
+        const t = vocab.typography[0];
+        out.push({
+          line: st.line, property: d.key, value: d.value,
+          message: `inline ${d.key}: "${d.value}" overrides the design system's typography — use <${t.name}>${t.props.length ? ` with ${t.props.slice(0, 2).map(p => p.name).join('/')}` : ''} (or the typography component that already produces this size) and remove the style property.`,
+        });
+      }
+    }
+  }
+  // Arbitrary utility values (`p-[24px]`) are the utility idiom's spelling of
+  // the same literal.
+  if (vocab.utilities) {
+    code.split('\n').forEach((text, i) => {
+      for (const m of text.matchAll(/\b((?:gap|space-[xy]|p|px|py|pt|pb|pl|pr|m|mx|my|mt|mb|ml|mr)-\[(-?\d*\.?\d+(?:px|rem|em))\])/g)) {
+        out.push({ line: i + 1, property: m[1].split('-[')[0], value: m[2], message: `${m[1]} is an arbitrary spacing value — use a step from this project's scale (${vocab.utilities!.classes.slice(0, 3).map(c => c.name).join(', ')}).` });
+      }
+    });
+  }
+  return out;
+}
+
+export interface TierViolation {
+  line: number;
+  primitive: string;
+  aliases: string[];
+  message: string;
+}
+
+/**
+ * A primitive colour token used where the project declares a semantic alias
+ * for it. The alias is what follows the theme; the primitive is one mode only.
+ */
+export function checkTokenTiers(code: string, vocab: SpacingVocabulary | null | undefined): TierViolation[] {
+  if (!vocab || !Object.keys(vocab.aliasesOf).length) return [];
+  const out: TierViolation[] = [];
+  const seen = new Set<string>();
+  code.split('\n').forEach((text, i) => {
+    for (const m of text.matchAll(/var\(\s*--([a-zA-Z][\w-]*)/g)) {
+      const name = m[1];
+      const aliases = vocab.aliasesOf[name];
+      if (!aliases?.length || seen.has(name)) continue;
+      seen.add(name);
+      const shown = aliases.slice(0, 3).map(a => `--${a}`).join(', ');
+      out.push({
+        line: i + 1, primitive: name, aliases,
+        message: `var(--${name}) is a primitive colour; this project aliases it as ${shown}${aliases.length > 3 ? ` (+${aliases.length - 3} more)` : ''}. Use the alias that names your intent — the primitive ignores the dark theme.`,
+      });
+    }
+  });
+  return out;
+}
+
+/**
+ * The one-paragraph spacing note a REPAIR prompt carries. A repair gets a
+ * fresh, minimal prompt with none of the generation's rules, and the first
+ * measured repair re-introduced `gap: '0.75rem'` into a Carbon story the
+ * generation had kept clean.
+ */
+export function repairSpacingNote(vocab: SpacingVocabulary | null | undefined): string | null {
+  if (!vocab || !vocab.hasScale) return null;
+  const how: string[] = [];
+  const gap = vocab.gapPrimitives.find(p => p.layoutCategory) || vocab.gapPrimitives[0];
+  if (gap && !(vocab.utilities && !gap.layoutCategory)) how.push(`<${gap.name} ${gap.prop}=…>${gap.values.length ? ` (${gap.values.slice(0, 8).join(' | ')})` : ''}`);
+  if (vocab.paddingOwners[0]) how.push(`<${vocab.paddingOwners[0].name} ${vocab.paddingOwners[0].props[0]}=…>`);
+  if (vocab.spacingTokens.length) how.push(`the spacing tokens (${vocab.spacingTokens.slice(0, 4).map(t => `var(--${t.name})`).join(', ')})`);
+  if (vocab.utilities) how.push(`${vocab.utilities.attribute} utilities (${vocab.utilities.classes.slice(0, 4).map(c => c.name).join(', ')})`);
+  return [
+    'SPACING: this design system spaces with ' + how.join(', ') + '.',
+    'Do not introduce an inline pixel/rem margin, padding or gap, or an inline fontSize/fontWeight, in the fix —',
+    'a repair that adds one is rejected.',
+  ].join('\n');
+}
+
+export function formatSpacingErrors(v: SpacingViolation[]): string[] {
+  return v.map(x => `Line ${x.line}: ${x.message}`);
+}
+
+export function formatTierErrors(v: TierViolation[]): string[] {
+  return v.map(x => `Line ${x.line}: ${x.message}`);
+}

--- a/story-generator/knowledge/stylingFacts.ts
+++ b/story-generator/knowledge/stylingFacts.ts
@@ -52,6 +52,13 @@ export interface StylingIdiom {
   attributes: Array<{ name: string; uses: number }>;
   /** Files sampled, so a caller can judge how much to trust it. */
   sampled: number;
+  /**
+   * Spacing utility classes the team writes in `className`/`class`
+   * (`gap-4`, `space-y-2`, `p-6`, Vuetify's `pa-4`), most-used first. For a
+   * utility-styled project this IS the spacing scale: the team's own stories
+   * state which steps they use, and no token list would say it better.
+   */
+  spacingClasses?: Array<{ name: string; uses: number }>;
 }
 
 /**
@@ -81,7 +88,12 @@ export interface StylingFacts {
   idiom: StylingIdiom;
   /** Provenance of the token read. Present so zero and absent are separable. */
   sources: TokenSources;
+  /** The stylesheets read (project, then package), so a caller can look for what a design system states only as class names. */
+  stylesheetFiles?: string[];
 }
+
+/** Tailwind (`gap-4`, `space-y-2`, `p-6`) and Vuetify (`ga-4`, `pa-4`) spacing utilities. */
+const SPACING_UTILITY_CLASS = /^(?:gap|gap-[xy]|space-[xy]|p|px|py|pt|pb|pl|pr|ps|pe|m|mx|my|mt|mb|ml|mr|ms|me|ga|gr|gc|pa|ma)-(?:\d+(?:\.\d+)?|px)$/;
 
 /** Attributes that carry styling. Deliberately broad; frequency decides. */
 const STYLE_ATTRS = new Set([
@@ -447,6 +459,7 @@ export function readDesignTokens(projectRoot: string, importPath?: string): Toke
  */
 export function readStylingIdiom(projectRoot: string, generatedFragment = 'generated'): StylingIdiom {
   const counts = new Map<string, number>();
+  const utilityCounts = new Map<string, number>();
   let sampled = 0;
 
   const walk = (dir: string, depth = 0) => {
@@ -470,6 +483,17 @@ export function readStylingIdiom(projectRoot: string, generatedFragment = 'gener
         if (!STYLE_ATTRS.has(attr)) continue;
         counts.set(attr, (counts.get(attr) || 0) + 1);
       }
+      // The spacing steps the team actually writes, read from their class
+      // strings. Only the literal string parts are read; an expression is
+      // opaque and is skipped rather than guessed at.
+      for (const m of src.matchAll(/(?:className|class)\s*=\s*(?:"([^"]*)"|'([^']*)'|\{\s*(?:"([^"]*)"|'([^']*)'|`([^`]*)`)\s*\})/g)) {
+        const value = m[1] ?? m[2] ?? m[3] ?? m[4] ?? m[5] ?? '';
+        for (const cls of value.split(/\s+/)) {
+          const bare = cls.replace(/^[a-z-]+:/, '');
+          if (!SPACING_UTILITY_CLASS.test(bare)) continue;
+          utilityCounts.set(bare, (utilityCounts.get(bare) || 0) + 1);
+        }
+      }
     }
   };
   walk(path.join(projectRoot, 'src'));
@@ -477,8 +501,11 @@ export function readStylingIdiom(projectRoot: string, generatedFragment = 'gener
   const attributes = [...counts.entries()]
     .map(([name, uses]) => ({ name, uses }))
     .sort((a, b) => b.uses - a.uses);
+  const spacingClasses = [...utilityCounts.entries()]
+    .map(([name, uses]) => ({ name, uses }))
+    .sort((a, b) => b.uses - a.uses || a.name.localeCompare(b.name));
 
-  return { attributes, sampled };
+  return { attributes, sampled, ...(spacingClasses.length ? { spacingClasses } : {}) };
 }
 
 export function readStylingFacts(
@@ -502,6 +529,7 @@ export function readStylingFacts(
   return {
     tokens,
     idiom: readStylingIdiom(projectRoot, generatedFragment),
+    stylesheetFiles: [...projectFiles, ...packageFiles],
     sources: {
       projectFiles: projectFiles.length,
       packageFiles: packageFiles.length,
@@ -550,17 +578,48 @@ export function formatStylingGuidance(facts: StylingFacts, maxPerGroup = 24): st
 
   if (tokens.length) {
     lines.push('', 'Design tokens available in this project:');
+    let tiered = false;
     for (const group of tokens) {
       if (group.category === 'other') continue;
-      const shown = group.names.slice(0, maxPerGroup);
-      const more = group.names.length - shown.length;
+      /**
+       * Semantic before primitive, for colours.
+       *
+       * A token whose value is `var(--other)` is an alias — the name says
+       * what the colour is FOR, and only that tier is redeclared under a
+       * dark theme. Twelve of 22 Sail Shelf stories painted surfaces with
+       * `--ss-navy-50` while `--ss-color-background-brand-subtle` pointed at
+       * it; listed alphabetically the primitives came first and filled the
+       * cap. The tier is read from the value, not from any naming scheme.
+       */
+      const isAlias = (n: string) => /^var\(/.test((group.values?.[n] || '').trim());
+      const ordered = group.category === 'color'
+        ? [...group.names.filter(isAlias), ...group.names.filter(n => !isAlias(n))]
+        : group.names;
+      const semanticCount = group.category === 'color' ? group.names.filter(isAlias).length : 0;
+      const shown = ordered.slice(0, maxPerGroup);
+      const more = ordered.length - shown.length;
       // Scale tokens carry their value: `--font-size-1 (72px)` says which end
       // of the scale it is; a colour's hex says nothing the name does not.
       const withValue = (n: string) => {
         const v = group.category !== 'color' ? group.values?.[n] : undefined;
         return v && v.length <= 24 && !/^var\(/.test(v) ? `--${n} (${v})` : `--${n}`;
       };
-      lines.push(`- ${group.category}: ${shown.map(withValue).join(', ')}${more > 0 ? `, …${more} more` : ''}`);
+      if (semanticCount > 0 && semanticCount < group.names.length) {
+        tiered = true;
+        const semantic = shown.filter(isAlias);
+        const primitive = shown.filter(n => !isAlias(n));
+        lines.push(`- ${group.category} (semantic — use these): ${semantic.map(withValue).join(', ')}${semanticCount > semantic.length ? `, …${semanticCount - semantic.length} more` : ''}`);
+        if (primitive.length) lines.push(`- ${group.category} (primitive — only where no semantic token names the intent): ${primitive.map(withValue).join(', ')}${more > 0 ? `, …${more} more` : ''}`);
+      } else {
+        lines.push(`- ${group.category}: ${shown.map(withValue).join(', ')}${more > 0 ? `, …${more} more` : ''}`);
+      }
+    }
+    if (tiered) {
+      lines.push(
+        'A semantic token is an alias (its value is var(--primitive)); it is the tier that follows',
+        'the theme. A primitive is one mode only: where a semantic token points at it, use the',
+        'semantic one. Validation reports a primitive used where its alias exists.',
+      );
     }
   }
 

--- a/story-generator/promptGenerator.ts
+++ b/story-generator/promptGenerator.ts
@@ -1,6 +1,7 @@
 import { StoryUIConfig } from '../story-ui.config.js';
 import { DiscoveredComponent } from './componentDiscovery.js';
 import { loadConsiderations, considerationsToPrompt } from './considerationsLoader.js';
+import { deriveIconVocabulary, formatIconRules } from './knowledge/iconFacts.js';
 import { DocumentationLoader } from './documentationLoader.js';
 import {
   getAdapterRegistry,
@@ -15,230 +16,23 @@ import * as path from 'path';
 /**
  * Icon package information for smart detection
  */
-interface IconPackageInfo {
-  name: string;
-  importPath: string;
-  commonIcons: string[];
-  importStyle: 'named' | 'default';
-  description: string;
-}
-
 /**
- * Known icon packages and their common icons
- * Used for smart detection when icon packages are installed
+ * Icon instructions, derived from the project.
+ *
+ * Replaces a hard-coded list of four icon packages (which could not know that
+ * `@carbon/icons-react` ships with `@carbon/react`, or that a local
+ * `src/icons` module exists) and advice to "use Unicode symbols" when none of
+ * the four was installed — the advice that produced ⋯ × ✓ as icons in six MUI
+ * stories. See knowledge/iconFacts.ts.
  */
-const KNOWN_ICON_PACKAGES: IconPackageInfo[] = [
-  {
-    name: '@tabler/icons-react',
-    importPath: '@tabler/icons-react',
-    commonIcons: [
-      'IconHome', 'IconSettings', 'IconUser', 'IconSearch', 'IconMenu2',
-      'IconBell', 'IconMail', 'IconCalendar', 'IconClock', 'IconStar',
-      'IconHeart', 'IconPlus', 'IconMinus', 'IconX', 'IconCheck',
-      'IconChevronRight', 'IconChevronLeft', 'IconChevronDown', 'IconChevronUp',
-      'IconArrowRight', 'IconArrowLeft', 'IconArrowUp', 'IconArrowDown',
-      'IconEdit', 'IconTrash', 'IconDownload', 'IconUpload', 'IconShare',
-      'IconFilter', 'IconSort', 'IconRefresh', 'IconEye', 'IconEyeOff',
-      'IconLock', 'IconUnlock', 'IconCopy', 'IconClipboard', 'IconFolder',
-      'IconFile', 'IconImage', 'IconVideo', 'IconMusic', 'IconLink',
-      'IconExternalLink', 'IconDots', 'IconDotsVertical', 'IconGripVertical',
-      'IconSun', 'IconMoon', 'IconCloud', 'IconBolt', 'IconDroplet',
-      'IconMapPin', 'IconPhone', 'IconMessage', 'IconSend', 'IconInbox',
-      'IconArchive', 'IconTag', 'IconBookmark', 'IconFlag', 'IconAward',
-      'IconTrendingUp', 'IconTrendingDown', 'IconActivity', 'IconPieChart',
-      'IconBarChart', 'IconLineChart', 'IconDatabase', 'IconServer', 'IconCode',
-      'IconTerminal', 'IconBrandGithub', 'IconBrandTwitter', 'IconBrandLinkedin',
-      'IconWorld', 'IconGlobe', 'IconWifi', 'IconBluetooth', 'IconCpu',
-      'IconDeviceDesktop', 'IconDeviceMobile', 'IconPrinter', 'IconCamera',
-      'IconMicrophone', 'IconVolume', 'IconPlayerPlay', 'IconPlayerPause',
-    ],
-    importStyle: 'named',
-    description: 'Tabler Icons - Free and open source icons (Mantine recommended)',
-  },
-  {
-    name: 'lucide-react',
-    importPath: 'lucide-react',
-    commonIcons: [
-      'Home', 'Settings', 'User', 'Search', 'Menu',
-      'Bell', 'Mail', 'Calendar', 'Clock', 'Star',
-      'Heart', 'Plus', 'Minus', 'X', 'Check',
-      'ChevronRight', 'ChevronLeft', 'ChevronDown', 'ChevronUp',
-      'ArrowRight', 'ArrowLeft', 'ArrowUp', 'ArrowDown',
-      'Edit', 'Trash', 'Download', 'Upload', 'Share',
-      'Filter', 'RefreshCw', 'Eye', 'EyeOff',
-      'Lock', 'Unlock', 'Copy', 'Clipboard', 'Folder',
-      'File', 'Image', 'Video', 'Music', 'Link',
-      'ExternalLink', 'MoreHorizontal', 'MoreVertical', 'GripVertical',
-      'Sun', 'Moon', 'Cloud', 'Zap', 'Droplet',
-      'MapPin', 'Phone', 'MessageSquare', 'Send', 'Inbox',
-    ],
-    importStyle: 'named',
-    description: 'Lucide Icons - Beautiful & consistent icons',
-  },
-  {
-    name: '@heroicons/react',
-    importPath: '@heroicons/react/24/outline',
-    commonIcons: [
-      'HomeIcon', 'Cog6ToothIcon', 'UserIcon', 'MagnifyingGlassIcon', 'Bars3Icon',
-      'BellIcon', 'EnvelopeIcon', 'CalendarIcon', 'ClockIcon', 'StarIcon',
-      'HeartIcon', 'PlusIcon', 'MinusIcon', 'XMarkIcon', 'CheckIcon',
-      'ChevronRightIcon', 'ChevronLeftIcon', 'ChevronDownIcon', 'ChevronUpIcon',
-      'ArrowRightIcon', 'ArrowLeftIcon', 'ArrowUpIcon', 'ArrowDownIcon',
-      'PencilIcon', 'TrashIcon', 'ArrowDownTrayIcon', 'ArrowUpTrayIcon', 'ShareIcon',
-      'FunnelIcon', 'ArrowPathIcon', 'EyeIcon', 'EyeSlashIcon',
-      'LockClosedIcon', 'LockOpenIcon', 'ClipboardIcon', 'FolderIcon',
-      'DocumentIcon', 'PhotoIcon', 'VideoCameraIcon', 'MusicalNoteIcon', 'LinkIcon',
-    ],
-    importStyle: 'named',
-    description: 'Heroicons - Beautiful hand-crafted SVG icons by Tailwind',
-  },
-  {
-    name: 'react-icons',
-    importPath: 'react-icons/fi', // Feather icons subset - most common
-    commonIcons: [
-      'FiHome', 'FiSettings', 'FiUser', 'FiSearch', 'FiMenu',
-      'FiBell', 'FiMail', 'FiCalendar', 'FiClock', 'FiStar',
-      'FiHeart', 'FiPlus', 'FiMinus', 'FiX', 'FiCheck',
-      'FiChevronRight', 'FiChevronLeft', 'FiChevronDown', 'FiChevronUp',
-      'FiArrowRight', 'FiArrowLeft', 'FiArrowUp', 'FiArrowDown',
-      'FiEdit', 'FiTrash', 'FiDownload', 'FiUpload', 'FiShare',
-      'FiFilter', 'FiRefreshCw', 'FiEye', 'FiEyeOff',
-    ],
-    importStyle: 'named',
-    description: 'React Icons - Popular icon packs as React components',
-  },
-  {
-    name: '@phosphor-icons/react',
-    importPath: '@phosphor-icons/react',
-    commonIcons: [
-      'House', 'Gear', 'User', 'MagnifyingGlass', 'List',
-      'Bell', 'Envelope', 'Calendar', 'Clock', 'Star',
-      'Heart', 'Plus', 'Minus', 'X', 'Check',
-      'CaretRight', 'CaretLeft', 'CaretDown', 'CaretUp',
-      'ArrowRight', 'ArrowLeft', 'ArrowUp', 'ArrowDown',
-      'PencilSimple', 'Trash', 'DownloadSimple', 'UploadSimple', 'ShareNetwork',
-      'Funnel', 'ArrowsClockwise', 'Eye', 'EyeSlash',
-    ],
-    importStyle: 'named',
-    description: 'Phosphor Icons - Flexible icon family',
-  },
-];
-
-/**
- * Detects installed icon packages by checking package.json
- * Returns the first detected icon package info, or null if none found
- */
-function detectInstalledIconPackage(projectPath?: string): IconPackageInfo | null {
-  const cwd = projectPath || process.cwd();
-  const packageJsonPath = path.join(cwd, 'package.json');
-
-  try {
-    if (!fs.existsSync(packageJsonPath)) {
-      return null;
-    }
-
-    const packageJson = JSON.parse(fs.readFileSync(packageJsonPath, 'utf-8'));
-    const allDeps = {
-      ...packageJson.dependencies,
-      ...packageJson.devDependencies,
-    };
-
-    // Check each known icon package
-    for (const iconPackage of KNOWN_ICON_PACKAGES) {
-      if (allDeps[iconPackage.name]) {
-        return iconPackage;
-      }
-    }
-
-    return null;
-  } catch (error) {
-    // If we can't read package.json, assume no icon package
-    return null;
-  }
-}
-
-/**
- * Generates icon usage instructions for the prompt
- * Uses smart detection to enable real icons when a supported icon package is installed
- */
-function generateIconInstructions(components: DiscoveredComponent[], projectPath?: string): string[] {
-  const instructions: string[] = [];
-
-  // First, check if an icon package is installed in the project
-  const installedIconPackage = detectInstalledIconPackage(projectPath);
-
-  if (installedIconPackage) {
-    // Icon package detected - enable icon usage with the installed package
-    const sampleIcons = installedIconPackage.commonIcons.slice(0, 20).join(', ');
-    instructions.push(
-      '',
-      '✅ ICON LIBRARY AVAILABLE ✅',
-      `You have ${installedIconPackage.name} installed in this project.`,
-      `${installedIconPackage.description}`,
-      '',
-      '📦 How to use icons:',
-      `   Import path: import { IconName } from '${installedIconPackage.importPath}';`,
-      `   Example icons: ${sampleIcons}`,
-      '',
-      '🎯 ICON BEST PRACTICES:',
-      '   - Use icons to enhance visual clarity and user experience',
-      '   - Common use cases: navigation, actions, status indicators, decorative elements',
-      '   - Icons should complement text, not replace it entirely for accessibility',
-      '   - Use consistent icon sizing (typically 16-24px for inline, 24-48px for prominent)',
-      '',
-      '⚠️ IMPORTANT:',
-      `   - ONLY import icons from '${installedIconPackage.importPath}'`,
-      '   - Do NOT import from other icon libraries not installed in the project',
-      '   - If you need an icon that may not exist, use a similar common icon from the list above',
-      ''
-    );
-    return instructions;
-  }
-
-  // No icon package installed - check if design system has icon components
-  const iconComponents = components.filter(c =>
-    c.name && typeof c.name === 'string' &&
-    (c.name.toLowerCase().includes('icon') || c.name === 'Icon' || c.name === 'v-icon' || c.name === 'mat-icon' || c.name === 'sl-icon')
-  );
-
-  if (iconComponents.length > 0) {
-    // Design system has icon support - allow those, prohibit external libraries
-    const allowedIconNames = iconComponents.map(c => c.name).join(', ');
-    instructions.push(
-      '',
-      '🔶 ICON USAGE RULES 🔶',
-      `Your design system includes icon components: ${allowedIconNames}`,
-      '✅ You MAY use these icon components from the Available components list',
-      '🚫 Do NOT import from external icon libraries:',
-      '   - @tabler/icons-react, @tabler/icons',
-      '   - react-icons, lucide-react, @heroicons/react',
-      '   - @fortawesome/react-fontawesome, @phosphor-icons/react',
-      '   - Any other external icon package',
-      'If you need icons beyond what the design system provides, use Unicode symbols (→ ✓ + ×) or text labels instead.',
-      ''
-    );
-  } else {
-    // No icon components discovered - prohibit all icon imports
-    instructions.push(
-      '',
-      '🔴 ICON IMPORT RESTRICTION 🔴',
-      'This design system does not include icon components in the available components list.',
-      '🚫 Do NOT import from ANY icon library:',
-      '   - @tabler/icons-react, @tabler/icons',
-      '   - react-icons, lucide-react, @heroicons/react',
-      '   - @fortawesome/react-fontawesome, @phosphor-icons/react',
-      '   - @mui/icons-material, @chakra-ui/icons',
-      '   - Any other icon package',
-      '✅ Instead, use:',
-      '   - Unicode symbols: → ✓ ✗ + − × ÷ • ★ ♦ ▶ ◀ ▲ ▼',
-      '   - Text labels: "Add", "Remove", "Edit", "Delete"',
-      '   - Badge or Button components with text content',
-      'Icons are NOT in the available components list and WILL cause import errors.',
-      ''
-    );
-  }
-
-  return instructions;
+function generateIconInstructions(components: DiscoveredComponent[], config?: StoryUIConfig, options?: StoryGenerationOptions): string[] {
+  const vocab = options?.icons ?? deriveIconVocabulary({
+    projectRoot: process.cwd(),
+    importPath: config?.importPath,
+    configuredPackage: config?.iconImports?.package,
+    components: components as any[],
+  });
+  return formatIconRules(vocab, options?.framework && options.framework !== 'react' ? 'html' : 'jsx');
 }
 
 /**
@@ -255,11 +49,25 @@ export interface FrameworkAwarePrompt extends Omit<FrameworkPrompt, 'layoutInstr
  * @param config - The StoryUI configuration object
  * @returns Array of layout instruction strings to be included in the prompt
  */
-export function generateLayoutInstructions(config: StoryUIConfig): string[] {
+export function generateLayoutInstructions(config: StoryUIConfig, options?: StoryGenerationOptions): string[] {
   const instructions: string[] = [];
   const layoutRules = config.layoutRules;
 
+  /**
+   * When the design system states its own spacing mechanism, the adapter's
+   * common rules carry it (knowledge/spacingFacts.ts) and the pixel doctrine
+   * below is withheld: it taught `gap: "16px"` and `marginTop: "24px"` to
+   * Carbon, Mantine and Tailwind projects alike, and the model copied it over
+   * the `Stack.gap` sitting in its own catalog.
+   */
+  const derived = options?.spacing?.hasScale === true;
+  if (derived) {
+    instructions.push('SPACING: follow the "MANDATORY SPACING & LAYOUT RULES — DERIVED FROM THIS DESIGN SYSTEM" section. No inline pixel/rem margins, paddings or gaps.');
+    instructions.push('');
+  }
+
   // MANDATORY VERTICAL SPACING RULES - These are non-negotiable for professional UI quality
+  if (!derived) {
   instructions.push('MANDATORY VERTICAL SPACING RULES (NON-NEGOTIABLE):');
   instructions.push('');
   instructions.push('** CRITICAL: Every component MUST have proper vertical spacing. Components without spacing look broken and unprofessional. **');
@@ -291,8 +99,21 @@ export function generateLayoutInstructions(config: StoryUIConfig): string[] {
   instructions.push('   - render: () => <div style={{ padding: "24px" }}>...content...</div>');
   instructions.push('   - This ensures content has breathing room within the Storybook canvas');
   instructions.push('');
+  }
 
-  if (layoutRules.multiColumnWrapper && layoutRules.columnComponent) {
+  // The config's wrapper/column names are stated only when the catalog
+  // confirms they exist; a config naming `Grid` where no Grid is exported
+  // (Sail Shelf) would otherwise instruct the model to import a phantom.
+  const columns = options?.spacing?.columns;
+  if (derived) {
+    if (columns?.column) {
+      instructions.push('MULTI-COLUMN LAYOUT RULES:');
+      instructions.push(`- For ANY multi-column layout (2, 3, or more columns), use ${columns.wrapper} with each column in its own ${columns.column}`);
+      instructions.push(`- Structure: <${columns.wrapper}><${columns.column}>column 1</${columns.column}><${columns.column}>column 2</${columns.column}></${columns.wrapper}>`);
+      instructions.push(`- NEVER use CSS properties as props (like display="grid" or gridTemplateColumns) - these are not valid props`);
+      instructions.push('');
+    }
+  } else if (layoutRules.multiColumnWrapper && layoutRules.columnComponent) {
     instructions.push('MULTI-COLUMN LAYOUT RULES:');
     instructions.push(`- For ANY multi-column layout (2, 3, or more columns), use ${layoutRules.multiColumnWrapper} components`);
     instructions.push(`- Each column must be wrapped in its own ${layoutRules.columnComponent} element`);
@@ -313,7 +134,7 @@ export function generateLayoutInstructions(config: StoryUIConfig): string[] {
   instructions.push(`- Use semantic heading components from your design system instead of raw <h1>-<h6> tags`);
   instructions.push(`- Use the design system's layout components and spacing tokens instead of inline styles when available`);
   instructions.push(`- Prefer design system components over plain HTML elements for consistent styling`);
-  instructions.push(`- ALWAYS test mentally: "Does this component have enough visual breathing room?" If not, add spacing.`);
+  if (!derived) instructions.push(`- ALWAYS test mentally: "Does this component have enough visual breathing room?" If not, add spacing.`);
 
   return instructions;
 }
@@ -341,7 +162,7 @@ export async function generateFrameworkAwarePrompt(
   const frameworkPrompt = await registry.generatePrompt(config, components, options);
 
   // Generate layout instructions (framework-agnostic)
-  const layoutInstructions = generateLayoutInstructions(config);
+  const layoutInstructions = generateLayoutInstructions(config, options);
 
   return {
     ...frameworkPrompt,
@@ -436,7 +257,7 @@ export async function buildFrameworkAwarePrompt(
   }
 
   // Smart icon handling - detect installed icon packages or fall back to design system icons
-  const iconInstructions2 = generateIconInstructions(components);
+  const iconInstructions2 = generateIconInstructions(components, config, options);
   promptParts.push(...iconInstructions2);
 
   // Add framework-specific rules


### PR DESCRIPTION

The prompt taught one spacing doctrine to every design system — inline
`padding: "24px"`, `marginTop: "24px"`, "MINIMUM 16px gap" — and every
review found the result: inline pixel layout in 14/22 Carbon, 22/22 Sail
Shelf and 17/20 Mantine stories. Replaced by facts read from the project:

- gap primitives (any component with a gap/spacing prop) with the values
  the prop's own type or the stylesheet's class family allows; utility
  steps counted from the team's own stories; a spacing-token scale; colour
  tiers from `--x: var(--y)` alias chains, semantic names first;
- layout rules only name wrappers the catalog actually has; a system with
  tokens but no primitive gets one grid recipe; a system with neither keeps
  the old inline examples, labelled as the fallback;
- icon packages judged by their manifests (project deps and the design
  system's own), export names from declarations; placeholder components
  first, remote photos only for real photos; text glyphs are never icons.

Deterministic checks beside the token check, fed to self-healing: inline
pixel spacing where a scale exists, primitive tokens where an alias exists,
icon imports outside the derived packages; repair candidates that add
literals are rejected. The prop-conformance check is wired here too.

Measured before → after on Carbon's settings page: 27 → 2 inline styles,
21 → 0 pixel literals, 6 → 0 font overrides, 2 → 0 blockers.


https://claude.ai/code/session_0158a8zxX4SKPdxm7DLfgqp4
