### PR TITLE
fix(cli): the preview root fills the canvas, so a story's width never follows its content

### DIFF
--- a/__tests__/loader-failure.test.ts
+++ b/__tests__/loader-failure.test.ts
@@ -52,12 +52,40 @@ describe('Storybook failing to load a story is not the story failing', () => {
 });
 
 describe('a composition must not resize when it is used', () => {
-  it('states the rule for compositions and exempts single specimens', async () => {
+  it('leaves the width to the author and forbids only content-dependent width', async () => {
     const { formatSpacingRules } = await import('../story-generator/knowledge/spacingFacts');
     const vocab: any = { primitives: [], tokens: [], utilities: null, typography: [], colourTiers: null };
     const text = formatSpacingRules(vocab, 'jsx', {});
-    expect(text).toContain('width from the SPACE IT IS GIVEN');
-    expect(text).toContain('switching a tab visibly resizes');
-    expect(text).toContain('should NOT be stretched');
+    // The width is the author's choice; only the dependence on content is a rule.
+    expect(text).toContain('Choose the width the request calls for');
+    expect(text).toContain('must not depend on');
+    expect(text).not.toContain('must take its width from the SPACE IT IS GIVEN');
+  });
+});
+
+describe('the preview root fills the canvas', () => {
+  it('appends the rule once, keeps the project\'s own CSS, and spares centered layouts', async () => {
+    const fs = await import('fs'); const os = await import('os'); const path = await import('path');
+    const { ensurePreviewRootCss, PREVIEW_ROOT_MARKER } = await import('../cli/setup');
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'preview-'));
+    fs.mkdirSync(path.join(dir, '.storybook'));
+    const theirs = '<style>\n  body.sb-main-padded { display: flex !important; align-items: center !important; }\n</style>\n';
+    fs.writeFileSync(path.join(dir, '.storybook', 'preview-head.html'), theirs);
+
+    const first = ensurePreviewRootCss(dir);
+    expect(first.action).toBe('appended');
+    const after = fs.readFileSync(path.join(dir, '.storybook', 'preview-head.html'), 'utf8');
+    expect(after).toContain('body.sb-main-padded { display: flex');           // theirs survives
+    expect(after).toContain('body:not(.sb-main-centered) #storybook-root { width: 100%; }');
+    expect(after).toContain(PREVIEW_ROOT_MARKER);
+
+    // Idempotent: running update again changes nothing.
+    expect(ensurePreviewRootCss(dir).action).toBe('unchanged');
+    expect(fs.readFileSync(path.join(dir, '.storybook', 'preview-head.html'), 'utf8')).toBe(after);
+
+    // A project with no preview-head gets one.
+    const fresh = fs.mkdtempSync(path.join(os.tmpdir(), 'preview2-'));
+    fs.mkdirSync(path.join(fresh, '.storybook'));
+    expect(ensurePreviewRootCss(fresh).action).toBe('created');
   });
 });

--- a/cli/setup.ts
+++ b/cli/setup.ts
@@ -541,6 +541,55 @@ export function ensureManagerHeadPort(
   return { path: file, action: existing === null ? 'created' : 'updated' };
 }
 
