### PR TITLE
fix(generator): open unions stay open; findings attributed by nearest owner; atomic story writes

### DIFF
--- a/__tests__/prop-doc-extraction.test.ts
+++ b/__tests__/prop-doc-extraction.test.ts
@@ -438,3 +438,32 @@ export interface FancyButtonProps {
     expect(prop('variant')?.optionsOpen).toBeUndefined();
   });
 });
+
+describe('open unions stay open', () => {
+  it('marks a prop whose union admits any string as open, even inside OverridableStringUnion', async () => {
+    const root = make('@acme/open', {
+      'typography.d.ts': `
+import { OverridableStringUnion } from '@mui/types';
+export interface TypographyOwnProps {
+  /** The colour. */
+  color?: OverridableStringUnion<'primary' | 'secondary' | 'error' | (string & {}), TypographyPropsColorOverrides>;
+  /** The variant. */
+  variant?: 'body1' | 'body2' | 'h1';
+  /** Alignment. */
+  align?: 'left' | 'center' | string;
+}
+export interface TypographyPropsColorOverrides {}
+export interface TypographyProps extends TypographyOwnProps {}
+export declare const Typography: (props: TypographyProps) => JSX.Element;
+`,
+    });
+    const out: any = await extractProps('@acme/open', root, { force: true });
+    const props = (out.components?.Typography ?? out.Typography)?.props ?? [];
+    const by = (n: string) => props.find(p => p.name === n)!;
+    expect(by('color').options).toEqual(expect.arrayContaining(['primary', 'secondary', 'error']));
+    expect(by('color').optionsOpen).toBe(true);
+    expect(by('align').optionsOpen).toBe(true);
+    expect(by('variant').options).toEqual(['body1', 'body2', 'h1']);
+    expect(by('variant').optionsOpen).toBeFalsy();
+  });
+});

