### PR TITLE
feat(generator): nothing broken ships — overflow probe, shippable critic, and a regeneration gate

### DIFF
--- a/__tests__/gate.test.ts
+++ b/__tests__/gate.test.ts
@@ -1,0 +1,50 @@
+import { describe, it, expect } from 'vitest';
+import { gateVerdict, pickBest, gateMaxAttempts, gateFeedback, gateStatusLine } from '../story-generator/verify/gate';
+
+const report = (outcome: any, findings: any[] = [], reason?: string): any => ({ outcome, findings, reason, metrics: {} });
+const blocker = (id: string, repairable = true, cls = 'code') => ({ id, severity: 'blocker', repairable, class: cls, message: `${id} broke`, evidence: 'x' });
+
+describe('gate verdict', () => {
+  it('passes a verified story with no story-authored blockers', () => {
+    const v = gateVerdict(report('verified', [{ id: 'w', severity: 'warning', message: 'meh' }]));
+    expect(v).toMatchObject({ shippable: true, retryable: false, rendered: true, verified: true, warnings: 1 });
+  });
+  it('does not retry what verification could not judge', () => {
+    const v = gateVerdict(report('not_verified', [], 'Storybook at http://x is not reachable'));
+    expect(v).toMatchObject({ shippable: false, retryable: false, verified: false });
+    expect(v.reason).toContain('not reachable');
+    expect(gateVerdict(undefined)).toMatchObject({ shippable: false, retryable: false });
+  });
+  it('retries a story the browser could not render, and one with story-authored blockers', () => {
+    const dead = gateVerdict(report('issues', [{ id: 'render-failed', severity: 'blocker', message: 'the story threw', repairable: true }]));
+    expect(dead).toMatchObject({ shippable: false, retryable: true, rendered: false });
+    const blocked = gateVerdict(report('issues', [blocker('content_escapes-1'), blocker('lib-thing', false)]));
+    expect(blocked.blockers.map(b => b.id)).toEqual(['content_escapes-1']);
+    expect(blocked.retryable).toBe(true);
+    // Only library-attributed blockers: nothing the story can fix, so it ships.
+    expect(gateVerdict(report('issues', [blocker('lib-thing', false)])).shippable).toBe(true);
+  });
+});
+
+describe('best attempt and retry instructions', () => {
+  it('keeps the rendered, least-blocked, latest attempt', () => {
+    const a = { n: 1, verdict: gateVerdict(report('issues', [blocker('a'), blocker('b')])) };
+    const b = { n: 2, verdict: gateVerdict(report('issues', [blocker('a')])) };
+    const c = { n: 3, verdict: gateVerdict(report('issues', [{ id: 'render-failed', severity: 'blocker', message: 'threw', repairable: true }])) };
+    expect(pickBest([a, b, c]).n).toBe(2);
+    const d = { n: 4, verdict: gateVerdict(report('issues', [blocker('a')])) };
+    expect(pickBest([a, b, d]).n).toBe(4);
+  });
+  it('bounds attempts and turns blockers into instructions', () => {
+    expect(gateMaxAttempts({})).toBe(3);
+    expect(gateMaxAttempts({ STORY_UI_GATE_ATTEMPTS: '9' })).toBe(5);
+    expect(gateMaxAttempts({ STORY_UI_GATE_ATTEMPTS: '0' })).toBe(1);
+    const v = gateVerdict(report('issues', [blocker('content_escapes-0')]));
+    expect(gateFeedback(v)[0]).toContain('content_escapes-0 broke');
+    expect(gateStatusLine(1, gateVerdict(report('verified')), 1)).toBeNull();
+    expect(gateStatusLine(2, gateVerdict(report('verified')), 2)).toContain('attempt 2 of 2');
+    expect(gateStatusLine(3, v, 2)).toContain('3 attempts; 1 blocker');
+    const dead = gateVerdict(report('issues', [{ id: 'render-failed', severity: 'blocker', message: 'threw', repairable: true }]));
+    expect(gateStatusLine(3, dead, 3)).toContain('did not render in a browser on any of 3 attempts');
+  });
+});

--- a/__tests__/overflow-probe.test.ts
+++ b/__tests__/overflow-probe.test.ts
@@ -1,0 +1,88 @@
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { resolveHostTooling } from '../story-generator/verify/hostTooling.js';
+import { acquireBrowser, closeBrowserSession } from '../story-generator/verify/browserSession.js';
+import { runOverflowProbe } from '../story-generator/verify/probes/overflow.js';
+
+const tooling = resolveHostTooling('/Users/tjpitre/Sites/test-storybooks/react-mantine');
+let browser: any;
+beforeAll(async () => { if (!tooling) return; browser = await acquireBrowser(tooling).catch(() => undefined); }, 60_000);
+afterAll(async () => { await closeBrowserSession(); });
+
+async function probe(html: string) {
+  const page = await browser.newPage({ viewport: { width: 1200, height: 800 } });
+  await page.setContent(`<style>body{margin:0;font-family:Arial}</style><div id="storybook-root">${html}</div>`);
+  await page.waitForTimeout(60);
+  const result = await runOverflowProbe(page);
+  await page.close();
+  return result;
+}
+const tile = (inner: string, w = 200) =>
+  `<div style="display:grid;grid-template-columns:repeat(3,${w}px);gap:16px;padding:24px">
+     <div style="border:1px solid #999;padding:16px;overflow:visible">${inner}</div>
+     <div style="border:1px solid #999;padding:16px">ARTICLES<div style="font-size:48px">128</div></div>
+     <div style="border:1px solid #999;padding:16px">FOLLOWERS<div style="font-size:48px">1,240</div></div>
+   </div>`;
+
+describe.runIf(tooling)('overflow probe — content escaping its box', { retry: 2 }, () => {
+  it('flags a stat value wider than its tile, with the pixels and the fix', async () => {
+    const r = await probe(tile(`SEA MILES<div style="font-size:64px;white-space:nowrap;font-weight:700">34,600 <span style="font-size:20px">nm</span></div>`));
+    const hits = r.problems.filter(p => p.kind === 'content_escapes');
+    expect(hits).toHaveLength(1);
+    expect(hits[0].message).toContain('34,600');
+    expect(hits[0].message).toMatch(/paints \d+px outside the right edge/);
+    expect(hits[0].message).toContain('type scale');
+  }, 30_000);
+
+  it('passes a value that fits', async () => {
+    const r = await probe(tile(`SEA MILES<div style="font-size:32px">34,600</div>`));
+    expect(r.problems.filter(p => p.kind === 'content_escapes')).toHaveLength(0);
+  }, 30_000);
+
+  it('ignores a badge the source positioned outside the card on purpose', async () => {
+    const r = await probe(`<div style="position:relative;border:1px solid #999;width:300px;height:120px;margin:40px">
+      <span style="position:absolute;top:-12px;right:-12px;background:#c00;color:#fff;padding:4px 8px">New</span>Body</div>`);
+    expect(r.problems.filter(p => p.kind === 'content_escapes')).toHaveLength(0);
+  }, 30_000);
+});
+
+describe.runIf(tooling)('overflow probe — clipped text', { retry: 2 }, () => {
+  it('flags text cut off by overflow hidden without an ellipsis', async () => {
+    const r = await probe(`<div style="width:160px;border:1px solid #999;overflow:hidden;white-space:nowrap;padding:8px">A very long product name that will not fit here</div>`);
+    const hits = r.problems.filter(p => p.kind === 'text_clipped');
+    expect(hits).toHaveLength(1);
+    expect(hits[0].message).toContain('cut off');
+  }, 30_000);
+
+  it('accepts an ellipsis truncation', async () => {
+    const r = await probe(`<div style="width:160px;border:1px solid #999;overflow:hidden;white-space:nowrap;text-overflow:ellipsis;padding:8px">A very long product name that will not fit here</div>`);
+    expect(r.problems.filter(p => p.kind === 'text_clipped')).toHaveLength(0);
+  }, 30_000);
+});
+
+describe.runIf(tooling)('overflow probe — overlap, page width, empty boxes', { retry: 2 }, () => {
+  it('flags two in-flow siblings that overlap', async () => {
+    const r = await probe(`<div style="width:600px;white-space:nowrap"><div style="display:inline-block;width:200px;background:#eee;padding:8px">Left</div><div style="display:inline-block;position:relative;left:-120px;width:200px;background:#ddd;padding:8px">Right</div></div>`);
+    const hits = r.problems.filter(p => p.kind === 'sibling_overlap');
+    expect(hits).toHaveLength(1);
+    expect(hits[0].message).toContain('overlap');
+  }, 30_000);
+
+  it('does not flag a negative-margin overlap the source wrote', async () => {
+    const r = await probe(`<div><div style="display:inline-block;width:40px;height:40px;border-radius:50%;background:#aaa"></div><div style="display:inline-block;width:40px;height:40px;border-radius:50%;background:#888;margin-left:-12px"></div></div>`);
+    expect(r.problems.filter(p => p.kind === 'sibling_overlap')).toHaveLength(0);
+  }, 30_000);
+
+  it('flags a page wider than the viewport and names the widest element', async () => {
+    const r = await probe(`<div style="width:1600px;background:#eee;padding:8px">Wide table</div>`);
+    const hits = r.problems.filter(p => p.kind === 'page_overflow');
+    expect(hits).toHaveLength(1);
+    expect(hits[0].message).toContain('wider than the viewport');
+  }, 30_000);
+
+  it('flags an empty bordered tile and accepts one with an icon', async () => {
+    const r = await probe(`<div style="display:flex;gap:16px"><div style="border:1px solid #999;width:200px;height:120px"></div><div style="border:1px solid #999;width:200px;height:120px"><svg width="24" height="24"><circle cx="12" cy="12" r="10"/></svg></div><hr style="width:200px"></div>`);
+    const hits = r.problems.filter(p => p.kind === 'empty_box');
+    expect(hits).toHaveLength(1);
+    expect(hits[0].message).toContain('nothing inside');
+  }, 30_000);
+});