+/** Marks the block Story UI owns inside .storybook/preview-head.html. */
+export const PREVIEW_ROOT_MARKER = 'Story UI: the preview root fills the canvas';
+
+/**
+ * The preview root fills the canvas.
+ *
+ * Storybook's own default is a block-level `#storybook-root`, which fills the
+ * width it is given. A project stylesheet that makes the body a centred flex
+ * column turns that root into a flex ITEM, which shrink-wraps to its content
+ * — so the page's width becomes "however wide the current content happens to
+ * be", and filtering a table or switching a tab visibly resizes the whole
+ * composition. Measured on a generated dashboard: choosing a status filter
+ * took it from 917px to 884px; with this rule, 1568px either way.
+ *
+ * This restores Storybook's default rather than imposing a new one, and it is
+ * scoped away from `layout: 'centered'`, where shrink-wrapping is the whole
+ * point of the setting. Nothing here constrains what a story may look like:
+ * a story that wants to be 400px wide still is.
+ */
+export function previewRootCss(): string {
+  return `<style>
+  /* ${PREVIEW_ROOT_MARKER}, so a story's width never follows its content.
+     Storybook's default #storybook-root is block-level and fills its parent;
+     a preview stylesheet that centres the body turns it into a shrink-to-fit
+     flex item, and the page then resizes whenever its content changes.
+     Not applied to layout: 'centered', where hugging the content is intended. */
+  body:not(.sb-main-centered) #storybook-root { width: 100%; }
+</style>`;
+}
+
+/**
+ * Append Story UI's preview-root rule, once. An existing preview-head.html is
+ * kept exactly as it is and the block is added after it: the file usually
+ * belongs to the project, and the rest of it is none of our business.
+ */
+export function ensurePreviewRootCss(
+  cwd: string,
+): { path: string; action: 'created' | 'appended' | 'unchanged' } {
+  const file = path.join(cwd, '.storybook', 'preview-head.html');
+  const existing = fs.existsSync(file) ? fs.readFileSync(file, 'utf-8') : null;
+  if (existing !== null && existing.includes(PREVIEW_ROOT_MARKER)) {
+    return { path: file, action: 'unchanged' };
+  }
+  fs.mkdirSync(path.dirname(file), { recursive: true });
+  const body = existing === null ? `${previewRootCss()}\n` : `${existing.replace(/\s*$/, '')}\n\n${previewRootCss()}\n`;
+  fs.writeFileSync(file, body);
+  return { path: file, action: existing === null ? 'created' : 'appended' };
+}
+
 /**
  * The port init configured, read back from what init wrote: `.env`'s
  * VITE_STORY_UI_PORT first, then the `--port` in the package.json `story-ui`
@@ -2445,6 +2494,17 @@ export default registry;
     if (head.action !== 'unchanged') {
       console.log(chalk.green(`✅ ${head.action === 'created' ? 'Created' : 'Updated'} .storybook/manager-head.html — the workspace page will talk to port ${chosenPort}`));
     }
+  }
+
+  // The preview root fills the canvas: Storybook's own default, restored so a
+  // story's width can never follow its content. See ensurePreviewRootCss.
+  try {
+    const previewRoot = ensurePreviewRootCss(process.cwd());
+    if (previewRoot.action !== 'unchanged') {
+      console.log(chalk.green(`✅ ${previewRoot.action === 'created' ? 'Created' : 'Updated'} .storybook/preview-head.html — the preview root fills the canvas`));
+    }
+  } catch (previewError: any) {
+    console.warn(chalk.yellow(`⚠️  Could not write .storybook/preview-head.html: ${previewError.message}`));
   }
 
   // Add .env to .gitignore if not already there

--- a/cli/update.ts
+++ b/cli/update.ts
@@ -7,6 +7,7 @@ import inquirer from 'inquirer';
 import { createRequire } from 'module';
 import { ensureWatcherPolling } from '../story-generator/verify/storybookWatcher.js';
 import { mergeEnv } from './envFile.js';
+import { ensurePreviewRootCss } from './setup.js';
 import { ensureManagerAddonWiring, ensureStoriesGlobCoversMdx, missingReactStorybookDep, ensureManagerHeadPort, readConfiguredPort, ensureScriptPort, viteFinalConfigSnippet, insertConfigProperty, missingViteCjsIncludes } from './setup.js';
 
 const __filename = fileURLToPath(import.meta.url);
@@ -654,6 +655,10 @@ export async function updateCommand(options: UpdateOptions = {}): Promise<Update
     const configured = readConfiguredPort(process.cwd());
     if (configured) {
       try {
+        const previewRoot = ensurePreviewRootCss(process.cwd());
+        if (previewRoot.action !== 'unchanged') {
+          console.log(chalk.green(`   ✅ ${previewRoot.action === 'created' ? 'Created' : 'Updated'} .storybook/preview-head.html — the preview root fills the canvas, so a story's width never follows its content (restart Storybook)`));
+        }
         const head = ensureManagerHeadPort(process.cwd(), configured.port);
         if (head.action !== 'unchanged') {
           console.log(chalk.green(`   ✅ ${head.action === 'created' ? 'Created' : 'Updated'} .storybook/manager-head.html — the workspace page talks to port ${configured.port} (from ${configured.source})`));

--- a/story-generator/knowledge/spacingFacts.ts
+++ b/story-generator/knowledge/spacingFacts.ts
@@ -552,13 +552,9 @@ export function formatSpacingRules(
 
   lines.push('1. STORY WRAPPER (REQUIRED): one outer container gives the story its breathing room.');
   lines.push(`   Pattern: ${wrapperExample}`);
-  lines.push('   A composition with regions — a page, a dashboard, a settings screen, anything with');
-  lines.push('   tabs, a table or a sidebar — must take its width from the SPACE IT IS GIVEN, never');
-  lines.push('   from its content: fill the available width, and add a max width only if it should');
-  lines.push('   not run too wide. A root that hugs its content is re-measured every time the content');
-  lines.push('   changes, so switching a tab visibly resizes the whole page. A single component shown');
-  lines.push('   on its own (one button, one card, one input) should NOT be stretched — this rule is');
-  lines.push('   about compositions, not specimens.');
+  lines.push('   Choose the width the request calls for — a settings page and a single card want');
+  lines.push('   different things. Only one property is not a choice: the width must not depend on');
+  lines.push('   WHICH content is showing, or filtering a table resizes the whole page.');
   lines.push('2. FORM FIELDS & VERTICAL GROUPS: siblings are spaced by their PARENT. Put the gap on the');
   lines.push('   container and give no child a margin — a one-sided margin on one field of a pair is');
   lines.push('   the most common misalignment in generated code.');
@@ -622,13 +618,9 @@ spacing utility scale, so inline spacing values are acceptable here — and only
    - The rendered story MUST have a wrapper element with padding
    - Pattern: ${ex.wrapper}
    - This ensures content has breathing room within the Storybook canvas
-   - A composition with regions — a page, a dashboard, a settings screen, anything with
-     tabs, a table or a sidebar — must take its width from the SPACE IT IS GIVEN, never
-     from its content: fill the available width, and add a max width only if it should
-     not run too wide. A root that hugs its content is re-measured every time the content
-     changes, so switching a tab visibly resizes the whole page. A single component shown
-     on its own (one button, one card, one input) should NOT be stretched — this rule is
-     about compositions, not specimens.
+   - Choose the width the request calls for; a settings page and a single card want
+     different things. Only one property is not a choice: the width must not depend on
+     WHICH content is showing, or filtering a table resizes the whole page.
 
 2. FORM FIELD SPACING (CRITICAL):
    - ALWAYS wrap form fields in a container with vertical spacing

--- a/story-generator/verify/probes/interaction.ts
+++ b/story-generator/verify/probes/interaction.ts
@@ -66,6 +66,16 @@ export interface Reflow {
   after: number;
   /** Body width change over the same click, so a scrollbar is not a finding. */
   hostDelta: number;