--- a/story-generator/knowledge/propExtractor.ts
+++ b/story-generator/knowledge/propExtractor.ts
@@ -118,6 +118,20 @@ export interface ExtractedProps {
 /** Long unions and generics hurt more than they help inside a prompt. */
 const MAX_TYPE_TEXT = 80;
 
+/**
+ * Does this type admit any string? `(string & {})` — the widen-proof idiom —
+ * or a bare `string` arm makes the literal options a hint, not a closed set.
+ * MUI's Typography `color` is `OverridableStringUnion<'primary' | … |
+ * (string & {}), Overrides>`; judging `color="text.secondary"` against the
+ * literals rejected correct code on every MUI prompt.
+ */
+export function typeAdmitsAnyString(node: ts.TypeNode | undefined): boolean {
+  if (!node) return false;
+  let text = '';
+  try { text = node.getText(); } catch { text = ''; }
+  return /\bstring\s*&\s*\{\s*\}|(^|[|<(,\s])string\s*($|[|>),\s])/.test(text);
+}
+
 export function shortType(node: ts.TypeNode | undefined, source: ts.SourceFile): string | undefined {
   if (!node) return undefined;
   const text = node.getText(source).replace(/\s+/g, ' ').trim();
@@ -398,6 +412,7 @@ function collectFromFile(
       if (!/^[a-zA-Z_$][\w$]*$/.test(name)) continue;
       if (name.startsWith('_')) continue;
       const opts = literalOptions(member.type);
+      const open = typeAdmitsAnyString(member.type);
       found.push({
         name,
         type: shortType(member.type, source),
@@ -405,7 +420,7 @@ function collectFromFile(
         ...readDoc(member, source),
         // Deduped and capped: a handful of variants is a control, forty is a
         // list nobody scrolls.
-        ...(opts.length > 1 && opts.length <= 24 ? { options: [...new Set(opts)] } : {}),
+        ...(opts.length > 1 && opts.length <= 24 ? { options: [...new Set(opts)], ...(open ? { optionsOpen: true } : {}) } : {}),
       });
     }
     return found;
@@ -644,7 +659,7 @@ function collectFromFile(
           type: shortType(member.type, source),
           required: !member.questionToken,
           ...readDoc(member, source),
-          ...(opts.length > 1 && opts.length <= 24 ? { options: [...new Set(opts)] } : {}),
+          ...(opts.length > 1 && opts.length <= 24 ? { options: [...new Set(opts)], ...(typeAdmitsAnyString(member.type) ? { optionsOpen: true } : {}) } : {}),
         });
       }
 
@@ -1318,7 +1333,7 @@ function collectPropTypes(source: ts.SourceFile, out: Record<string, ComponentFa
  *    exported component rather than a `<Name>Props` convention; a path given
  *    as the package no longer reads node_modules.
  */
-const EXTRACTOR_SCHEMA = 6 // 6: OverridableStringUnion literals; caches written before it hid MUI's variant/color/size;
+const EXTRACTOR_SCHEMA = 7 // 7: optionsOpen from the member's own type text; 6: OverridableStringUnion literals; caches written before it hid MUI's variant/color/size;
 
 /**
  * Keyed on version AND a content fingerprint (`knowledge/cacheKey`).

--- a/story-generator/storyArtifacts.ts
+++ b/story-generator/storyArtifacts.ts
@@ -107,6 +107,20 @@ export function rewriteStylesheetImport(code: string, target: string): string {
  * The model cannot know the hashed filename, so it is told to import
  * `./styles.module.css`; that import is rewritten here to the real sibling.
  */
+/**
+ * Write through a temporary name and rename into place. Storybook's indexer
+ * reacts to the CREATE event and can read the file before its bytes are all
+ * there; a story it parsed half-written stays out of the index until that
+ * file changes again — two stories in the confirmation run were served by
+ * Vite yet absent from the index fifteen minutes later. A rename is atomic:
+ * the watcher sees a complete file or nothing.
+ */
+function writeAtomically(target: string, content: string): void {
+  const tmp = path.join(path.dirname(target), `.${path.basename(target)}.${process.pid}.tmp`);
+  fs.writeFileSync(tmp, content, 'utf-8');
+  fs.renameSync(tmp, target);
+}
+
 export function writeStoryArtifacts(args: {
   dir: string;
   fileName: string;
@@ -136,7 +150,7 @@ export function writeStoryArtifacts(args: {
       ? css.trim()
       : `${GENERATED_CSS_MARKER}\n${css.trim()}\n`;
     fs.writeFileSync(cssPath, body, 'utf-8');
-    fs.writeFileSync(storyPath, code, 'utf-8');
+    writeAtomically(storyPath, code);
     logger.log(`🎨 Wrote stylesheet ${cssName}`);
     return { storyPath, stylesheetPath: cssPath, code };
   }
@@ -148,7 +162,7 @@ export function writeStoryArtifacts(args: {
     try { fs.unlinkSync(staleCss); } catch { /* best effort */ }
   }
 
-  fs.writeFileSync(storyPath, code, 'utf-8');
+  writeAtomically(storyPath, code);
   return { storyPath, code };
 }
 

--- a/story-generator/verify/probes/a11y.ts
+++ b/story-generator/verify/probes/a11y.ts
@@ -31,6 +31,8 @@ export interface A11yViolation {
   nodeCount: number;
   /** First offending element, as a selector. */
   selector?: string;
+  /** The component that wrote the first offending element (React fiber owner), when known. */
+  owner?: string | null;
   /** axe's own failure summary for the first node. */
   detail?: string;
 }
@@ -215,6 +217,47 @@ export async function runA11yProbe(page: any, tooling: HostTooling): Promise<A11
           region: { enabled: false },
         },
       });
+      // Who wrote the offending element: the same fiber-owner rule the other
+      // probes use, with the nearest attributable ancestor as fallback. A
+      // Mantine Rating star (`svg.m_5662a89a`, a hashed class no selector
+      // pattern can recognise) blocked a correct story for 1.30:1 contrast on
+      // the library's own empty-star glyph.
+      const ownerOf = (node: any): string | null => {
+        const nm = (t: any): string | null => {
+          if (!t) return null;
+          if (typeof t === 'string') return null;
+          if (typeof t === 'function') return t.displayName || t.name || null;
+          if (typeof t === 'object') return t.displayName || nm(t.render) || nm(t.type) || null;
+          return null;
+        };
+        const NOISE = /^(Fragment|ForwardRef|Memo|Unknown|Anonymous|Slot|Provider|_c\d*)$/;
+        const walk = (el: any): string | null => {
+          const key = Object.keys(el).find((k: string) => k.startsWith('__reactFiber$') || k.startsWith('__reactInternalInstance$'));
+          if (!key) return null;
+          let f: any = el[key];
+          let guard = 0;
+          while (f && guard++ < 200) {
+            if (typeof f.type !== 'string' && f.type) {
+              const n = (nm(f.type) || '').replace(/^.*\//, '');
+              if (n && !NOISE.test(n)) return n;
+            }
+            f = f.return;
+          }
+          return null;
+        };
+        let el: any = node;
+        let hops = 0;
+        while (el && hops++ < 12) {
+          const n = walk(el);
+          if (n) return n;
+          el = el.parentElement;
+        }
+        return null;
+      };
+      const ownerFor = (selector: string | undefined): string | null => {
+        if (!selector) return null;
+        try { const el = document.querySelector(selector); return el ? ownerOf(el) : null; } catch { return null; }
+      };
       return {
         violations: (results.violations || []).map((v: any) => ({
           id: v.id,
@@ -223,6 +266,7 @@ export async function runA11yProbe(page: any, tooling: HostTooling): Promise<A11
           nodeCount: (v.nodes || []).length,
           selector: v.nodes?.[0]?.target?.[0],
           detail: v.nodes?.[0]?.failureSummary,
+          owner: ownerFor(v.nodes?.[0]?.target?.[0]),
         })),
         passCount: (results.passes || []).length,
       };

--- a/story-generator/verify/probes/interaction.ts
+++ b/story-generator/verify/probes/interaction.ts
@@ -190,12 +190,33 @@ export async function runInteractionProbe(
         const NOISE = /^(Fragment|ForwardRef|Memo|Unknown|Anonymous|Slot|Provider|_c\d*)$/;
         let f: any = node[key];
         let guard = 0;
-        while (f && guard++ < 40) {
+        while (f && guard++ < 200) {
           if (typeof f.type !== 'string' && f.type) {
             const n = (nm(f.type) || '').replace(/^.*\//, '');
             if (n && !NOISE.test(n)) return n;
           }
           f = f.return;
+        }
+        // Nothing named on this element's own fiber path (a star inside a
+        // Rating, a ripple span): the nearest ancestor that IS attributable
+        // decides. An unknown owner blocks, and both Mantine's and MUI's
+        // Rating markup blocked correct stories for want of a name.
+        let up: any = (node as Element).parentElement;
+        let hops = 0;
+        while (up && hops++ < 12) {
+          const k = Object.keys(up).find((x: string) => x.startsWith('__reactFiber$') || x.startsWith('__reactInternalInstance$'));
+          if (k) {
+            let g: any = up[k];
+            let inner = 0;
+            while (g && inner++ < 200) {
+              if (typeof g.type !== 'string' && g.type) {
+                const n = (nm(g.type) || '').replace(/^.*\//, '');
+                if (n && !NOISE.test(n)) return n;
+              }
+              g = g.return;
+            }
+          }
+          up = up.parentElement;
         }
         return null;
       };

--- a/story-generator/verify/verifyStory.ts
+++ b/story-generator/verify/verifyStory.ts
@@ -260,6 +260,9 @@ export function censusFindings(problems: Awaited<ReturnType<typeof runDomCensus>
   });
 }
 
+/** How long a new story gets to reach Storybook's index. A live watcher answers in about a second; a busy one in tens. */
+export const INDEX_WAIT_MS = 60_000;
+
 export async function verifyStory(options: VerifyStoryOptions): Promise<VerifyReport> {
   const started = Date.now();
   const { storybookUrl, storyIdPrefix, title, projectRoot = process.cwd(), timeoutMs = 20000, libraryComponents, generatedDir, visualCritic, request, componentsUsed, framework } = options;
@@ -287,7 +290,9 @@ export async function verifyStory(options: VerifyStoryOptions): Promise<VerifyRe
   // machine, a story the harness later found within a minute was reported
   // "not in the index" at thirty seconds. A live watcher (polling) still
   // answers in about a second; the cap only matters when it is busy.
-  const indexed = await waitForStoryIndexed(storybookUrl, storyIdPrefix, Math.min(60000, timeoutMs), 250, title, options.fileName);
+  // Independent of the render timeout: that defaults to 20s and capped the
+  // index wait with it, so a story indexed at 25s was reported missing.
+  const indexed = await waitForStoryIndexed(storybookUrl, storyIdPrefix, INDEX_WAIT_MS, 250, title, options.fileName);
   if (!indexed.indexed || !indexed.storyId) {
     // Down, stale watcher, or not picked up yet? Reachability and the counts
     // answer it, and the three need different responses from whoever reads
@@ -569,7 +574,8 @@ export async function verifyStory(options: VerifyStoryOptions): Promise<VerifyRe
       for (const v of a11y.violations) {
         // A violation on markup the library renders is not something the story
         // can fix, however severe the rule.
-        const libraryInternal = isDesignSystemInternal(v.selector);
+        const libraryInternal = isDesignSystemInternal(v.selector)
+          || (!!v.owner && (libraryComponents ?? []).includes(v.owner));
         /**
          * Unreadable text blocks, unless the library rendered it.
          *


### PR DESCRIPTION

From the 5.3.0 confirmation run on four design systems:

- MUI's Typography `color` is `OverridableStringUnion<'primary' | … |
  (string & {}), …>`; the extractor kept the literals and lost the
  `(string & {})`, so `color="text.secondary"` was rejected on every MUI
  prompt and the repair steered to a wrong colour. Any union that admits a
  string is recorded as open, in both option readers, and never judged.
- A Rating star (Mantine `svg.m_…`, MUI's `MuiRating-root` span) had no
  named component on its own fiber path; unknown ownership blocks, so
  correct stories were repaired for the library's own glyphs. The owner
  walk goes deeper and falls back to the nearest attributable ancestor, and
  axe violations are attributed the same way instead of by class pattern.
- Two stories were served by Vite yet absent from the index fifteen
  minutes later: the indexer read the file on its CREATE event before the
  bytes were all there. Stories are written to a temporary name and
  renamed into place. The index wait is its own 60s, no longer capped by
  the 20s render timeout.



Full suite green (1163 tests) at commit time.

https://claude.ai/code/session_0158a8zxX4SKPdxm7DLfgqp4