--- a/__tests__/visual-critic-shippable.test.ts
+++ b/__tests__/visual-critic-shippable.test.ts
@@ -1,0 +1,32 @@
+import { describe, it, expect } from 'vitest';
+import { parseCritique } from '../story-generator/verify/probes/visualCritic';
+
+const reply = (findings: any[]) => JSON.stringify({ findings });
+
+describe('the critic judges shippability', () => {
+  it('turns each shippability category into a blocker that names the element and its container', () => {
+    const cats = ['overflow', 'overlap', 'clipped', 'empty', 'misaligned', 'illegible', 'unstyled', 'missing'];
+    const out = parseCritique(reply(cats.map(c => ({
+      category: c, severity: 'warning', element: `the value 34,600 nm (${c})`, container: 'the Sea Miles tile',
+      issue: `Category ${c}: the number paints past the tile's right border`, fix: 'use the next smaller size from the type scale for the value',
+    }))));
+    expect(out).toHaveLength(6); // capped, still six
+    expect(out.every(f => f.severity === 'blocker')).toBe(true);
+    expect(out.every(f => f.element && f.container === 'the Sea Miles tile')).toBe(true);
+    expect(out.map(f => f.category)).toEqual(cats.slice(0, 6));
+  });
+
+  it('drops taste, demotes unnamed or fix-less blockers to warnings; an empty list is the normal answer', () => {
+    const out = parseCritique(reply([
+      { category: 'overflow', severity: 'blocker', element: 'the value 34,600 nm', container: 'the Sea Miles tile', issue: 'The number paints past the tile', fix: 'shrink the value one step on the type scale' },
+      { category: 'other', severity: 'warning', element: 'the card', issue: 'Consider a softer shadow for the card', fix: 'maybe reduce it' },
+      { category: 'misaligned', severity: 'blocker', issue: 'Some fields are out of line with each other', fix: 'align them' },
+      { category: 'empty', severity: 'blocker', element: 'the third column', issue: 'The third column is blank where a card was expected' },
+      { severity: 'warning', element: 'the Save button', issue: 'Save and Publish carry the same weight so the primary action is ambiguous', fix: 'make Publish primary and Save secondary' },
+    ]));
+    // The unnamed misaligned finding and the fix-less empty one are kept as warnings, not blockers.
+    expect(out.map(f => [f.category, f.severity])).toEqual([['overflow', 'blocker'], [undefined, 'warning'], [undefined, 'warning'], [undefined, 'warning']]);
+    expect(parseCritique(reply([]))).toEqual([]);
+    expect(parseCritique('Looks good to me.')).toEqual([]);
+  });
+});