+  /**
+   * The HOST makes the story shrink-wrap: Storybook's root is a flex or grid
+   * ITEM whose cross-axis sizing hugs its content, which happens when a
+   * project's preview stylesheet centres the body. Then the width follows the
+   * content no matter what the story does, and the fix is one line of CSS in
+   * the preview — not a change to the composition. Story UI writes that line
+   * into .storybook/preview-head.html; a project that predates it has not got
+   * it yet.
+   */
+  hostShrinkWraps: boolean;
 }
 
 export interface InteractionResult {
@@ -343,6 +353,26 @@ export async function runInteractionProbe(
       // Below this, sub-pixel layout and a focus ring account for the change.
       const REFLOW_PX = 8;
 
+      /** Does the HOST force the story to hug its content? */
+      const hostShrinkWraps = (() => {
+        const host = (document.querySelector('#storybook-root') || document.querySelector('#root')) as HTMLElement | null;
+        const parent = host?.parentElement;
+        if (!host || !parent) return false;
+        const ps = getComputedStyle(parent);
+        const hs = getComputedStyle(host);
+        if (hs.width && hs.width.endsWith('%')) return false;
+        const flex = ps.display.includes('flex');
+        const grid = ps.display.includes('grid');
+        if (!flex && !grid) return false;
+        // Cross-axis sizing that hugs: anything but stretch/normal.
+        const cross = flex && ps.flexDirection.startsWith('column') ? ps.alignItems : (grid ? ps.justifyItems : ps.alignItems);
+        const hugs = /center|start|end|flex-start|flex-end/.test(cross);
+        // Proof rather than inference: the root is narrower than the space it has.
+        const room = parent.getBoundingClientRect().width;
+        const used = host.getBoundingClientRect().width;
+        return hugs && used < room - 24;
+      })();
+
       for (const el of toggles) {
         const before = toggleState(el);
         const sizeBefore = widths();
@@ -361,6 +391,7 @@ export async function runInteractionProbe(
             before: Math.round(sizeBefore.story),
             after: Math.round(sizeAfter.story),
             hostDelta: Math.round(hostDelta),
+            hostShrinkWraps,
           });
         }
 
@@ -417,6 +448,68 @@ export async function runInteractionProbe(
             before: Math.round(sizeBefore.story),
             after: Math.round(sizeAfter.story),
             hostDelta: Math.round(hostDelta),
+            hostShrinkWraps,
+          });
+        }
+      }
+
+      /* ── 1c. Filters: does choosing a value keep the page the same width? ── */
+
+      /**
+       * The trigger people actually hit. A status filter narrowing a table
+       * from six rows to two measured 917px → 884px on a generated dashboard,
+       * and neither the toggle loop nor the tab pass reaches a select: one has
+       * no checked state, the other is not a tab. Filtering legitimately
+       * changes a page's HEIGHT; it must never change its WIDTH.
+       *
+       * Two shapes, because design systems ship both: a native <select>,
+       * changed through the DOM so no menu has to open, and the listbox
+       * pattern, where the trigger is pressed and an option chosen.
+       */
+      const filters = queryAll('select, [role="combobox"]')
+        .filter(el => {
+          const r = el.getBoundingClientRect();
+          return r.width > 0 && r.height > 0 && !(el as HTMLSelectElement).disabled;
+        })
+        .slice(0, 3);
+
+      for (const el of filters) {
+        const filterLabel = nameOf(el).slice(0, 40);
+        const sizeBefore = widths();
+        let changed = false;
+
+        if (el.tagName === 'SELECT') {
+          const select = el as HTMLSelectElement;
+          if (select.options.length > 1) {
+            const next = (select.selectedIndex + 1) % select.options.length;
+            select.selectedIndex = next;
+            select.dispatchEvent(new Event('input', { bubbles: true }));
+            select.dispatchEvent(new Event('change', { bubbles: true }));
+            changed = true;
+          }
+        } else {
+          try {
+            press(el as HTMLElement);
+            await sleep(220);
+            const option = Array.from(document.querySelectorAll('[role="option"]'))
+              .find(o => o.getAttribute('aria-selected') !== 'true' && (o as HTMLElement).offsetParent !== null) as HTMLElement | undefined;
+            if (option) { press(option); changed = true; }
+          } catch { /* a trigger that refuses to open tells us nothing */ }
+        }
+        if (!changed) continue;
+        await sleep(320);   // let the filtered content settle
+
+        const sizeAfter = widths();
+        const hostDelta = sizeAfter.host - sizeBefore.host;
+        const storyDelta = sizeAfter.story - sizeBefore.story;
+        if (Math.abs(storyDelta - hostDelta) > REFLOW_PX && result.reflows.length < 4) {
+          result.reflows.push({
+            label: filterLabel,
+            descriptor: `${el.tagName.toLowerCase()}${el.getAttribute('role') ? `[role=${el.getAttribute('role')}]` : ''}`,
+            before: Math.round(sizeBefore.story),
+            after: Math.round(sizeAfter.story),
+            hostDelta: Math.round(hostDelta),
+            hostShrinkWraps,
           });
         }
       }

