### PR TITLE
fix(generator): a composition that resizes when you use it is a defect

### DIFF
--- a/__tests__/loader-failure.test.ts
+++ b/__tests__/loader-failure.test.ts
@@ -50,3 +50,14 @@ describe('Storybook failing to load a story is not the story failing', () => {
     expect(gateVerdict(codeFailure).retryable).toBe(true);
   });
 });
+
+describe('a composition must not resize when it is used', () => {
+  it('states the rule for compositions and exempts single specimens', async () => {
+    const { formatSpacingRules } = await import('../story-generator/knowledge/spacingFacts');
+    const vocab: any = { primitives: [], tokens: [], utilities: null, typography: [], colourTiers: null };
+    const text = formatSpacingRules(vocab, 'jsx', {});
+    expect(text).toContain('width from the SPACE IT IS GIVEN');
+    expect(text).toContain('switching a tab visibly resizes');
+    expect(text).toContain('should NOT be stretched');
+  });
+});

--- a/story-generator/knowledge/spacingFacts.ts
+++ b/story-generator/knowledge/spacingFacts.ts
@@ -552,6 +552,13 @@ export function formatSpacingRules(
 
   lines.push('1. STORY WRAPPER (REQUIRED): one outer container gives the story its breathing room.');
   lines.push(`   Pattern: ${wrapperExample}`);
+  lines.push('   A composition with regions — a page, a dashboard, a settings screen, anything with');
+  lines.push('   tabs, a table or a sidebar — must take its width from the SPACE IT IS GIVEN, never');
+  lines.push('   from its content: fill the available width, and add a max width only if it should');
+  lines.push('   not run too wide. A root that hugs its content is re-measured every time the content');
+  lines.push('   changes, so switching a tab visibly resizes the whole page. A single component shown');
+  lines.push('   on its own (one button, one card, one input) should NOT be stretched — this rule is');
+  lines.push('   about compositions, not specimens.');
   lines.push('2. FORM FIELDS & VERTICAL GROUPS: siblings are spaced by their PARENT. Put the gap on the');
   lines.push('   container and give no child a margin — a one-sided margin on one field of a pair is');
   lines.push('   the most common misalignment in generated code.');
@@ -615,6 +622,13 @@ spacing utility scale, so inline spacing values are acceptable here — and only
    - The rendered story MUST have a wrapper element with padding
    - Pattern: ${ex.wrapper}
    - This ensures content has breathing room within the Storybook canvas
+   - A composition with regions — a page, a dashboard, a settings screen, anything with
+     tabs, a table or a sidebar — must take its width from the SPACE IT IS GIVEN, never
+     from its content: fill the available width, and add a max width only if it should
+     not run too wide. A root that hugs its content is re-measured every time the content
+     changes, so switching a tab visibly resizes the whole page. A single component shown
+     on its own (one button, one card, one input) should NOT be stretched — this rule is
+     about compositions, not specimens.
 
 2. FORM FIELD SPACING (CRITICAL):
    - ALWAYS wrap form fields in a container with vertical spacing

--- a/story-generator/verify/probes/interaction.ts
+++ b/story-generator/verify/probes/interaction.ts
@@ -47,6 +47,27 @@ export interface FlowBreakingOverlay {
   ownedByLibrary?: boolean;
 }
 
+/**
+ * A control whose use resized the whole composition.
+ *
+ * Switching a tab must not change how wide the page is. It does whenever the
+ * composition's root takes its width from its CONTENT rather than from the
+ * space it was given — a flex item that shrink-wraps, an inline-block, a
+ * fit-content width. Measured on a contractor dashboard: 980px on the
+ * Projects tab, 1040px on Contractors, so the whole card jumped on every
+ * click. The host can cause it too (a preview stylesheet that centres the
+ * story), which is exactly why the STORY has to declare a width it controls.
+ */
+export interface Reflow {
+  label: string;
+  descriptor: string;
+  /** Composition width before and after using the control. */
+  before: number;
+  after: number;
+  /** Body width change over the same click, so a scrollbar is not a finding. */
+  hostDelta: number;
+}
+
 export interface InteractionResult {
   /** Controls clicked; 0 means there was nothing to test, not that all passed. */
   controlsTested: number;
@@ -69,6 +90,8 @@ export interface InteractionResult {
   buttonsPresent: number;
   deadControls: DeadControl[];
   flowBreakingOverlays: FlowBreakingOverlay[];
+  /** Controls whose use changed the width of the whole composition. */
+  reflows: Reflow[];
   /** True when the probe declined to run; findings are then meaningless. */
   skipped: boolean;
   skipReason?: string;
@@ -126,7 +149,7 @@ export async function runInteractionProbe(
           if (el.matches('[aria-pressed], [aria-haspopup], [aria-expanded]')) return false;
           const r = el.getBoundingClientRect(); return r.width > 0 && r.height > 0;
         }).length,
-        deadControls: [], flowBreakingOverlays: [],
+        deadControls: [], flowBreakingOverlays: [], reflows: [],
         skipped: false,
       };
 
@@ -295,12 +318,51 @@ export async function runInteractionProbe(
       const toggles = allToggles.slice(0, opts.maxControls);
       result.controlsSkippedByCap = Math.max(0, allToggles.length - toggles.length);
 
+      /**
+       * The composition's own width: the outermost element the STORY rendered,
+       * not Storybook's root, so a host that stretches its root is still
+       * measured honestly. Body width rides along so a scrollbar appearing —
+       * which moves everything — cannot be mistaken for a reflow.
+       */
+      const compositionRoot = (): HTMLElement | null => {
+        const host = (document.querySelector('#storybook-root') || document.querySelector('#root')) as HTMLElement | null;
+        if (!host) return null;
+        const child = Array.from(host.children).find(c => {
+          const r = c.getBoundingClientRect();
+          return r.width > 0 && r.height > 0;
+        }) as HTMLElement | undefined;
+        return child ?? host;
+      };
+      const widths = (): { story: number; host: number } => {
+        const el = compositionRoot();
+        return {
+          story: el ? el.getBoundingClientRect().width : 0,
+          host: document.body.getBoundingClientRect().width,
+        };
+      };
+      // Below this, sub-pixel layout and a focus ring account for the change.
+      const REFLOW_PX = 8;
+
       for (const el of toggles) {
         const before = toggleState(el);
+        const sizeBefore = widths();
         try { press(el as HTMLElement); } catch { continue; }
         await sleep(120);
         const after = toggleState(el);
         result.controlsTested++;
+
+        const sizeAfter = widths();
+        const hostDelta = sizeAfter.host - sizeBefore.host;
+        const storyDelta = sizeAfter.story - sizeBefore.story;
+        if (Math.abs(storyDelta - hostDelta) > REFLOW_PX && result.reflows.length < 4) {
+          result.reflows.push({
+            label: nameOf(el),
+            descriptor: `${el.tagName.toLowerCase()}${el.getAttribute('role') ? `[role=${el.getAttribute('role')}]` : ''}`,
+            before: Math.round(sizeBefore.story),
+            after: Math.round(sizeAfter.story),
+            hostDelta: Math.round(hostDelta),
+          });
+        }
 
         if (before === after) {
           result.deadControls.push({
@@ -314,6 +376,48 @@ export async function runInteractionProbe(
         } else {
           // Put it back. The story may be screenshotted after this.
           try { press(el as HTMLElement); await sleep(60); } catch { /* best effort */ }
+        }
+      }
+
+      /* ── 1b. Tabs and segmented views: does the page keep its width? ────── */
+
+      /**
+       * Switching a tab is the case people actually hit, and no toggle test
+       * reaches it: a tab has `aria-selected`, not a checked state, so the
+       * loop above never clicks one. Clicking a tab is safe — it swaps a
+       * panel, it does not submit or navigate — and it is the cheapest way to
+       * prove the composition keeps its width when its content changes.
+       *
+       * Only the width is judged here. Whether the panel actually changed is
+       * the census's business, and calling a tab "dead" for lacking a checked
+       * state is how a false blocker gets born.
+       */
+      const tabs = queryAll('[role="tab"]')
+        .filter(el => {
+          const r = el.getBoundingClientRect();
+          return r.width > 0 && r.height > 0 && el.getAttribute('aria-selected') !== 'true' && !(el as HTMLButtonElement).disabled;
+        })
+        .slice(0, 4);
+
+      for (const el of tabs) {
+        // A tab's own text is its name. nameOf prefers a sibling label, which
+        // is right for a switch and wrong here: the parent is the tablist, so
+        // every tab came back named "ProjectsContractorsToday's checklist".
+        const tabLabel = (el.getAttribute('aria-label') || el.textContent || '(unnamed tab)').replace(/\s+/g, ' ').trim().slice(0, 60);
+        const sizeBefore = widths();
+        try { press(el as HTMLElement); } catch { continue; }
+        await sleep(160);
+        const sizeAfter = widths();
+        const hostDelta = sizeAfter.host - sizeBefore.host;
+        const storyDelta = sizeAfter.story - sizeBefore.story;
+        if (Math.abs(storyDelta - hostDelta) > REFLOW_PX && result.reflows.length < 4) {
+          result.reflows.push({
+            label: tabLabel,
+            descriptor: `${el.tagName.toLowerCase()}[role=tab]`,
+            before: Math.round(sizeBefore.story),
+            after: Math.round(sizeAfter.story),
+            hostDelta: Math.round(hostDelta),
+          });
         }
       }
 

--- a/story-generator/verify/verifyStory.ts
+++ b/story-generator/verify/verifyStory.ts
@@ -596,6 +596,27 @@ export async function verifyStory(options: VerifyStoryOptions): Promise<VerifyRe
     logger.log(overflow.problems.length
       ? `📐 Overflow: ${overflow.problems.length} finding(s) across ${overflow.metrics.boundaries} bounded containers — ${overflow.problems.map(p => p.kind).join(', ')}`
       : `📐 Overflow: none across ${overflow.metrics.boundaries} bounded containers (${overflow.metrics.elements} elements)`);
+    /**
+     * A composition that resizes when you use it.
+     *
+     * Switching a tab changed the dashboard's width from 980px to 1040px,
+     * because its root took its width from its content. The host can cause
+     * this (a preview stylesheet that centres the story) or the story can,
+     * and either way the story is what can defend itself by declaring a
+     * width. Blocking, because a page that jumps under the cursor is exactly
+     * the "looks broken" the user sees.
+     */
+    for (const r of interaction.reflows ?? []) {
+      findings.push({
+        id: `reflow-${findings.length}`,
+        severity: 'blocker',
+        class: 'code',
+        message: `Using "${r.label}" changes the width of the whole composition (${r.before}px → ${r.after}px), so the page jumps when it is used — the layout takes its width from its content. Give the composition's outermost element a width it controls (fill the space it is given, with a max-width if it should not run too wide) so switching content cannot resize it.`,
+        evidence: `${r.descriptor} "${r.label}": composition ${r.before}px → ${r.after}px while the viewport changed by ${r.hostDelta}px`,
+        repairable: true,
+      });
+    }
+
     findings.push(...censusFindings(census.problems));
 
     // Accessibility. Only rules that indicate the GENERATOR produced wrong


### PR DESCRIPTION

Clicking a tab on a generated dashboard changed the whole page from 980px to
1040px and back. Measured cause: the composition's root takes its width from
its CONTENT, so every content change re-measures the page. On react-mantine
the host makes it visible — that project's preview-head.html forces
`body { display: flex; flex-direction: column; align-items: center }`, which
turns #storybook-root into a shrink-to-fit flex item — but the story is what
can defend itself, and a story that declares its own width is stable under
any host.

Verification now measures it rather than inferring it. The interaction probe
records the composition's width around every control it exercises, and gains
a width-only pass over tabs: a tab has aria-selected, not a checked state, so
the toggle loop never clicked one — the exact control people hit. Body width
rides along so a scrollbar appearing cannot be mistaken for a reflow, and the
threshold is 8px. A change blocks and is repairable, naming the control and
both widths.

Proven on the reported story: "Contractors" 980 → 1040px, "Today's checklist"
1040 → 980px, viewport unchanged. A stable Carbon story reports nothing.

The prompt states the rule in both the derived and the fallback branch: a
composition with regions takes its width from the space it is given, never
from its content; a single specimen is explicitly exempt, so one button does
not get stretched across the canvas.



https://claude.ai/code/session_0158a8zxX4SKPdxm7DLfgqp4
