### PR TITLE
fix(ui): design context does not count a README the generator never reads

### DIFF
--- a/mcp-server/routes/designContext.ts
+++ b/mcp-server/routes/designContext.ts
@@ -50,6 +50,8 @@ interface DocFile {
   chars: number;
   overBudget: boolean;
   updatedAt: string;
+  /** A README: read by people, skipped by the loader, not counted. */
+  instructional?: boolean;
 }
 
 function listDocs(): DocFile[] {
@@ -66,6 +68,10 @@ function listDocs(): DocFile[] {
         name: f,
         chars,
         overBudget: chars > PER_FILE_CHAR_BUDGET,
+        // The loader skips READMEs (they instruct the author, not the model),
+        // so the panel must not count one toward the budget — the scaffold's
+        // README alone read as "2.0k / 24k used" of guidance that was never sent.
+        instructional: /^readme\.(md|mdx|txt)$/i.test(f),
         updatedAt: stat.mtime.toISOString(),
       };
     })
@@ -80,7 +86,7 @@ function listDocs(): DocFile[] {
 export function getDesignContext(_req: Request, res: Response): void {
   try {
     const files = listDocs();
-    const totalChars = files.reduce((sum, f) => sum + f.chars, 0);
+    const totalChars = files.reduce((sum, f) => sum + (f.instructional ? 0 : f.chars), 0);
     res.json({
       exists: fs.existsSync(docsDir()),
       dir: DOCS_DIRNAME,

--- a/templates/StoryUI/DesignContextPanel.tsx
+++ b/templates/StoryUI/DesignContextPanel.tsx
@@ -19,6 +19,8 @@ interface DocFile {
   name: string;
   chars: number;
   overBudget: boolean;
+  /** A README the loader skips; shown, editable, never counted. */
+  instructional?: boolean;
   updatedAt: string;
 }
 
@@ -240,8 +242,8 @@ export const DesignContextPanel: React.FC<DesignContextPanelProps> = ({
               >
                 <button type="button" className="sui-context-item-open" onClick={() => openDoc(f.name)}>
                   <span className="sui-context-item-name">{f.name}</span>
-                  <span className={`sui-context-item-size ${f.overBudget ? 'sui-context-item-size--over' : ''}`}>
-                    {(f.chars / 1000).toFixed(1)}k
+                  <span className={`sui-context-item-size ${f.overBudget ? 'sui-context-item-size--over' : ''}`} title={f.instructional ? 'README files guide you; the generator does not read them' : undefined}>
+                    {f.instructional ? 'not sent' : `${(f.chars / 1000).toFixed(1)}k`}
                   </span>
                 </button>
                 <button


### PR DESCRIPTION
The loader skips READMEs as instructional; the tab counted the scaffold's 2.0k README toward the 24k budget. Listed as "not sent" and excluded from the total. Full suite green at commit time.

https://claude.ai/code/session_0158a8zxX4SKPdxm7DLfgqp4