--- a/story-generator/verify/verifyStory.ts
+++ b/story-generator/verify/verifyStory.ts
@@ -614,14 +614,33 @@ export async function verifyStory(options: VerifyStoryOptions): Promise<VerifyRe
      * the "looks broken" the user sees.
      */
     for (const r of interaction.reflows ?? []) {
-      findings.push({
-        id: `reflow-${findings.length}`,
-        severity: 'blocker',
-        class: 'code',
-        message: `Using "${r.label}" changes the width of the whole composition (${r.before}px → ${r.after}px), so the page jumps when it is used — the layout takes its width from its content. Give the composition's outermost element a width it controls (fill the space it is given, with a max-width if it should not run too wide) so switching content cannot resize it.`,
-        evidence: `${r.descriptor} "${r.label}": composition ${r.before}px → ${r.after}px while the viewport changed by ${r.hostDelta}px`,
-        repairable: true,
-      });
+      /**
+       * Whose defect is this?
+       *
+       * When Storybook's own root is a shrink-to-fit flex item — which a
+       * project's preview stylesheet causes by centring the body — the width
+       * follows the content whatever the story does, and asking a model to
+       * fix it would have it rewrite a correct composition. That is the
+       * environment's to fix, in one line of CSS, which `story-ui update`
+       * writes. Only when the host is innocent is the story answerable.
+       */
+      findings.push(r.hostShrinkWraps
+        ? {
+            id: `reflow-host-${findings.length}`,
+            severity: 'warning',
+            class: 'infrastructure',
+            message: `Using "${r.label}" changes the width of the whole page (${r.before}px → ${r.after}px), because this Storybook's preview makes the story hug its content rather than fill the canvas. The story is not the cause. Run \`npx story-ui update\` to add the one-line preview rule, then restart Storybook.`,
+            evidence: `${r.descriptor} "${r.label}": ${r.before}px → ${r.after}px; #storybook-root is a shrink-to-fit item of a flex/grid parent`,
+            repairable: false,
+          }
+        : {
+            id: `reflow-${findings.length}`,
+            severity: 'blocker',
+            class: 'code',
+            message: `Using "${r.label}" changes the width of the whole composition (${r.before}px → ${r.after}px), so the page jumps when it is used — its width depends on which content is showing. Give the composition's outermost element a width that does not follow its content.`,
+            evidence: `${r.descriptor} "${r.label}": composition ${r.before}px → ${r.after}px while the viewport changed by ${r.hostDelta}px`,
+            repairable: true,
+          });
     }
 
     findings.push(...censusFindings(census.problems));


