### PR TITLE
chore: no absolute paths to one machine anywhere in the repository

### DIFF
--- a/__tests__/a11y-root-environment.test.ts
+++ b/__tests__/a11y-root-environment.test.ts
@@ -10,11 +10,11 @@
  */
 import { describe, it, expect, beforeAll, afterAll } from 'vitest';
 
-import { resolveHostTooling } from '../story-generator/verify/hostTooling.js';
+import { testHostTooling } from './helpers/hostProject.js';
 import { acquireBrowser, closeBrowserSession } from '../story-generator/verify/browserSession.js';
 import { runA11yProbe } from '../story-generator/verify/probes/a11y.js';
 
-const tooling = resolveHostTooling('/Users/tjpitre/Sites/test-storybooks/react-mantine');
+const tooling = testHostTooling();
 let browser: any;
 
 beforeAll(async () => {

--- a/__tests__/browser-session.test.ts
+++ b/__tests__/browser-session.test.ts
@@ -19,7 +19,8 @@ import {
   closeBrowserSession,
   currentBrowser,
 } from '../story-generator/verify/browserSession.js';
-import { resolveHostTooling, canLaunchBrowser } from '../story-generator/verify/hostTooling.js';
+import { canLaunchBrowser } from '../story-generator/verify/hostTooling.js';
+import { testHostTooling } from './helpers/hostProject.js';
 import { renderStory } from '../story-generator/verify/renderHarness.js';
 
 function fakeBrowser() {
@@ -187,7 +188,7 @@ describe('browser session (fake playwright)', () => {
  * A real browser, resolved from a host project the way the pipeline resolves
  * it. Skipped when the host has no Playwright.
  */
-const realTooling = resolveHostTooling('/Users/tjpitre/Sites/test-storybooks/react-mantine');
+const realTooling = testHostTooling();
 
 describe.runIf(realTooling)('browser session (real chromium)', { retry: 2 }, () => {
   it('acquire twice returns one live browser; release counts down; the last release ends it', async () => {

--- a/__tests__/class-effect.test.ts
+++ b/__tests__/class-effect.test.ts
@@ -27,7 +27,7 @@
 
 import { describe, it, expect, beforeAll, afterAll } from 'vitest';
 
-import { resolveHostTooling } from '../story-generator/verify/hostTooling.js';
+import { testHostTooling } from './helpers/hostProject.js';
 import { acquireBrowser, closeBrowserSession } from '../story-generator/verify/browserSession.js';
 import { runClassEffectProbe } from '../story-generator/verify/probes/classEffect.js';
 
@@ -35,7 +35,7 @@ import { runClassEffectProbe } from '../story-generator/verify/probes/classEffec
  * A real browser, resolved from a host project the same way the pipeline does.
  * When none is available these tests are skipped rather than silently passing.
  */
-const tooling = resolveHostTooling('/Users/tjpitre/Sites/test-storybooks/react-mantine');
+const tooling = testHostTooling();
 let browser: any;
 
 beforeAll(async () => {

--- a/__tests__/helpers/hostProject.ts
+++ b/__tests__/helpers/hostProject.ts
@@ -1,0 +1,112 @@
+/**
+ * A project to borrow Playwright from, for the tests that drive a real browser.
+ *
+ * Verification deliberately resolves `playwright` and `axe-core` from the
+ * CONSUMING project rather than from Story UI's own dependencies — that is the
+ * behaviour under test, and the reason this repository does not depend on
+ * Playwright itself. So the browser-driving tests need some project on the
+ * machine that has it installed.
+ *
+ * That project used to be named by an absolute path, which meant the tests ran
+ * on exactly one machine and published a maintainer's home directory to a
+ * public repository. It is now discovered:
+ *
+ *   1. `STORY_UI_TEST_PROJECT` — an explicit path, for CI or an unusual layout.
+ *   2. `STORY_UI_TEST_PROJECTS` (or `../test-storybooks`) — the conventional
+ *      sibling directory of Storybook fixtures; the first entry that has a
+ *      usable Playwright wins.
+ *   3. The repository itself and its siblings, in case Playwright is installed
+ *      somewhere else nearby.
+ *
+ * When nothing on the machine has Playwright, this returns null and every
+ * caller skips through `describe.runIf(...)`. That is the honest outcome: a
+ * browser test that cannot start a browser has not passed, and it must not
+ * look as though it did.
+ */
+
+import fs from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
+import { resolveHostTooling, type HostTooling } from '../../story-generator/verify/hostTooling.js';
+
+const REPO_ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..', '..');
+
+/** Directories to try, in order of how likely they are to be the right answer. */
+function candidates(): string[] {
+  const out: string[] = [];
+  const add = (dir: string | undefined) => {
+    if (!dir) return;
+    const resolved = path.resolve(dir);
+    if (!out.includes(resolved)) out.push(resolved);
+  };
+
+  add(process.env.STORY_UI_TEST_PROJECT);
+
+  const fixtures = process.env.STORY_UI_TEST_PROJECTS
+    ? path.resolve(process.env.STORY_UI_TEST_PROJECTS)
+    : path.resolve(REPO_ROOT, '..', 'test-storybooks');
+  try {
+    for (const entry of fs.readdirSync(fixtures, { withFileTypes: true })) {
+      if (entry.isDirectory() && !entry.name.startsWith('.')) add(path.join(fixtures, entry.name));
+    }
+  } catch { /* no fixtures directory on this machine */ }
+
+  add(REPO_ROOT);
+  try {
+    const siblings = path.resolve(REPO_ROOT, '..');
+    for (const entry of fs.readdirSync(siblings, { withFileTypes: true })) {
+      if (entry.isDirectory() && !entry.name.startsWith('.')) add(path.join(siblings, entry.name));
+    }
+  } catch { /* unreadable parent */ }
+
+  return out;
+}
+
+/**
+ * Is this Playwright's browser actually on disk?
+ *
+ * Resolving the `playwright` package is not enough, and the difference is not
+ * academic: the first fixture found alphabetically had Playwright installed
+ * from an older release whose Chromium had never been downloaded, so every
+ * probe test failed at `browser.newPage()` instead of skipping. A candidate
+ * that cannot launch is not a candidate.
+ *
+ * `canLaunchBrowser` is the thorough check, but it is async and the callers
+ * need an answer at collection time for `describe.runIf`. The executable's
+ * existence is the same fact, synchronously. When Playwright will not say
+ * where its binary is (a custom channel, a remote endpoint), that is not
+ * evidence of breakage, so the candidate is accepted and the launch decides.
+ */
+function browserIsInstalled(tooling: HostTooling): boolean {
+  try {
+    const executable = tooling.playwright?.chromium?.executablePath?.();
+    if (!executable) return true;
+    return fs.existsSync(executable);
+  } catch {
+    return true;
+  }
+}
+
+let cached: { value: HostTooling | null } | undefined;
+
+/**
+ * Tooling from the first candidate project whose Playwright can actually run,
+ * or null. Cached: the search touches the filesystem and every probe test asks.
+ */
+export function testHostTooling(): HostTooling | null {
+  if (cached) return cached.value;
+  let value: HostTooling | null = null;
+  for (const dir of candidates()) {
+    if (!fs.existsSync(path.join(dir, 'package.json'))) continue;
+    const tooling = resolveHostTooling(dir);
+    if (tooling && browserIsInstalled(tooling)) { value = tooling; break; }
+  }
+  if (!value && !process.env.CI) {
+    console.warn(
+      '[tests] No project with Playwright found, so the browser-driven probe tests are skipped. ' +
+      'Set STORY_UI_TEST_PROJECT=/path/to/a/storybook-project (one that has run `npx playwright install chromium`) to run them.',
+    );
+  }
+  cached = { value };
+  return value;
+}

--- a/__tests__/interaction-probe.test.ts
+++ b/__tests__/interaction-probe.test.ts
@@ -19,7 +19,7 @@
 
 import { describe, it, expect, beforeAll, afterAll } from 'vitest';
 
-import { resolveHostTooling } from '../story-generator/verify/hostTooling.js';
+import { testHostTooling } from './helpers/hostProject.js';
 import { acquireBrowser, closeBrowserSession } from '../story-generator/verify/browserSession.js';
 import { runInteractionProbe } from '../story-generator/verify/probes/interaction.js';
 
@@ -27,7 +27,7 @@ import { runInteractionProbe } from '../story-generator/verify/probes/interactio
  * A real browser, resolved the way the pipeline resolves it. When none is
  * available these are skipped rather than passing on literals.
  */
-const tooling = resolveHostTooling('/Users/tjpitre/Sites/test-storybooks/react-mantine');
+const tooling = testHostTooling();
 let browser: any;
 
 beforeAll(async () => {

--- a/__tests__/layout-probe.test.ts
+++ b/__tests__/layout-probe.test.ts
@@ -14,7 +14,7 @@
 
 import { describe, it, expect, beforeAll, afterAll } from 'vitest';
 
-import { resolveHostTooling } from '../story-generator/verify/hostTooling.js';
+import { testHostTooling } from './helpers/hostProject.js';
 import { acquireBrowser, closeBrowserSession } from '../story-generator/verify/browserSession.js';
 import { runLayoutProbe } from '../story-generator/verify/probes/layout.js';
 
@@ -31,7 +31,7 @@ import { runLayoutProbe } from '../story-generator/verify/probes/layout.js';
  * fails on the first attempt.
  */
 
-const tooling = resolveHostTooling('/Users/tjpitre/Sites/test-storybooks/react-mantine');
+const tooling = testHostTooling();
 let browser: any;
 
 beforeAll(async () => {

--- a/__tests__/overflow-probe.test.ts
+++ b/__tests__/overflow-probe.test.ts
@@ -1,9 +1,9 @@
 import { describe, it, expect, beforeAll, afterAll } from 'vitest';
-import { resolveHostTooling } from '../story-generator/verify/hostTooling.js';
+import { testHostTooling } from './helpers/hostProject.js';
 import { acquireBrowser, closeBrowserSession } from '../story-generator/verify/browserSession.js';
 import { runOverflowProbe } from '../story-generator/verify/probes/overflow.js';
 
-const tooling = resolveHostTooling('/Users/tjpitre/Sites/test-storybooks/react-mantine');
+const tooling = testHostTooling();
 let browser: any;
 beforeAll(async () => { if (!tooling) return; browser = await acquireBrowser(tooling).catch(() => undefined); }, 60_000);
 afterAll(async () => { await closeBrowserSession(); });

--- a/__tests__/probe-false-blockers.test.ts
+++ b/__tests__/probe-false-blockers.test.ts
@@ -3,12 +3,12 @@
  * repair pass that could fix nothing.
  */
 import { describe, it, expect, beforeAll, afterAll } from 'vitest';
-import { resolveHostTooling } from '../story-generator/verify/hostTooling.js';
+import { testHostTooling } from './helpers/hostProject.js';
 import { acquireBrowser, closeBrowserSession } from '../story-generator/verify/browserSession.js';
 import { runInteractionProbe } from '../story-generator/verify/probes/interaction.js';
 import { runDomCensus } from '../story-generator/verify/probes/domCensus.js';
 
-const tooling = resolveHostTooling('/Users/tjpitre/Sites/test-storybooks/react-mantine');
+const tooling = testHostTooling();
 let browser: any;
 beforeAll(async () => { if (tooling) browser = await acquireBrowser(tooling).catch(() => undefined); }, 60_000);
 afterAll(async () => { await closeBrowserSession(); });

--- a/bench/componentSelection.mjs
+++ b/bench/componentSelection.mjs
@@ -26,6 +26,7 @@
 import { extractProps } from '../dist/story-generator/knowledge/propExtractor.js';
 import fs from 'fs';
 import path from 'path';
+import { fileURLToPath } from 'url';
 
 const args = process.argv.slice(2);
 const arg = (n, d) => { const i = args.indexOf(`--${n}`); return i >= 0 && args[i + 1] ? args[i + 1] : d; };
@@ -50,12 +51,22 @@ const SUITE = arg('suite', null);
  * one project while resolving imports against another produced a bench that
  * measured neither.
  */
+/**
+ * Where the Storybook fixtures live. They are separate checkouts, so only
+ * their LOCATION is configurable; which suites exist stays in git. Override
+ * with STORY_UI_TEST_PROJECTS, or name any project with --project.
+ */
+const PROJECTS_ROOT = process.env.STORY_UI_TEST_PROJECTS
+  ? path.resolve(process.env.STORY_UI_TEST_PROJECTS)
+  : path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..', '..', 'test-storybooks');
+const project = (dir) => path.resolve(PROJECTS_ROOT, dir);
+
 const SUITE_CONFIG = {
-  mantine: { project: '/Users/tjpitre/Sites/test-storybooks/react-mantine', importPath: '@mantine/core', mcp: 'http://localhost:4101' },
-  ct: { project: '/Users/tjpitre/Sites/college-town', importPath: '@/components', mcp: 'http://localhost:4106' },
-  mui: { project: '/Users/tjpitre/Sites/test-storybooks/mui-material', importPath: '@mui/material', mcp: 'http://localhost:4107' },
-  atlaskit: { project: '/Users/tjpitre/Sites/test-storybooks/atlaskit', importPath: '@atlaskit', mcp: 'http://localhost:4108' },
-  carbon: { project: '/Users/tjpitre/Sites/test-storybooks/carbon', importPath: '@carbon/react', mcp: 'http://localhost:4109' },
+  mantine: { project: project('react-mantine'), importPath: '@mantine/core', mcp: 'http://localhost:4101' },
+  ct: { project: project('../college-town'), importPath: '@/components', mcp: 'http://localhost:4106' },
+  mui: { project: project('mui-material'), importPath: '@mui/material', mcp: 'http://localhost:4107' },
+  atlaskit: { project: project('atlaskit'), importPath: '@atlaskit', mcp: 'http://localhost:4108' },
+  carbon: { project: project('carbon'), importPath: '@carbon/react', mcp: 'http://localhost:4109' },
 };
 
 const suiteDefaults = SUITE_CONFIG[SUITE] || SUITE_CONFIG.mantine;
@@ -81,7 +92,7 @@ const IMPORT_PATH = arg('import', suiteDefaults.importPath);
  * primitives when it does not know the library ships one.
  *
  *   node bench/componentSelection.mjs --suite ct --mcp http://localhost:4106 \
- *     --project /Users/tjpitre/Sites/college-town --import '@/components'
+ *     --project ../college-town --import '@/components'
  */
 const CT_CASES = [
   {

--- a/bench/resolution.mjs
+++ b/bench/resolution.mjs
@@ -30,50 +30,65 @@
 
 import fs from 'fs';
 import path from 'path';
-import { pathToFileURL } from 'url';
+import { pathToFileURL, fileURLToPath } from 'url';
 
 const args = process.argv.slice(2);
 const arg = (n, d) => { const i = args.indexOf(`--${n}`); return i >= 0 && args[i + 1] ? args[i + 1] : d; };
 const flag = (n) => args.includes(`--${n}`);
 
-const DIST = '/Users/tjpitre/Sites/story-ui/dist';
+/**
+ * The build this bench measures: this repository's own dist, found from the
+ * script's location. It used to be an absolute path to one machine.
+ */
+const REPO = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+const DIST = path.join(REPO, 'dist');
+
+/**
+ * Where the Storybook fixtures live. They are separate checkouts, not part of
+ * this repository, so only their LOCATION is configurable — the list below,
+ * which is the set of environments Story UI claims to support, stays in git.
+ */
+const PROJECTS_ROOT = process.env.STORY_UI_TEST_PROJECTS
+  ? path.resolve(process.env.STORY_UI_TEST_PROJECTS)
+  : path.resolve(REPO, '..', 'test-storybooks');
+const project = (dir) => path.resolve(PROJECTS_ROOT, dir);
 
 /** Every environment we claim to support, so a change is measured against all. */
 const ENVIRONMENTS = [
-  { name: 'react-mantine (npm barrel)', project: '/Users/tjpitre/Sites/test-storybooks/react-mantine', storybook: 'http://localhost:6101' },
-  { name: 'college-town (Radix+Tailwind, local)', project: '/Users/tjpitre/Sites/college-town', storybook: 'http://localhost:6006' },
-  { name: 'mui-material (subpath npm)', project: '/Users/tjpitre/Sites/test-storybooks/mui-material', storybook: 'http://localhost:6107' },
-  { name: 'atlaskit (package-per-component)', project: '/Users/tjpitre/Sites/test-storybooks/atlaskit', storybook: 'http://localhost:6108' },
-  { name: 'carbon (IBM, barrel + SCSS)', project: '/Users/tjpitre/Sites/test-storybooks/carbon', storybook: 'http://localhost:6109' },
+  { name: 'react-mantine (npm barrel)', project: project('react-mantine'), storybook: 'http://localhost:6101' },
+  { name: 'college-town (Radix+Tailwind, local)', project: project('../college-town'), storybook: 'http://localhost:6006' },
+  { name: 'mui-material (subpath npm)', project: project('mui-material'), storybook: 'http://localhost:6107' },
+  { name: 'atlaskit (package-per-component)', project: project('atlaskit'), storybook: 'http://localhost:6108' },
+  { name: 'carbon (IBM, barrel + SCSS)', project: project('carbon'), storybook: 'http://localhost:6109' },
   // Federated barrel: declares nothing, re-exports its whole API from 58
   // sibling packages. Measured by nobody until it was added here, and it was
   // the only architecture reporting props for 0 of 233 components.
-  { name: 'fluent (federated barrel)', project: '/Users/tjpitre/Sites/test-storybooks/fluent', storybook: 'http://localhost:6110' },
+  { name: 'fluent (federated barrel)', project: project('fluent'), storybook: 'http://localhost:6110' },
   // Published June 2026, after every current model's training cutoff — the only
   // environment here that cannot be answered from memory instead of knowledge.
-  { name: 'astryx (Meta, StyleX)', project: '/Users/tjpitre/Sites/test-storybooks/astryx', storybook: 'http://localhost:6111' },
+  { name: 'astryx (Meta, StyleX)', project: project('astryx'), storybook: 'http://localhost:6111' },
   // Namespace-only exports: `import { Menu }` then `<Menu.Root>`. 29 of its 40
   // top-level exports are namespaces, and they were invisible — a shape
   // carrying roughly 10% of the React component-library market by installs.
-  { name: 'base-ui (namespace exports)', project: '/Users/tjpitre/Sites/test-storybooks/base-ui', storybook: 'http://localhost:6112' },
+  { name: 'base-ui (namespace exports)', project: project('base-ui'), storybook: 'http://localhost:6112' },
   // Federated NAMESPACE barrel — the composition of two architectures, and the
   // single largest package in the ecosystem at 42.4M installs/month. Every one
   // of its 55 siblings arrives as `import * as x` + `export { x as Name }`,
   // which needs federation to reach props AND namespaces to know the members
   // are `Dialog.Root`. Either half alone yields nothing usable.
-  { name: 'radix-ui (federated namespace)', project: '/Users/tjpitre/Sites/test-storybooks/radix', storybook: 'http://localhost:6113' },
+  { name: 'radix-ui (federated namespace)', project: project('radix'), storybook: 'http://localhost:6113' },
   // Ships BOTH surfaces for the same components — flat `DialogRoot` and
   // namespace `Dialog.Root` — and states nearly every prop through an inherited
   // generic, which is the deepest heritage chain measured anywhere.
-  { name: 'chakra-v3 (dual surface)', project: '/Users/tjpitre/Sites/test-storybooks/chakra', storybook: 'http://localhost:6114' },
+  { name: 'chakra-v3 (dual surface)', project: project('chakra'), storybook: 'http://localhost:6114' },
   // The four non-React frameworks CLAUDE.md claims support for. Until they
   // were listed here their numbers were assumed, not measured — and the bench
   // instantiated ReactAdapter for every environment regardless of the
   // configured componentFramework, so it could not have measured them anyway.
-  { name: 'vue-vuetify (Vue 3)', project: '/Users/tjpitre/Sites/test-storybooks/vue-vuetify', storybook: 'http://localhost:6103' },
-  { name: 'angular-material (Angular)', project: '/Users/tjpitre/Sites/test-storybooks/angular-material', storybook: 'http://localhost:6102' },
-  { name: 'svelte-flowbite (Svelte 5)', project: '/Users/tjpitre/Sites/test-storybooks/svelte-flowbite', storybook: 'http://localhost:6104' },
-  { name: 'web-components-shoelace (Lit)', project: '/Users/tjpitre/Sites/test-storybooks/web-components-shoelace', storybook: 'http://localhost:6105' },
+  { name: 'vue-vuetify (Vue 3)', project: project('vue-vuetify'), storybook: 'http://localhost:6103' },
+  { name: 'angular-material (Angular)', project: project('angular-material'), storybook: 'http://localhost:6102' },
+  { name: 'svelte-flowbite (Svelte 5)', project: project('svelte-flowbite'), storybook: 'http://localhost:6104' },
+  { name: 'web-components-shoelace (Lit)', project: project('web-components-shoelace'), storybook: 'http://localhost:6105' },
 ];
 
 /**

--- a/scripts/clean-test.sh
+++ b/scripts/clean-test.sh
@@ -8,10 +8,18 @@
 
 set -e
 
-# Configuration
-STORY_UI_DIR="/Users/tjpitre/Sites/story-ui"
-TEST_STORYBOOKS_DIR="/Users/tjpitre/Sites/test-storybooks"
+# Configuration. The repository is found from this script's own location, and
+# the Storybook fixtures are a sibling checkout by convention — override with
+# STORY_UI_TEST_PROJECTS. Neither is a path to one person's machine.
+STORY_UI_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+TEST_STORYBOOKS_DIR="${STORY_UI_TEST_PROJECTS:-$(cd "$STORY_UI_DIR/.." && pwd)/test-storybooks}"
 DEFAULT_TEST_ENV="react-mantine"
+
+if [ ! -d "$TEST_STORYBOOKS_DIR" ]; then
+    echo "No Storybook fixtures at $TEST_STORYBOOKS_DIR."
+    echo "Set STORY_UI_TEST_PROJECTS to the directory holding your test Storybooks."
+    exit 1
+fi
 
 # Color output
 RED='\033[0;31m'


### PR DESCRIPTION

Ten tracked files hardcoded /Users/<name>/Sites/…, which published a
maintainer's home directory to a public repository and meant the browser
tests and both benches ran on exactly one machine.

Tests (7 files). They need a project with Playwright because verification
deliberately resolves it from the CONSUMING project — that is the behaviour
under test, and why this repo does not depend on Playwright itself. A new
helper, __tests__/helpers/hostProject.ts, discovers one instead: an explicit
STORY_UI_TEST_PROJECT, then the conventional sibling fixtures directory
(STORY_UI_TEST_PROJECTS, default ../test-storybooks), then the repository and
its siblings. Nothing found means the tests skip through the runIf they
already had, with a line saying how to run them.

A candidate must be able to LAUNCH, not merely resolve. The first fixture
found alphabetically had Playwright installed from an older release whose
Chromium had never been downloaded, so every probe test failed at
browser.newPage() rather than skipping — absent looking like broken, which is
the failure shape this project keeps paying for. The helper checks the
executable is on disk, and treats "Playwright will not say where its binary
is" as no evidence either way.

bench/resolution.mjs. DIST came from an absolute path; it is now this
repository's own dist, found from the script's location. The ENVIRONMENTS
table stays in git — it is the set of environments Story UI claims to support
— but only the fixtures' LOCATION is configurable, through the same
STORY_UI_TEST_PROJECTS convention.

bench/componentSelection.mjs. Same treatment for SUITE_CONFIG, and its usage
example no longer names a home directory.

scripts/clean-test.sh. Both directories are derived: the repository from the
script's own location, the fixtures from the sibling convention, with a clear
message when they are not there.

Verified: 1179 tests pass with the probe suites RUNNING (40 browser tests, not
skipped); `node bench/resolution.mjs --all` walks all 14 environments. The
only /Users/ strings left in the repository are placeholders in fixtures and
comments (/Users/me, /Users/x), and the username appears nowhere.



https://claude.ai/code/session_0158a8zxX4SKPdxm7DLfgqp4
