### PR TITLE
fix(generator): the prompt bounds scope instead of instructing more of it

### DIFF
--- a/__tests__/loader-failure.test.ts
+++ b/__tests__/loader-failure.test.ts
@@ -89,3 +89,26 @@ describe('the preview root fills the canvas', () => {
     expect(ensurePreviewRootCss(fresh).action).toBe('created');
   });
 });
+
+describe('the prompt bounds scope instead of encouraging it', () => {
+  it('keeps operability and forbids inventing regions the request did not ask for', async () => {
+    // The rules live in the prompt buildFrameworkAwarePrompt assembles — the
+    // live path generationCore uses, not the legacy component reference.
+    const { buildFrameworkAwarePrompt } = await import('../story-generator/promptGenerator');
+    const text = await buildFrameworkAwarePrompt(
+      'a navigation bar with logo and menu links',
+      { importPath: '@acme/ui', layoutRules: {}, componentFramework: 'react', framework: 'react', generatedStoriesPath: './src/stories/generated/' } as any,
+      [{ name: 'Button', filePath: '', props: [] }] as any,
+      { framework: { componentFramework: 'react' } } as any,
+    );
+    // Operability survives: that rule exists because "keep it concise" once
+    // produced mockups with no interactive controls at all.
+    expect(text).toContain('MUST be operable, not a mockup');
+    expect(text).toContain('NEVER render a visual stand-in');
+    // The instruction that caused over-building is gone, and bounded.
+    expect(text).not.toContain('Prefer completeness of behavior over brevity');
+    expect(text).toContain('Completeness means BEHAVIOUR, not scope');
+    expect(text).toContain('Build what was asked for');
+    expect(text).toContain('a navigation bar is a navigation bar');
+  });
+});

--- a/story-generator/promptGenerator.ts
+++ b/story-generator/promptGenerator.ts
@@ -319,7 +319,18 @@ export async function buildFrameworkAwarePrompt(
     // with zero inputs, zero links and no interactive states.
     '- The story MUST be operable, not a mockup: anything a user would click, type into, toggle or select MUST be the real interactive component from the design system, with real state and real handlers',
     '- NEVER render a visual stand-in for an interactive element (no text styled to look like an input, no bare icon standing in for a button, no static row standing in for tabs or a menu)',
-    '- Prefer completeness of behavior over brevity — these stories are lifted directly into product code',
+    // "Prefer completeness of behavior over brevity" sat here, and it was
+    // read as licence to build MORE: a request for a navigation bar came back
+    // as a 327-line page with a hero and a feature grid. Measured across four
+    // design systems, invented scope was the single largest preventable
+    // defect class (41 findings, all four libraries) — instructed by this
+    // prompt, not invented by the model.
+    //
+    // Completeness and scope are different axes. The rule above already
+    // demands operability; this one bounds what is built, so the two cannot
+    // be confused.
+    '- Completeness means BEHAVIOUR, not scope: what the story does include must be fully operable, with real state and handlers. It does not mean adding more.',
+    '- Build what was asked for, and what that plainly requires — nothing else. A request for a navigation bar is a navigation bar, not a page built around one. Do not add regions, panels or features the request did not ask for (a search field, a filter bar, a notification centre, an activity feed, a toast system). When a request is broad ("a dashboard"), build the parts it names or plainly implies and make those excellent, rather than adding others to look thorough.',
     // Verification blocks on this and the prompt never mentioned it, so the
     // model was being failed for a rule it was never given. Measured on one
     // loan-calculator generation: 7 blockers, 5 of them icon-only controls


### PR DESCRIPTION

Mining 80 generations across four design systems for what fails on the FIRST
attempt put invented scope at the top of the preventable list: 41 findings,
present in all four libraries — "a navigation bar" returning a 327-line page
with a hero and a feature grid. It is not the model inventing; it is this
prompt asking:

  '- Prefer completeness of behavior over brevity — these stories are lifted
    directly into product code'

That line earned its place: the rule before it said "keep the story concise
and avoid complex layouts", and the measured result was mockups with no
interactive controls at all. But completeness and scope are different axes,
and one sentence covering both is read as licence to build more.

They are now separate. Operability is unchanged and still demanded — what the
story includes must be real, with state and handlers. A second rule bounds
what gets built: what was asked and what it plainly requires, nothing else,
with a broad request answered by making the parts it names excellent rather
than adding others to look thorough.

No new knowledge, no new probe, no cost. The corpus predicts this is the
single largest first-attempt improvement available.



https://claude.ai/code/session_0158a8zxX4SKPdxm7DLfgqp4