### PR DESCRIPTION

A generated dashboard resized itself every time a filter or a tab changed:
917px on one status, 884px on another. The story was not the cause. That
project's preview stylesheet centres the body, which turns Storybook's own
#storybook-root into a shrink-to-fit flex item — so the page's width becomes
"however wide the current content happens to be", whatever the composition
does.

Measured, one line of CSS on the container: 917 → 884px before, 1568 → 1568px
after, with the story untouched.

So the fix belongs to the container, not the generations. init and update now
write that line into .storybook/preview-head.html, appended after whatever the
project already has and never replacing it, idempotently. It restores
Storybook's own default rather than imposing a new one, and it is scoped away
from layout: 'centered', where hugging the content is the point.

The rule this previously put on generations is withdrawn. Width is the
author's choice — a settings page and a single card want different things —
and the prompt now says only that the width must not depend on WHICH content
is showing.

Verification keeps measuring the symptom and learns whose it is: when
Storybook's root is a shrink-to-fit item the finding is infrastructure, a
warning, never repairable, and it names `story-ui update` as the fix, so no
model is ever asked to rewrite a correct composition for someone else's CSS.
The reflow pass also covers filters now — a select or combobox changing value
was the trigger here, and neither the toggle loop nor the tab pass reached it.



https://claude.ai/code/session_0158a8zxX4SKPdxm7DLfgqp4