--- a/mcp-server/routes/generationCore.ts
+++ b/mcp-server/routes/generationCore.ts
@@ -131,6 +131,7 @@ import { isSafeStoryFileName,
 import { attemptVerificationRepair } from './verifyRepair.js';
 import type { VerifyReport, RepairSummary } from '../../story-generator/verify/findings.js';
 import { registerActiveGeneration, unregisterActiveGeneration, isGenerationCancelled, cancellationSignal } from './activeGenerations.js';
+import { gateVerdict, pickBest, gateMaxAttempts, gateFeedback, gateStatusLine, type GateVerdict } from '../../story-generator/verify/gate.js';
 
 // ============================================================
 // Public interface
@@ -168,6 +169,18 @@ export interface GenerationRequest {
    */
   storybookUrl?: string;
   voiceMode?: boolean;
+  /**
+   * Set by the shippable gate on a retry: what the browser measured on the
+   * previous attempt, as rules the next composition must satisfy.
+   */
+  gateFeedback?: string[];
+  /** Which attempt this is (1-based); recorded with the completion. */
+  gateAttempt?: number;
+  /**
+   * A retry writes the SAME story: same file, same title, same hash — never
+   * a "v2" beside the failed one.
+   */
+  regenerateOf?: { fileName: string; title: string; hash: string };
 }
 
 export interface GenerationEvents {
@@ -253,6 +266,10 @@ export interface GenerationOutcome {
    * Absent when verification could not run (no Playwright, no Storybook URL).
    */
   verification?: VerifyReport;
+  /** The generated stylesheet, when the model wrote one — so a kept attempt can be restored with it. */
+  stylesheet?: string;
+  /** What the shippable gate did: attempts spent, whether the kept attempt is shippable, and why. */
+  gate?: { attempts: number; bestAttempt: number; shippable: boolean; reason: string };
   /** Conversational, model-authored reply describing what was built. */
   chatSummary?: string;
   /** Short follow-up prompt ideas the user can click to refine. */
@@ -295,12 +312,90 @@ export async function runStoryGeneration(
   // Name the run to the client so Stop can address it.
   events.onStarted?.(activeKey);
   try {
-    return await runStoryGenerationPipeline(request, events, startedAt, activeKey);
+    return await runGatedGeneration(request, events, startedAt, activeKey);
   } finally {
     unregisterActiveGeneration(activeKey);
     // Verification and repair share one Chromium per run; it ends with the run.
     await closeBrowserSession().catch(() => undefined);
   }
+}
+
+/**
+ * The shippable gate around the pipeline.
+ *
+ * One pipeline run produces a story and a verdict. A story that rendered
+ * and has no blocker of its own ships. One that did not render, or that
+ * keeps a blocker after repair, is generated AGAIN from scratch with the
+ * browser's findings as instructions — the same file, title and id, so
+ * the user sees one story, not a failed one beside a retry — up to
+ * STORY_UI_GATE_ATTEMPTS (default 3). The best attempt is kept, and the
+ * reply says what happened: "verified clean on attempt 2", or what still
+ * stands. A story verification could not judge is reported as such and
+ * not retried; regeneration cannot fix a missing Storybook.
+ */
+async function runGatedGeneration(
+  request: GenerationRequest,
+  events: GenerationEvents,
+  startedAt: number,
+  activeKey: string,
+): Promise<GenerationOutcome> {
+  const maxAttempts = gateMaxAttempts();
+  const attempts: Array<{ result: GenerationOutcome; verdict: GateVerdict }> = [];
+  let req: GenerationRequest = request;
+  for (let attempt = 1; attempt <= maxAttempts; attempt++) {
+    const attemptEvents: GenerationEvents = attempt === 1 ? events : {
+      ...events,
+      onStarted: undefined,
+      onProgress: (step, total, phase, message, details) =>
+        events.onProgress?.(step, total, phase, `Attempt ${attempt} of ${maxAttempts}: ${message}`, details),
+    };
+    const result = await runStoryGenerationPipeline(req, attemptEvents, startedAt, activeKey);
+    const verdict = gateVerdict(result.verification);
+    attempts.push({ result, verdict });
+    logger.log(verdict.shippable
+      ? `🚦 Gate: shippable on attempt ${attempt} of ${maxAttempts} (${verdict.reason})`
+      : `🚦 Gate: attempt ${attempt} of ${maxAttempts} not shippable — ${verdict.reason}${verdict.retryable && attempt < maxAttempts ? '; regenerating with the findings' : ''}`);
+    if (verdict.shippable || !verdict.retryable || result.isFallbackStory || attempt === maxAttempts) break;
+    if (isGenerationCancelled(activeKey)) break;
+    const hash = result.fileName.match(/-([a-f0-9]{8})(?:\.stories\.\w+)?$/)?.[1]
+      ?? crypto.createHash('sha1').update(result.fileName).digest('hex').slice(0, 8);
+    req = {
+      ...request,
+      gateFeedback: gateFeedback(verdict),
+      gateAttempt: attempt + 1,
+      regenerateOf: { fileName: result.fileName, title: result.title, hash },
+    };
+    events.onProgress?.(11, 12, 'gate_retry',
+      `Attempt ${attempt} failed verification (${verdict.reason.slice(0, 80)}) — generating again with the findings`);
+  }
+
+  const best = pickBest(attempts);
+  const bestIndex = attempts.indexOf(best) + 1;
+  const last = attempts[attempts.length - 1];
+  if (best !== last) {
+    // A later attempt overwrote the file; put the kept attempt back on disk.
+    try {
+      const cfg = loadUserConfig();
+      const dir = path.resolve(process.cwd(), cfg.generatedStoriesPath || './src/stories/generated/');
+      writeStoryArtifacts({ dir, fileName: best.result.fileName, code: best.result.code, css: best.result.stylesheet ?? null });
+      logger.log(`🚦 Gate: restored attempt ${bestIndex} to disk (attempt ${attempts.length} was worse)`);
+    } catch (err) {
+      logger.warn(`🚦 Gate: could not restore attempt ${bestIndex}: ${err instanceof Error ? err.message : String(err)}`);
+    }
+  }
+  const status = gateStatusLine(attempts.length, best.verdict, bestIndex);
+  const out: GenerationOutcome = {
+    ...best.result,
+    gate: { attempts: attempts.length, bestAttempt: bestIndex, shippable: best.verdict.shippable, reason: best.verdict.reason },
+  };
+  if (status) {
+    out.chatSummary = out.chatSummary ? `${status}\n\n${out.chatSummary}` : status;
+    if (!best.verdict.shippable) {
+      out.notice = [status, out.notice].filter(Boolean).join(' ');
+      if (!best.verdict.rendered) out.suggestions = ['Try again', ...(out.suggestions ?? []).filter(s => s !== 'Try again')].slice(0, 5);
+    }
+  }
+  return out;
 }
 
 async function runStoryGenerationPipeline(
@@ -935,8 +1030,16 @@ async function runStoryGenerationPipeline(
     hasContext: intent.promptAnalysis.hasConversationContext,
   });
 
+  /**
+   * A retry from the shippable gate carries what the browser measured on the
+   * previous attempt. Appended to the request, not the system prompt, so it
+   * reads as this request's requirement.
+   */
+  const promptForModel = request.gateFeedback?.length
+    ? `${prompt}\n\nTHE PREVIOUS ATTEMPT FAILED VERIFICATION. Rendered in a browser, it had these defects:\n${request.gateFeedback.map(f => `- ${f}`).join('\n')}\nProduce a composition that CANNOT have these defects: every value stays inside its container (a shorter value or the type scale's smaller step, never a hand-set size), paired fields align, every panel holds content, nothing overlaps, and nothing beyond the request is added.`
+    : prompt;
   let initialPrompt = await buildClaudePromptWithContext(
-    prompt, config, conversation, previousCode, components, {
+    promptForModel, config, conversation, previousCode, components, {
       framework: detectedFramework,
       visionMode: visionMode as VisionPromptType | undefined,
       designSystem,
@@ -1660,7 +1763,12 @@ async function runStoryGenerationPipeline(
   let finalFileName: string;
   let storyId: string;
 
-  if (isActualUpdate && (fileName || providedStoryId)) {
+  if (request.regenerateOf) {
+    // A gate retry: the failed attempt's identity, so the retry overwrites it.
+    hash = request.regenerateOf.hash;
+    finalFileName = request.regenerateOf.fileName;
+    storyId = `story-${hash}`;
+  } else if (isActualUpdate && (fileName || providedStoryId)) {
     if (providedStoryId) {
       storyId = providedStoryId;
       // The classic panel sends the FILE NAME as storyId. Hashing the prompt
@@ -1685,7 +1793,9 @@ async function runStoryGenerationPipeline(
   }
 
   const prettyPrompt = escapeTitleForTS(aiTitle);
-  const cleanTitle = sanitizeStoryTitle(isActualUpdate ? prettyPrompt : storyTracker.getNextVersionTitle(prettyPrompt));
+  const cleanTitle = request.regenerateOf
+    ? sanitizeStoryTitle(request.regenerateOf.title)
+    : sanitizeStoryTitle(isActualUpdate ? prettyPrompt : storyTracker.getNextVersionTitle(prettyPrompt));
   if (cleanTitle !== prettyPrompt) {
     logger.log(`📋 Title "${prettyPrompt}" already exists, using "${cleanTitle}" instead`);
   }
@@ -2517,6 +2627,7 @@ async function runStoryGenerationPipeline(
           ...(verification ? {
             verification: {
               outcome: verification.outcome,
+              attempts: request.gateAttempt ?? 1,
               ...(verification.reason ? { reason: verification.reason.slice(0, 300) } : {}),
               blockers: verification.findings.filter(f => f.severity === 'blocker').length,
               warnings: verification.findings.filter(f => f.severity === 'warning').length,
@@ -2594,6 +2705,7 @@ async function runStoryGenerationPipeline(
     storyId,
     outPath,
     code: fixedFileContents,
+    stylesheet: generatedStylesheet ?? undefined,
     isUpdate: isActualUpdate,
     analysis,
     validation: {

--- a/story-generator/manifestManager.ts
+++ b/story-generator/manifestManager.ts
@@ -98,6 +98,8 @@ export interface ManifestEntry {
         warnings?: number;
         /** The badge's headline metric ("Verified in browser · 6 focusable"). */
         focusables?: number;
+        /** How many gate attempts the kept story took. */
+        attempts?: number;
         /** Compact findings, so a panel rebuilt after a reload can still expand the badge. */
         findings?: Array<{ id: string; severity: string; class?: string; message: string; evidence?: string; repairable?: boolean }>;
       };

--- a/story-generator/verify/findings.ts
+++ b/story-generator/verify/findings.ts
@@ -80,18 +80,20 @@ export interface LayerCoverage {
 export interface VerifyCoverage {
   census: LayerCoverage;
   layout: LayerCoverage;
+  /** Content escaping its box, clipped text, overlapping siblings, page overflow, empty boxes. */
+  overflow?: { ran: boolean; reason?: string };
   classes: LayerCoverage;
   interaction: LayerCoverage;
   a11y: LayerCoverage;
   visual: LayerCoverage;
 }
 
-export const LAYER_COUNT = 6;
+export const LAYER_COUNT = 7;
 
 /** How many layers ran, for the summary line and the badge. */
 export const coverageRatio = (c?: VerifyCoverage): { ran: number; total: number } => {
   if (!c) return { ran: 0, total: LAYER_COUNT };
-  const layers = [c.census, c.layout, c.classes, c.interaction, c.a11y, c.visual];
+  const layers = [c.census, c.layout, c.overflow ?? { ran: false, reason: 'overflow probe did not run' }, c.classes, c.interaction, c.a11y, c.visual];
   return { ran: layers.filter(l => l?.ran).length, total: LAYER_COUNT };
 };
 

--- a/story-generator/verify/gate.ts
+++ b/story-generator/verify/gate.ts
@@ -1,0 +1,103 @@
+/**
+ * The shippable gate.
+ *
+ * "We should never be able to generate something that is broken, looks
+ * broken, isn't able to be generated, or says it's generated but then shows
+ * you a blank story." Verification answers whether a story is any of those;
+ * this module turns that answer into a decision the pipeline acts on — try
+ * again with the findings as instructions, keep the best attempt, and say
+ * exactly what happened — rather than a badge the user reads after the fact.
+ *
+ * Pure functions, so the decision is testable without a browser.
+ */
+
+import type { Finding, VerifyReport } from './findings.js';
+
+export interface GateVerdict {
+  /** Rendered, verified, and no blocker the story itself could fix. */
+  shippable: boolean;
+  /**
+   * Whether another attempt could change the answer. A story verification
+   * could not judge (no Storybook, no browser) is not shippable AND not
+   * retryable: regenerating cannot fix the infrastructure, and pretending it
+   * might costs minutes.
+   */
+  retryable: boolean;
+  /** One line a person can read: why, and what stood in the way. */
+  reason: string;
+  rendered: boolean;
+  verified: boolean;
+  /** Blockers the story authored — the ones a regeneration can remove. */
+  blockers: Finding[];
+  warnings: number;
+}
+
+/** Blockers the story wrote: the library's own markup is not the story's to fix. */
+export function storyBlockers(report: VerifyReport): Finding[] {
+  return report.findings.filter(f => f.severity === 'blocker' && f.repairable !== false && f.class !== 'infrastructure');
+}
+
+export function gateVerdict(report: VerifyReport | undefined): GateVerdict {
+  if (!report) {
+    return { shippable: false, retryable: false, reason: 'verification did not run', rendered: true, verified: false, blockers: [], warnings: 0 };
+  }
+  const warnings = report.findings.filter(f => f.severity === 'warning').length;
+  if (report.outcome === 'not_verified') {
+    return {
+      shippable: false, retryable: false, rendered: true, verified: false, blockers: [], warnings,
+      reason: `not verified: ${report.reason || 'verification could not run'}`,
+    };
+  }
+  const rendered = !report.findings.some(f => f.id === 'render-failed' || f.id.startsWith('render-failed'));
+  const blockers = storyBlockers(report);
+  if (!rendered) {
+    const why = report.findings.find(f => f.id.startsWith('render-failed'))?.message || 'the story did not render';
+    return { shippable: false, retryable: true, rendered: false, verified: true, blockers, warnings, reason: `did not render: ${why.slice(0, 160)}` };
+  }
+  if (blockers.length > 0) {
+    return {
+      shippable: false, retryable: true, rendered: true, verified: true, blockers, warnings,
+      reason: `${blockers.length} blocker${blockers.length === 1 ? '' : 's'}: ${blockers.map(b => b.message.replace(/\s+—.*$/, '').slice(0, 90)).join('; ')}`,
+    };
+  }
+  return { shippable: true, retryable: false, rendered: true, verified: true, blockers: [], warnings, reason: warnings ? `verified, ${warnings} warning${warnings === 1 ? '' : 's'}` : 'verified clean' };
+}
+
+/**
+ * The attempt to keep: one that rendered beats one that did not; fewer
+ * story blockers beats more; fewer warnings; then the LATER attempt, which
+ * had the most instructions. Never an unverified attempt over a verified one.
+ */
+export function pickBest<T extends { verdict: GateVerdict }>(attempts: T[]): T {
+  if (attempts.length === 0) throw new Error('pickBest: no attempts');
+  return [...attempts].sort((a, b) => {
+    const av = a.verdict, bv = b.verdict;
+    if (av.shippable !== bv.shippable) return av.shippable ? -1 : 1;
+    if (av.verified !== bv.verified) return av.verified ? -1 : 1;
+    if (av.rendered !== bv.rendered) return av.rendered ? -1 : 1;
+    if (av.blockers.length !== bv.blockers.length) return av.blockers.length - bv.blockers.length;
+    if (av.warnings !== bv.warnings) return av.warnings - bv.warnings;
+    return attempts.indexOf(b) - attempts.indexOf(a);
+  })[0];
+}
+
+/** How many attempts the gate may spend, including the first. Bounded: this is minutes of the user's time. */
+export function gateMaxAttempts(env: NodeJS.ProcessEnv = process.env): number {
+  const n = Number(env.STORY_UI_GATE_ATTEMPTS ?? 3);
+  return Number.isFinite(n) ? Math.min(5, Math.max(1, Math.floor(n))) : 3;
+}
+
+/** The instructions a retry carries: what the browser measured, as a rule the next composition must satisfy. */
+export function gateFeedback(verdict: GateVerdict): string[] {
+  if (!verdict.rendered) return [`The story did not render in a browser: ${verdict.reason.replace(/^did not render: /, '')}`];
+  return verdict.blockers.slice(0, 6).map(b => `${b.message}${b.evidence ? ` (measured: ${String(b.evidence).slice(0, 140)})` : ''}`);
+}
+
+/** The sentence the reply leads with when the gate did more than pass. */
+export function gateStatusLine(attempts: number, best: GateVerdict, bestAttempt: number): string | null {
+  if (attempts === 1 && best.shippable) return null;
+  if (best.shippable) return `Verified clean on attempt ${bestAttempt} of ${attempts}; the earlier attempt${attempts - 1 === 1 ? '' : 's'} failed verification and ${attempts - 1 === 1 ? 'was' : 'were'} discarded.`;
+  if (!best.verified) return null; // infrastructure: the existing "not verified" reporting says it
+  if (!best.rendered) return `This story did not render in a browser on any of ${attempts} attempt${attempts === 1 ? '' : 's'}. The last attempt's code is kept so you can inspect it; it is not a working story. Try again, or narrow the request.`;
+  return `${attempts} attempt${attempts === 1 ? '' : 's'}; ${best.reason}. The best attempt is kept, and the issue${best.blockers.length === 1 ? '' : 's'} above still need${best.blockers.length === 1 ? 's' : ''} a fix.`;
+}

--- a/story-generator/verify/probes/overflow.ts
+++ b/story-generator/verify/probes/overflow.ts
@@ -1,0 +1,362 @@
+/**
+ * "Looks broken" — measured, not judged.
+ *
+ * A profile card whose stat value "34,600 nm" painted past the edge of its
+ * tile went out as "Verified". The design reviewer called it broken on
+ * sight; nothing in verification had compared the glyphs' box with the
+ * tile's. Every check here is that comparison, in one of five shapes:
+ *
+ *   content_escapes  a descendant's box (a text run, a child element) extends
+ *                    beyond the padding box of the nearest ancestor that draws
+ *                    a visible boundary and does not clip
+ *   text_clipped     text cut off by an ancestor that clips without an
+ *                    ellipsis or a scrollbar
+ *   sibling_overlap  two in-flow siblings whose boxes intersect
+ *   page_overflow    the document is wider than the viewport
+ *   empty_box        a bordered box of real size with nothing painted inside
+ *
+ * Thresholds are pixels, justified beside each. Intentional escape — an
+ * absolutely positioned badge on a card, a negative margin the source wrote,
+ * a transform — is not reported. Attribution is the fiber-owner rule the
+ * other probes use: a story-authored defect blocks and is repairable; one the
+ * library rendered is a warning; an unknown owner blocks, as everywhere.
+ */
+
+export type OverflowProblemKind =
+  | 'content_escapes'
+  | 'text_clipped'
+  | 'sibling_overlap'
+  | 'page_overflow'
+  | 'empty_box';
+
+export interface OverflowProblem {
+  kind: OverflowProblemKind;
+  message: string;
+  evidence: string;
+  selector?: string;
+  owner?: string;
+  ownedByLibrary?: boolean;
+}
+
+export interface OverflowResult {
+  metrics: {
+    /** Elements examined inside the story root. */
+    elements: number;
+    /** Containers that draw a boundary (the ones content can escape from). */
+    boundaries: number;
+  };
+  problems: OverflowProblem[];
+}
+
+export interface OverflowOptions {
+  /** Design system component names, so a defect can be attributed. */
+  libraryComponents?: string[];
+}
+
+export async function runOverflowProbe(page: any, options: OverflowOptions = {}): Promise<OverflowResult> {
+  return page.evaluate((opts: OverflowOptions) => {
+    const LIBRARY = new Set(opts?.libraryComponents || []);
+    const root: HTMLElement =
+      (document.querySelector('#storybook-root') as HTMLElement) ||
+      (document.querySelector('#root') as HTMLElement) ||
+      document.body;
+
+    // Sub-pixel layout, antialiasing and a focus ring account for a pixel or
+    // two; an escape a person notices is at least a glyph's width.
+    const ESCAPE_PX = 4;
+    const OVERLAP_PX = 4;
+    const MAX_CONTAINERS = 300;
+    const MAX_PROBLEMS = 12;
+
+    /** Who wrote the element — same rule as the layout probe, with the nearest attributable ancestor as fallback. */
+    const authorOf = (node: any): { owner?: string; ownedByLibrary?: boolean } => {
+      const nameOf = (t: any): string | null => {
+        if (!t) return null;
+        if (typeof t === 'string') return null;
+        if (typeof t === 'function') return t.displayName || t.name || null;
+        if (typeof t === 'object') return t.displayName || nameOf(t.render) || nameOf(t.type) || null;
+        return null;
+      };
+      const NOISE = /^(Fragment|ForwardRef|Memo|Unknown|Anonymous|Slot|Provider|_c\d*)$/;
+      const cleanName = (f: any): string | null => {
+        if (!f || typeof f.type === 'string' || !f.type) return null;
+        const n = (nameOf(f.type) || '').replace(/^.*\//, '');
+        return n && !NOISE.test(n) ? n : null;
+      };
+      const firstNamedOwner = (f: any): string | null => {
+        let o = f?._debugOwner;
+        let guard = 0;
+        while (o && guard++ < 60) {
+          const n = cleanName(o);
+          if (n) return n;
+          o = o._debugOwner;
+        }
+        return null;
+      };
+      const forElement = (el: any): { owner?: string; ownedByLibrary?: boolean } | null => {
+        const key = Object.keys(el).find((k: string) => k.startsWith('__reactFiber$') || k.startsWith('__reactInternalInstance$'));
+        if (!key) return null;
+        let f: any = el[key];
+        let last: any = f;
+        let guard = 0;
+        while (f?.return && guard++ < 60) {
+          const p = f.return;
+          if (typeof p.type === 'string' || !p.type) break;
+          const n = cleanName(p);
+          if (n && !LIBRARY.has(n)) {
+            const o = firstNamedOwner(p);
+            if (!o || !LIBRARY.has(o)) return { owner: n, ownedByLibrary: false };
+          }
+          last = p;
+          f = p;
+        }
+        const o = firstNamedOwner(last);
+        return o ? { owner: o, ownedByLibrary: LIBRARY.has(o) } : null;
+      };
+      let el: any = node && node.nodeType === 3 ? node.parentElement : node;
+      let hops = 0;
+      while (el && hops++ < 12) {
+        const r = forElement(el);
+        if (r) return r;
+        el = el.parentElement;
+      }
+      return {};
+    };
+
+    const cs = (el: Element) => getComputedStyle(el);
+    const visible = (el: Element): boolean => {
+      const s = cs(el);
+      if (s.display === 'none' || s.visibility === 'hidden' || Number(s.opacity) === 0) return false;
+      const r = el.getBoundingClientRect();
+      return r.width > 0 && r.height > 0;
+    };
+    const textOf = (el: Element): string => ((el as HTMLElement).innerText || el.textContent || '').replace(/\s+/g, ' ').trim();
+    const describe = (el: Element): string => {
+      const t = textOf(el).slice(0, 40);
+      const label = el.getAttribute('aria-label');
+      return `<${el.tagName.toLowerCase()}>${label ? ` "${label}"` : t ? ` "${t}${textOf(el).length > 40 ? '…' : ''}"` : ''}`;
+    };
+    const selectorOf = (el: Element): string => {
+      const parts: string[] = [];
+      let cur: Element | null = el;
+      let depth = 0;
+      while (cur && cur !== root && depth++ < 4) {
+        const cls = Array.from(cur.classList).slice(0, 2).map(c => `.${c}`).join('');
+        parts.unshift(`${cur.tagName.toLowerCase()}${cls}`);
+        cur = cur.parentElement;
+      }
+      return parts.join(' > ');
+    };
+    const px = (v: string) => parseFloat(v) || 0;
+    const alpha = (color: string): number => {
+      const m = color.match(/rgba?\(([^)]+)\)/);
+      if (!m) return color === 'transparent' ? 0 : 1;
+      const parts = m[1].split(',').map(s => parseFloat(s));
+      return parts.length === 4 ? parts[3] : 1;
+    };
+    /** Does this element draw an edge a person can see content cross? */
+    const drawsBoundary = (el: Element): boolean => {
+      const s = cs(el);
+      const border = ['borderTopWidth', 'borderRightWidth', 'borderBottomWidth', 'borderLeftWidth']
+        .some(k => px((s as any)[k]) > 0 && !/none|hidden/.test((s as any)[k.replace('Width', 'Style')]));
+      if (border) return true;
+      if (s.boxShadow && s.boxShadow !== 'none') return true;
+      if (s.outlineStyle && s.outlineStyle !== 'none' && px(s.outlineWidth) > 0) return true;
+      const bg = s.backgroundColor;
+      const parentBg = el.parentElement ? cs(el.parentElement).backgroundColor : 'rgba(0, 0, 0, 0)';
+      return alpha(bg) > 0 && bg !== parentBg;
+    };
+    const paddingBox = (el: Element) => {
+      const r = el.getBoundingClientRect();
+      const s = cs(el);
+      return {
+        left: r.left + px(s.borderLeftWidth), right: r.right - px(s.borderRightWidth),
+        top: r.top + px(s.borderTopWidth), bottom: r.bottom - px(s.borderBottomWidth),
+      };
+    };
+    /** Escape the source wrote on purpose, anywhere between `d` and `container`. */
+    const intentionallyOutside = (d: Element, container: Element): boolean => {
+      let cur: Element | null = d;
+      while (cur && cur !== container) {
+        const s = cs(cur);
+        if (s.position === 'absolute' || s.position === 'fixed' || s.position === 'sticky') return true;
+        if (s.transform && s.transform !== 'none') return true;
+        if (px(s.marginLeft) < 0 || px(s.marginRight) < 0 || px(s.marginTop) < 0 || px(s.marginBottom) < 0) return true;
+        if (s.float && s.float !== 'none') return true;
+        cur = cur.parentElement;
+      }
+      return false;
+    };
+    const clips = (el: Element): boolean => {
+      const s = cs(el);
+      return /hidden|clip|auto|scroll/.test(s.overflowX) || /hidden|clip|auto|scroll/.test(s.overflowY);
+    };
+    /** The nearest ancestor (inclusive) that clips, so an escape past a clipping box is judged as a clip. */
+    const textRanges = (el: Element): Array<{ node: Text; rect: DOMRect }> => {
+      const out: Array<{ node: Text; rect: DOMRect }> = [];
+      const walker = document.createTreeWalker(el, NodeFilter.SHOW_TEXT);
+      let n: Node | null;
+      while ((n = walker.nextNode())) {
+        const t = n as Text;
+        if (!t.data.trim()) continue;
+        const range = document.createRange();
+        range.selectNodeContents(t);
+        const rect = range.getBoundingClientRect();
+        if (rect.width > 0 && rect.height > 0) out.push({ node: t, rect });
+        if (out.length > 400) break;
+      }
+      return out;
+    };
+
+    const problems: OverflowProblem[] = [];
+    const all = Array.from(root.querySelectorAll('*')) as HTMLElement[];
+    const seenContainers = new Set<Element>();
+    let boundaries = 0;
+
+    /* ── 1 & 2. content escaping a boundary; text clipped ─────────────── */
+    const containers = all.filter(el => visible(el) && drawsBoundary(el)).slice(0, MAX_CONTAINERS);
+    for (const container of containers) {
+      boundaries++;
+      const box = paddingBox(container);
+      const clipping = clips(container);
+      let worst: { d: Element | Text; by: number; side: string } | null = null;
+      // Text runs are what actually paint past an edge; child boxes catch
+      // images, buttons and nested tiles.
+      for (const { node, rect } of textRanges(container)) {
+        const holder = node.parentElement!;
+        if (intentionallyOutside(holder, container)) continue;
+        // A run inside a nearer clipping ancestor is that ancestor's business.
+        let mid: Element | null = holder;
+        let nearerClip = false;
+        while (mid && mid !== container) { if (clips(mid)) { nearerClip = true; break; } mid = mid.parentElement; }
+        if (nearerClip) continue;
+        const by = Math.max(rect.right - box.right, box.left - rect.left, rect.bottom - box.bottom, box.top - rect.top);
+        const side = rect.right - box.right === by ? 'right' : box.left - rect.left === by ? 'left' : rect.bottom - box.bottom === by ? 'bottom' : 'top';
+        if (by > ESCAPE_PX && (!worst || by > worst.by)) worst = { d: node, by, side };
+      }
+      for (const child of Array.from(container.querySelectorAll('img, svg, button, input, select, textarea, video, canvas, [role="img"]'))) {
+        if (!visible(child) || intentionallyOutside(child, container)) continue;
+        const r = child.getBoundingClientRect();
+        const by = Math.max(r.right - box.right, box.left - r.left, r.bottom - box.bottom, box.top - r.top);
+        const side = r.right - box.right === by ? 'right' : box.left - r.left === by ? 'left' : r.bottom - box.bottom === by ? 'bottom' : 'top';
+        if (by > ESCAPE_PX && (!worst || by > worst.by)) worst = { d: child, by, side };
+      }
+      if (!worst) continue;
+      const holder = worst.d.nodeType === 3 ? (worst.d as Text).parentElement! : (worst.d as Element);
+      const text = worst.d.nodeType === 3 ? (worst.d as Text).data.replace(/\s+/g, ' ').trim().slice(0, 40) : textOf(holder).slice(0, 40);
+      const who = authorOf(holder);
+      const containerWho = authorOf(container);
+      const amount = Math.round(worst.by);
+      if (clipping) {
+        const s = cs(container);
+        if (/ellipsis/.test(s.textOverflow) || /auto|scroll/.test(s.overflowX + s.overflowY)) continue;
+        problems.push({
+          kind: 'text_clipped',
+          message: `"${text}" is cut off: it extends ${amount}px past the ${worst.side} edge of ${describe(container)}, which clips without an ellipsis or a scrollbar — let the text wrap, widen the container, or use the design system's truncation`,
+          evidence: `${selectorOf(holder)} overflows ${selectorOf(container)} by ${amount}px (${worst.side}); overflow: ${s.overflowX}/${s.overflowY}, text-overflow: ${s.textOverflow}`,
+          selector: selectorOf(holder),
+          ...(who.owner ? who : containerWho),
+        });
+      } else {
+        problems.push({
+          kind: 'content_escapes',
+          message: `"${text}" paints ${amount}px outside the ${worst.side} edge of its container ${describe(container)}${containerWho.owner ? ` (<${containerWho.owner}>)` : ''} — the content does not fit: use a smaller size from the type scale for the value, let the container grow with its content, allow wrapping, or give the flex child min-width: 0`,
+          evidence: `${selectorOf(holder)} right/bottom edge exceeds the padding box of ${selectorOf(container)} by ${amount}px on the ${worst.side}; container overflow is visible`,
+          selector: selectorOf(holder),
+          ...(who.owner ? who : containerWho),
+        });
+      }
+      seenContainers.add(container);
+      if (problems.length >= MAX_PROBLEMS) break;
+    }
+
+    /* ── 3. siblings that overlap ────────────────────────────────────── */
+    if (problems.length < MAX_PROBLEMS) {
+      const inFlow = (el: Element): boolean => {
+        const s = cs(el);
+        if (!/^(static|relative)$/.test(s.position)) return false;
+        if (s.transform && s.transform !== 'none') return false;
+        if (px(s.marginLeft) < 0 || px(s.marginRight) < 0 || px(s.marginTop) < 0 || px(s.marginBottom) < 0) return false;
+        if (s.float && s.float !== 'none') return false;
+        return true;
+      };
+      const paints = (el: Element): boolean => textOf(el).length > 0 || drawsBoundary(el) || !!el.querySelector('img, svg, input, button');
+      outer: for (const parent of all) {
+        const kids = (Array.from(parent.children) as HTMLElement[]).filter(k => visible(k) && inFlow(k) && paints(k)).slice(0, 12);
+        if (kids.length < 2) continue;
+        const ps = cs(parent);
+        // Explicitly placed grid items may overlap by design.
+        const explicitGrid = ps.display.includes('grid') && kids.every(k => { const s = cs(k); return (s.gridRowStart !== 'auto' || s.gridColumnStart !== 'auto'); });
+        if (explicitGrid) continue;
+        for (let i = 0; i < kids.length; i++) {
+          for (let j = i + 1; j < kids.length; j++) {
+            const a = kids[i].getBoundingClientRect();
+            const b = kids[j].getBoundingClientRect();
+            const w = Math.min(a.right, b.right) - Math.max(a.left, b.left);
+            const h = Math.min(a.bottom, b.bottom) - Math.max(a.top, b.top);
+            if (w <= OVERLAP_PX || h <= OVERLAP_PX) continue;
+            const smaller = Math.min(a.width * a.height, b.width * b.height);
+            if (w * h < smaller * 0.1) continue;
+            const who = authorOf(kids[j]);
+            problems.push({
+              kind: 'sibling_overlap',
+              message: `${describe(kids[i])} and ${describe(kids[j])} overlap by ${Math.round(w)}×${Math.round(h)}px inside ${describe(parent)} — two siblings occupy the same space: give the container a gap or a layout (flex/grid), or size the children so they fit`,
+              evidence: `${selectorOf(kids[i])} ∩ ${selectorOf(kids[j])} = ${Math.round(w)}×${Math.round(h)}px; both in flow (position ${cs(kids[i]).position}/${cs(kids[j]).position})`,
+              selector: selectorOf(kids[j]),
+              ...who,
+            });
+            if (problems.length >= MAX_PROBLEMS) break outer;
+            continue outer;
+          }
+        }
+      }
+    }
+
+    /* ── 4. the page itself is wider than the viewport ───────────────── */
+    const docEl = document.documentElement;
+    if (docEl.scrollWidth > docEl.clientWidth + ESCAPE_PX) {
+      let widest: HTMLElement | null = null;
+      let widestRight = docEl.clientWidth;
+      for (const el of all) {
+        if (!visible(el)) continue;
+        const r = el.getBoundingClientRect();
+        if (r.right > widestRight + ESCAPE_PX && (!widest || r.right > widestRight)) { widest = el; widestRight = r.right; }
+      }
+      const who = widest ? authorOf(widest) : {};
+      problems.push({
+        kind: 'page_overflow',
+        message: `The story is ${docEl.scrollWidth - docEl.clientWidth}px wider than the viewport (${docEl.clientWidth}px), so it scrolls sideways${widest ? ` — ${describe(widest)} reaches ${Math.round(widestRight)}px` : ''}; size the layout to its container (max-width: 100%, min-width: 0 on flex children, responsive columns)`,
+        evidence: `document.scrollWidth ${docEl.scrollWidth} > clientWidth ${docEl.clientWidth}${widest ? `; widest ${selectorOf(widest)}` : ''}`,
+        selector: widest ? selectorOf(widest) : undefined,
+        ...who,
+      });
+    }
+
+    /* ── 5. bordered boxes with nothing in them ─────────────────────── */
+    if (problems.length < MAX_PROBLEMS) {
+      for (const el of all) {
+        if (!visible(el) || seenContainers.has(el)) continue;
+        const r = el.getBoundingClientRect();
+        if (r.width < 48 || r.height < 24) continue;
+        const s = cs(el);
+        const bordered = ['borderTopWidth', 'borderRightWidth', 'borderBottomWidth', 'borderLeftWidth'].some(k => px((s as any)[k]) > 0);
+        if (!bordered) continue; // a coloured block may be a swatch or an image placeholder; a bordered one promised content
+        if (/^(hr|input|textarea|select|button|img|svg|video|canvas|iframe)$/i.test(el.tagName)) continue;
+        if (el.getAttribute('aria-hidden') === 'true' || el.getAttribute('role') === 'presentation') continue;
+        if (textOf(el)) continue;
+        if (el.querySelector('img, svg, input, button, select, textarea, video, canvas, [role="img"], [role="progressbar"]')) continue;
+        if (s.backgroundImage && s.backgroundImage !== 'none') continue;
+        problems.push({
+          kind: 'empty_box',
+          message: `${describe(el)} is a bordered ${Math.round(r.width)}×${Math.round(r.height)}px box with nothing inside — an empty tile or panel where content was expected; fill it with the content the request asked for or remove it`,
+          evidence: `${selectorOf(el)}: border ${s.borderTopWidth}, no text, no image, no control`,
+          selector: selectorOf(el),
+          ...authorOf(el),
+        });
+        if (problems.length >= MAX_PROBLEMS) break;
+      }
+    }
+
+    return { metrics: { elements: all.length, boundaries }, problems } as OverflowResult;
+  }, options);
+}

--- a/story-generator/verify/probes/visualCritic.ts
+++ b/story-generator/verify/probes/visualCritic.ts
@@ -27,6 +27,10 @@
 import { logger } from '../../logger.js';
 
 export interface VisualFinding {
+  /** Which shippability category the critic put it in, when it said. */
+  category?: string;
+  /** The container the element sits in, as the critic named it. */
+  container?: string;
   /** What is wrong, stated so a reader could confirm it from the image. */
   issue: string;
   /** The visible thing it concerns — "the filters panel", "the metric tiles". */
@@ -52,7 +56,7 @@ export type CritiqueModel = (
   screenshot: Buffer,
 ) => Promise<string>;
 
-const CRITIQUE_PROMPT = (request: string, components: string[]) => `You are reviewing a UI that was generated from a written request. You can see the rendered result.
+const CRITIQUE_PROMPT = (request: string, components: string[]) => `You are the last reviewer before a generated UI is shown to the person who asked for it. You can see the rendered result. Answer one question: is this shippable as it stands?
 
 THE REQUEST WAS:
 ${request}
@@ -60,22 +64,27 @@ ${request}
 COMPONENTS THE DESIGN SYSTEM PROVIDED (the implementation may only use these):
 ${components.length ? components.join(', ') : '(not recorded)'}
 
-Judge ONLY what is visible in the screenshot. Report a finding when the rendered result:
-- fails to deliver something the request explicitly asked for
-- has an obviously broken or unbalanced layout (an element overflowing, a region conspicuously empty, content colliding or clipped)
-- has a hierarchy that misleads — for example a secondary action styled as the primary one, or a heading that reads as body text
+A result is NOT shippable — report a BLOCKER — when you can see any of these. Each category is something a person calls "broken" on sight:
+- overflow: text, a number, an image or a control paints outside the box that contains it (a value wider than its tile, a label crossing a card's border)
+- overlap: two elements occupy the same space
+- clipped: text is cut off mid-word or mid-number where the whole was meant to show
+- empty: a tile, panel, column or card that was meant to hold content is blank
+- misaligned: rows, columns or paired fields visibly out of line with each other (one field lower than its partner, a card taller than its siblings for no reason)
+- illegible: text too small, too faint, or wrapping mid-word so it cannot be read
+- unstyled: a raw element (a browser-default button, input, table or link) inside an otherwise styled composition
+- missing: something the request explicitly asked for is not there, or a state it asked for (an error state, a highlighted tier, three columns) is absent
 
 RULES, which matter more than the findings themselves:
-1. Every finding must name something a person could POINT AT in the image.
-2. Every finding must state a concrete change. "Improve the visual hierarchy" is not a finding. "The Save and Publish buttons are identical weight, so the primary action is ambiguous — make Publish primary and Save secondary" is.
-3. Do NOT report subjective polish: colour preferences, spacing you would have chosen differently, or anything phrased as "consider".
+1. Every finding names the element by its visible text or label ("the value 34,600 nm", "the Sign in button") AND the container it sits in ("the Sea Miles tile", "the third card"). A reader must be able to point at it.
+2. Every finding states one concrete change the code can make: a smaller size from the type scale, letting the tile grow, wrapping, a gap, an alignment, the missing element. "Improve the layout" is not a finding.
+3. Do NOT report taste: colour preferences, spacing you would have chosen differently, or anything phrased as "consider" or "could". Those are dropped unread.
 4. Do NOT suggest components that are not in the list above.
-5. If the composition delivers the request and has no visible defect, return an EMPTY list. That is a normal and expected answer — most well-formed output should produce it. Inventing a finding to seem useful causes correct code to be rewritten.
+5. If the composition delivers the request and nothing in the list above is visible, return an EMPTY list. That is the normal answer for good output; inventing a finding causes correct code to be rewritten.
 
 Respond with JSON only, no prose around it:
-{"findings":[{"issue":"...","element":"...","severity":"blocker|warning","fix":"..."}]}
+{"findings":[{"category":"overflow|overlap|clipped|empty|misaligned|illegible|unstyled|missing|other","issue":"...","element":"...","container":"...","severity":"blocker|warning","fix":"..."}]}
 
-Use "blocker" ONLY when the result fails the request or is visibly broken. Everything else is "warning".`;
+Use "blocker" for every category above. Use "warning" only for something real that is not in the list (a hierarchy that misleads — a secondary action styled as the primary one).`;
 
 /**
  * Ask a vision model whether the rendered composition answers the request.
@@ -144,16 +153,34 @@ export function parseCritique(raw: string): VisualFinding[] {
   const findings = Array.isArray(parsed?.findings) ? parsed.findings : [];
   const VAGUE = /\b(consider|might|could|perhaps|maybe|generally|overall|polish|more modern|nicer|cleaner|improve the (look|feel|aesthetic))\b/i;
 
+  const SHIPPABILITY = new Set(['overflow', 'overlap', 'clipped', 'empty', 'misaligned', 'illegible', 'unstyled', 'missing']);
   return findings
     .filter((f: any) => typeof f?.issue === 'string' && f.issue.trim().length > 12)
     // A finding phrased as a suggestion is an opinion. Opinions rewrite
     // working code.
     .filter((f: any) => !VAGUE.test(f.issue) && !VAGUE.test(f.fix ?? ''))
+    // Rules 1 and 2 are enforced here, not merely asked, for anything that
+    // would BLOCK: a blocker that names no element is one nobody can point
+    // at and the repair cannot target; one without a fix is a complaint.
+    // Both are kept as warnings, so the observation is not lost.
+    .map((f: any) => {
+      const named = typeof f.element === 'string' && f.element.trim().length > 1;
+      const fixed = typeof f.fix === 'string' && f.fix.trim().length > 8;
+      const wantsBlock = f.severity === 'blocker' || (typeof f.category === 'string' && SHIPPABILITY.has(f.category.toLowerCase()));
+      return wantsBlock && !(named && fixed) ? { ...f, category: undefined, severity: 'warning' } : f;
+    })
     .slice(0, 6)
-    .map((f: any) => ({
-      issue: String(f.issue).slice(0, 300),
-      element: typeof f.element === 'string' ? f.element.slice(0, 80) : undefined,
-      severity: f.severity === 'blocker' ? 'blocker' : 'warning',
-      fix: typeof f.fix === 'string' ? f.fix.slice(0, 300) : undefined,
-    })) as VisualFinding[];
+    .map((f: any) => {
+      const category = typeof f.category === 'string' && SHIPPABILITY.has(f.category.toLowerCase()) ? f.category.toLowerCase() : undefined;
+      return {
+        category,
+        issue: String(f.issue).slice(0, 300),
+        element: typeof f.element === 'string' ? f.element.slice(0, 80) : undefined,
+        container: typeof f.container === 'string' ? f.container.slice(0, 80) : undefined,
+        // A shippability category is a blocker by definition; anything else
+        // is a blocker only if the critic said so and named the fix.
+        severity: category || f.severity === 'blocker' ? 'blocker' : 'warning',
+        fix: typeof f.fix === 'string' ? f.fix.slice(0, 300) : undefined,
+      };
+    }) as VisualFinding[];
 }

--- a/story-generator/verify/verifyStory.ts
+++ b/story-generator/verify/verifyStory.ts
@@ -19,6 +19,7 @@ import { resolveHostTooling, canLaunchBrowser } from './hostTooling.js';
 import { renderStory, waitForStoryIndexed, indexIsStale, type IndexLookup } from './renderHarness.js';
 import { runDomCensus } from './probes/domCensus.js';
 import { runLayoutProbe } from './probes/layout.js';
+import { runOverflowProbe } from './probes/overflow.js';
 import { runClassEffectProbe } from './probes/classEffect.js';
 import { runInteractionProbe } from './probes/interaction.js';
 import { runVisualCritique, type CritiqueModel } from './probes/visualCritic.js';
@@ -563,6 +564,38 @@ export async function verifyStory(options: VerifyStoryOptions): Promise<VerifyRe
         repairable: !p.ownedByLibrary,
       });
     }
+    /**
+     * Looks broken, measured: content painting past its container, text cut
+     * off, siblings overlapping, a page wider than the viewport, a bordered
+     * box with nothing in it. A stat value "34,600 nm" wider than its tile
+     * went out as "Verified" before this ran. Every kind blocks when the
+     * story wrote it — a person would call each one broken on sight — and is
+     * repairable with the numbers and the fix in the message.
+     */
+    const overflow = await runOverflowProbe(render.page, { libraryComponents });
+    coverage.overflow = { ran: true };
+    for (const p of overflow.problems) {
+      // Content that does not fit its box is the STORY's to fix even when a
+      // library component drew the box: the story chose the value, the size
+      // and the column width. "34,600 nm" spilling out of a design system's
+      // stat tile is shortened, resized or given room by the composition,
+      // never by the library. The other kinds follow the usual attribution.
+      const storyCanFix = p.kind === 'content_escapes' || p.kind === 'text_clipped' || !p.ownedByLibrary;
+      findings.push({
+        id: `${p.kind}-${findings.length}`,
+        severity: storyCanFix ? 'blocker' : 'warning',
+        class: 'code',
+        message: p.ownedByLibrary && p.owner
+          ? `${p.message} — rendered by <${p.owner}>, a design system component${storyCanFix ? ': change what the story passes to it (a shorter value, a size prop, a wider column), not the component' : ''}`
+          : p.message,
+        evidence: p.evidence,
+        selector: p.selector,
+        repairable: storyCanFix,
+      });
+    }
+    logger.log(overflow.problems.length
+      ? `📐 Overflow: ${overflow.problems.length} finding(s) across ${overflow.metrics.boundaries} bounded containers — ${overflow.problems.map(p => p.kind).join(', ')}`
+      : `📐 Overflow: none across ${overflow.metrics.boundaries} bounded containers (${overflow.metrics.elements} elements)`);
     findings.push(...censusFindings(census.problems));
 
     // Accessibility. Only rules that indicate the GENERATOR produced wrong


### PR DESCRIPTION

A profile card whose stat value "34,600 nm" painted past its tile went out
as "Verified". Three layers now stand between that and the user:

- A deterministic "looks broken" probe: content escaping the box that
  contains it, text clipped without an ellipsis, in-flow siblings
  overlapping, a page wider than the viewport, a bordered box with nothing
  inside — pixels measured, element and container named, the fix in the
  message. Content that does not fit blocks even inside a library component:
  the story chose the value. Live on the card: "nm" 84px past the Sea Miles
  tile, "1,240" 16px past Followers.
- The visual critic judges one question, shippable or not, with named
  categories (overflow, overlap, clipped, empty, misaligned, illegible,
  unstyled, missing); the parser demotes any blocker that names no element
  or no fix, so nothing vague can trigger a rewrite.
- A gate around the pipeline: a story that did not render, or keeps a
  blocker of its own after repair, is generated again with the browser's
  findings as requirements — same file, title and id — up to
  STORY_UI_GATE_ATTEMPTS (default 3); the best attempt is kept, restored to
  disk if a later one was worse, and the reply says what happened. A story
  verification could not judge is reported as such, not retried.

Live on Sail Shelf: the card prompt rendered with 4 blockers, repair rewrote
the values as "4.2 k" and "31.4 k", the re-render measured clean, shippable
on attempt 1. Coverage now counts seven layers.



https://claude.ai/code/session_0158a8zxX4SKPdxm7DLfgqp4
