### PR TITLE
feat(ci): bench how often the first model output is already right

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -551,6 +551,14 @@ measure a filesystem property, badly:
   components.
 - **`bench/componentSelection.mjs`** — LLM, slow, noisy. Judgement only. Run
   rarely.
+- **`bench/firstAttempt.mjs`** — LLM, minutes. The pipeline's own recovery
+  hides its failure rate: validation self-heals, verification repairs, the gate
+  regenerates, and all three report "Verified". This one records what happened
+  BEFORE any of that, and prints one number —
+  `first-attempt clean: N/20 (X%) · median model calls M · median Ns`.
+  Run it either side of a PREVENTION change (knowledge, prompt), never on every
+  commit. A run it could not judge is counted in neither column and said out
+  loud; the percentage is over what was judged.
 
 ### Test environments, and a warning
 

--- a/__tests__/first-attempt-record.test.ts
+++ b/__tests__/first-attempt-record.test.ts
@@ -1,0 +1,262 @@
+/**
+ * The first-attempt bench's record shaping.
+ *
+ * The cases that matter are the ones a live run will not produce on demand: a
+ * stream that ends without a completion, a server too old to send `gate`, a
+ * verification that could not judge. Every one of them must come out as
+ * UNKNOWN — distinct from both clean and dirty — because the whole point of
+ * the metric is that it cannot be gamed by a check that silently did not run.
+ */
+import { describe, it, expect } from 'vitest';
+// @ts-expect-error — the bench is plain ESM JavaScript, deliberately outside tsconfig.
+import { buildRecord, summarise, headline, classifyValidationError, storyBlockerVerdict, median } from '../bench/lib/firstAttemptRecord.mjs';
+// @ts-expect-error — same.
+import { PROMPTS, selectSuite } from '../bench/firstAttempt.mjs';
+
+const P = { id: 'c01', suite: 'classic', complexity: 'simple', prompt: 'A primary button' };
+
+const ev = (type: string, data: unknown) => ({ type, timestamp: 0, data });
+const progress = (phase: string, message = '') => ev('progress', { step: 1, totalSteps: 11, phase, message });
+
+function completion(over: Record<string, unknown> = {}) {
+  return ev('completion', {
+    success: true,
+    storyId: 'story-abc',
+    fileName: 'button-abc12345.stories.tsx',
+    summary: { action: 'created', description: '' },
+    metrics: { totalTimeMs: 30000, llmCallsCount: 2 },
+    validation: { isValid: true, errors: [], warnings: [], autoFixApplied: false, attempts: 1, selfHealingUsed: false },
+    verification: { outcome: 'verified', findings: [] },
+    gate: { attempts: 1, bestAttempt: 1, shippable: true, reason: 'verified clean' },
+    ...over,
+  });
+}
+
+const validationOk = ev('validation', { isValid: true, errors: [], warnings: [], autoFixApplied: false });
+
+describe('firstAttemptClean', () => {
+  it('is true only when validation passed round 1, verification found no story blocker, and the gate spent one attempt', () => {
+    const r = buildRecord({ prompt: P, events: [validationOk, progress('verified'), completion()], durationMs: 31000 });
+    expect(r.firstAttemptClean).toBe(true);
+    expect(r.validation.attempts).toBe(1);
+    expect(r.gate.attempts).toBe(1);
+    expect(r.modelCalls).toBe(2);
+    expect(r.seconds).toBe(31);
+  });
+
+  it('is false when the first output failed validation, even though healing made it valid', () => {
+    const events = [
+      ev('validation', {
+        isValid: false,
+        errors: ['Line 4: <Button tone="loud"> it accepts only "primary" | "secondary"'],
+        errorsByBucket: { syntax: [], pattern: [], import: ['Line 4: <Button tone="loud"> it accepts only "primary" | "secondary"'] },
+        warnings: [], autoFixApplied: false,
+      }),
+      ev('retry', { attempt: 2, maxAttempts: 3, reason: 'AI self-healing: fixing validation errors', errors: [] }),
+      validationOk,
+      progress('verified'),
+      completion({ validation: { isValid: true, errors: [], warnings: [], autoFixApplied: false, attempts: 2, selfHealingUsed: true } }),
+    ];
+    const r = buildRecord({ prompt: P, events, durationMs: 60000 });
+    expect(r.firstAttemptClean).toBe(false);
+    expect(r.validation.attempts).toBe(2);
+    expect(r.validation.passedFirstRound).toBe(false);
+    expect(r.validation.rounds[0].errors[0].class).toBe('prop-bad-value');
+    expect(r.validation.rounds[0].errors[0].bucket).toBe('import');
+  });
+
+  it('is false when the gate regenerated, and records why the earlier attempt failed', () => {
+    const events = [
+      validationOk,
+      progress('verify_issues', '2 blockers'),
+      progress('gate_retry', 'Attempt 1 failed verification (2 blockers: text overflows) — generating again with the findings'),
+      validationOk,
+      progress('verified'),
+      completion({ gate: { attempts: 2, bestAttempt: 2, shippable: true, reason: 'verified clean' } }),
+    ];
+    const r = buildRecord({ prompt: P, events, durationMs: 90000 });
+    expect(r.firstAttemptClean).toBe(false);
+    expect(r.gate.attempts).toBe(2);
+    expect(r.gate.earlierFailures[0].reason).toMatch(/2 blockers/);
+    // Validation counted for ATTEMPT 1 only, not the whole run.
+    expect(r.validation.attempts).toBe(1);
+  });
+
+  it('is false when a repair pass was needed, even though the repaired story verifies clean', () => {
+    // The gate's verdict is computed AFTER repair, so `shippable` alone cannot
+    // tell "was right" from "was made right". A repair having run is the proof.
+    const r = buildRecord({
+      prompt: P,
+      events: [validationOk, progress('verify_repairing'), progress('verify_repaired'), progress('verified'), completion()],
+      durationMs: 40000,
+    });
+    expect(r.verification.repairRan).toBe(true);
+    expect(r.verification.storyBlockerFree).toBe(true);   // after repair
+    expect(r.verification.firstOutputClean).toBe(false);  // before it
+    expect(r.firstAttemptClean).toBe(false);
+  });
+
+  it('records repair separately from the headline, with "ran but did not help" distinct from "did not run"', () => {
+    const ran = buildRecord({
+      prompt: P,
+      events: [validationOk, progress('verify_repairing'), progress('verify_repair_failed'), progress('verify_issues'),
+        completion({ gate: { attempts: 1, bestAttempt: 1, shippable: false, reason: '1 blocker: empty panel' } })],
+      durationMs: 1000,
+    });
+    expect(ran.verification.repairRan).toBe(true);
+    expect(ran.verification.repairImproved).toBe(false);
+    expect(ran.firstAttemptClean).toBe(false);
+
+    const never = buildRecord({ prompt: P, events: [validationOk, progress('verified'), completion()], durationMs: 1000 });
+    expect(never.verification.repairRan).toBe(false);
+    expect(never.verification.repairImproved).toBe(null);
+  });
+});
+
+describe('absent is not zero', () => {
+  it('a run that never reached a verification outcome is UNKNOWN, not clean', () => {
+    const r = buildRecord({ prompt: P, events: [validationOk, completion({ gate: undefined, verification: undefined })], durationMs: 1000 });
+    expect(r.verification.repairRan).toBe(null);
+    expect(r.firstAttemptClean).toBe(null);
+    expect(r.unknown.join(' ')).toMatch(/whether a repair was needed is unknown/);
+  });
+
+  it('an unverifiable run is UNKNOWN, not clean and not dirty', () => {
+    const r = buildRecord({
+      prompt: P,
+      events: [validationOk, progress('verify_inconclusive'), completion({
+        verification: { outcome: 'not_verified', reason: 'Storybook unreachable', findings: [] },
+        gate: { attempts: 1, bestAttempt: 1, shippable: false, reason: 'not verified: Storybook unreachable' },
+      })],
+      durationMs: 1000,
+    });
+    expect(r.firstAttemptClean).toBe(null);
+    expect(r.unknown.join(' ')).toMatch(/verification inconclusive/);
+  });
+
+  it('a stream that ends without a completion reports null counts, never 0', () => {
+    const r = buildRecord({ prompt: P, events: [], durationMs: 5000, transportError: { code: 'TIMEOUT', message: 'no completion within 600s' } });
+    expect(r.firstAttemptClean).toBe(null);
+    expect(r.modelCalls).toBe(null);
+    expect(r.validation.attempts).toBe(null);
+    expect(r.gate.attempts).toBe(null);
+    expect(r.outcome).toBe('transport-error');
+  });
+
+  it('a definite failure stays false even when another leg is unknown', () => {
+    const r = buildRecord({
+      prompt: P,
+      events: [
+        ev('validation', { isValid: false, errors: ['Import error: "@foo/bar" does not resolve to a file'], warnings: [], autoFixApplied: false }),
+        progress('verify_inconclusive'),
+        completion({ verification: { outcome: 'not_verified', reason: 'no browser', findings: [] }, gate: undefined }),
+      ],
+      durationMs: 1000,
+    });
+    expect(r.firstAttemptClean).toBe(false);
+  });
+
+  it('blockers without attribution cannot be read as none', () => {
+    const withoutRepairable = storyBlockerVerdict(
+      { verification: { outcome: 'issues', findings: [{ id: 'x', severity: 'blocker', class: 'code', message: 'm' }] } },
+      1,
+    );
+    expect(withoutRepairable.verdict).toBe(null);
+    const libraryOwned = storyBlockerVerdict(
+      { verification: { outcome: 'issues', findings: [{ id: 'x', severity: 'blocker', class: 'a11y', message: 'm', repairable: false }] } },
+      1,
+    );
+    expect(libraryOwned.verdict).toBe(true);
+  });
+
+  it('falls back to counting gate_retry events when the server does not send gate', () => {
+    const r = buildRecord({
+      prompt: P,
+      events: [validationOk, progress('gate_retry', 'Attempt 1 failed'), validationOk, progress('verified'),
+        completion({ gate: undefined, verification: { outcome: 'verified', findings: [] } })],
+      durationMs: 1000,
+    });
+    expect(r.gate.attempts).toBe(2);
+    expect(r.gate.source).toBe('gate_retry progress events');
+    expect(r.firstAttemptClean).toBe(false);
+  });
+});
+
+describe('summary', () => {
+  const clean = buildRecord({ prompt: P, events: [validationOk, progress('verified'), completion()], durationMs: 20000 });
+  const dirty = buildRecord({
+    prompt: { ...P, id: 'c02' },
+    events: [
+      ev('validation', {
+        isValid: false,
+        errors: ['Line 3: var(--brand-500) is not a design token in this project'],
+        errorsByBucket: { syntax: [], pattern: [], import: ['Line 3: var(--brand-500) is not a design token in this project'] },
+        warnings: [], autoFixApplied: false,
+      }),
+      ev('retry', { attempt: 2, maxAttempts: 3, reason: 'AI self-healing: fixing validation errors', errors: [] }),
+      validationOk, progress('verified'),
+      completion({ metrics: { totalTimeMs: 1, llmCallsCount: 4 } }),
+    ],
+    durationMs: 40000,
+  });
+  const unknown = buildRecord({
+    prompt: { ...P, id: 'c03' },
+    events: [validationOk, progress('verify_inconclusive'), completion({ verification: { outcome: 'not_verified', reason: 'no browser', findings: [] }, gate: { attempts: 1, bestAttempt: 1, shippable: false, reason: 'not verified: no browser' } })],
+    durationMs: 30000,
+  });
+
+  it('scores the percentage over what was JUDGED and names the unjudged', () => {
+    const s = summarise([clean, dirty, unknown]);
+    expect(s.total).toBe(3);
+    expect(s.clean).toBe(1);
+    expect(s.dirty).toBe(1);
+    expect(s.unknown).toBe(1);
+    expect(s.judged).toBe(2);
+    expect(s.percent).toBe(50);
+    expect(headline(s)).toBe('first-attempt clean: 1/2 judged of 3 (50%) · median model calls 2 · median 30s');
+  });
+
+  it('counts first-round error classes only — the prevention targets', () => {
+    const s = summarise([clean, dirty, unknown]);
+    expect(s.validationClasses).toEqual([['token-undeclared', 1]]);
+    expect(s.selfHealed).toBe(1);
+  });
+
+  it('median ignores nulls and is null when nothing was measured', () => {
+    expect(median([1, null, 3])).toBe(2);
+    expect(median([null, undefined])).toBe(null);
+  });
+});
+
+describe('selectSuite', () => {
+  it('spreads a subset across the complexity range instead of taking the easy end', () => {
+    const six = selectSuite(PROMPTS, 6);
+    expect(six).toHaveLength(6);
+    expect(new Set(six.map((p: { complexity: string }) => p.complexity))).toEqual(new Set(['simple', 'medium']));
+    expect(six.map((p: { id: string }) => p.id)).toEqual(['c01', 'c04', 'c07', 'w01', 'w04', 'w07']);
+    expect(selectSuite(PROMPTS, 0)).toHaveLength(PROMPTS.length);
+    expect(selectSuite(PROMPTS, 99)).toHaveLength(PROMPTS.length);
+  });
+});
+
+describe('classifyValidationError', () => {
+  it.each([
+    ['Import from "@atlaskit" is not valid — that is an npm SCOPE, a directory of packages', 'import-isolation'],
+    ['Import error: "../x" does not export "Meta".', 'import-missing-export'],
+    ['Import error: "Foo" is an unknown component (not in the catalog for @mantine/core).', 'catalog-unknown-component'],
+    ['Line 2: "IconFoo" is not exported by lucide-react', 'icon-import'],
+    ['Line 9: inline gap: "12px" is a raw spacing value in a design system that has a spacing scale', 'inline-spacing'],
+    ['Line 5: <Card elevated> is not a prop this component declares', 'prop-undeclared'],
+    ['Line 7: var(--x) is a primitive colour; this project aliases it as --surface', 'token-tier'],
+    // Carbon's real wording, which an earlier pattern list classified as import-other.
+    ['Line 286: <IconButton kind="danger--ghost"> is not one of the values this prop accepts: primary | secondary. Map your data to those values.', 'prop-bad-value'],
+    ['Line 3: <Tile as={… as any}> casts away this prop\'s type; it accepts only "sm" | "lg".', 'prop-cast'],
+  ])('%s → %s', (message, cls) => {
+    expect(classifyValidationError(message as string)).toBe(cls);
+  });
+
+  it('falls back to the pipeline bucket rather than a catch-all', () => {
+    expect(classifyValidationError('TS1005: expected ;', 'syntax')).toBe('syntax-other');
+    expect(classifyValidationError('something new', null)).toBe('unclassified');
+  });
+});

--- a/bench/README.md
+++ b/bench/README.md
@@ -1,13 +1,86 @@
 # Benches
 
-Two benches, deliberately separate. Conflating them meant paying LLM prices
+Four benches, deliberately separate. Conflating them meant paying LLM prices
 to measure a filesystem property, badly.
 
 | Bench | Measures | Cost | Run |
 |---|---|---|---|
 | `resolution.mjs` | what the engine **knows** about a design system: components found, import specifiers resolve, props/descriptions/examples known | free, seconds, deterministic | on every change |
 | `fidelity.mjs` | what the engine **produces**: right components, right variants, inside the design system, minimal iterations, pins kept | LLM calls, minutes, noisy subject with deterministic scoring | when generation behaviour changes |
+| `firstAttempt.mjs` | how often the **first** model output is already right, before healing, repair or regeneration | LLM calls, minutes | before and after a prevention change |
 | `componentSelection.mjs` | judgement only | LLM | rarely |
+
+## firstAttempt.mjs
+
+The pipeline hides its own failure rate. Validation self-heals up to three
+times, verification repairs, and the shippable gate regenerates up to three
+times — so a story that cost four model calls and two rewrites reports exactly
+what a story that was right immediately reports: "Verified". That is right for
+the user and useless for judging PREVENTION work, which is about the first
+output, not the recovery.
+
+This bench drives the real server over `POST /mcp/generate-story-stream` and
+records, per prompt, what happened *before* any healing.
+
+```bash
+node bench/firstAttempt.mjs --server http://localhost:4109 --storybook http://localhost:6109 --name carbon
+node bench/firstAttempt.mjs --server http://localhost:4110 --suite 6          # 6 prompts, spread across the range
+node bench/firstAttempt.mjs --server http://localhost:4110 --only c01,c05,w03 # named prompts
+```
+
+Flags: `--server`, `--storybook`, `--project` (a path, or a directory name
+under `STORY_UI_TEST_PROJECTS` / `../test-storybooks`), `--name`, `--suite N`,
+`--only id,id`, `--timeout SECONDS` (default 600), `--keep` (do not delete the
+generated stories).
+
+The prompt set — 10 "classic" and 10 "workspace", simple → complex — lives in
+the script so two runs are comparable. `--suite N` takes N *evenly across* the
+ordered set: taking the first N would take the three simple ones and call the
+result a first-attempt rate.
+
+### The metric
+
+```
+first-attempt clean: N/20 (X%) · median model calls M · median Ns
+```
+
+`firstAttemptClean` is true when **all three** hold:
+
+| Leg | Read from |
+|---|---|
+| static validation passed on round 1 | the first `validation` SSE event of gate attempt 1 |
+| verification found no story-authored blocker, **and no repair was needed** | no `verify_repairing` phase, plus `completion.gate.shippable` (fallback: `verification.findings`, filtered exactly as `gate.ts` `storyBlockers` does) |
+| the gate spent one attempt | `completion.gate.attempts` (fallback: counting `gate_retry` progress events) |
+
+The repair clause is load-bearing. The gate's verdict is computed on the
+report taken *after* the repair pass, so `shippable` alone cannot tell a story
+that was right from one that was made right — a repair having run is itself
+proof that verification found a story-authored blocker in the first output.
+On the first carbon run this was the difference between 4/6 and 2/6.
+
+Also per prompt: `validationAttempts` and the classified errors of each
+correction round, `repairRan` / `repairImproved`, `gateAttempts` with the
+reason each earlier attempt failed, model calls (the server's own count across
+every gate attempt), seconds, findings by severity/class, and the outcome.
+
+### Absent is never zero
+
+A leg the stream could not report is `null`, printed as `?` and as `UNKNOWN`,
+and the run is counted in **neither** column — the percentage is over what was
+*judged*, with the unjudged count printed beside it. A Storybook that stalls
+mid-run therefore lowers confidence in a run instead of silently inflating or
+deflating the score. A conjunction with one definitely-false leg is still
+`false`, though, even when another leg is unknown.
+
+`node_modules` note: verification needs the project's Playwright and a
+reachable Storybook. **react-mantine (6101) cannot load newly created stories**
+and every run there reports `not_verified`; use another environment.
+
+### Output
+
+`bench/results/first-attempt/<timestamp>/<id>.json` per prompt, plus
+`summary.json`, a printed table, and the headline line. The table's last
+column is the first round's error classes — the prevention targets.
 
 ## fidelity.mjs
 

--- a/bench/firstAttempt.mjs
+++ b/bench/firstAttempt.mjs
@@ -1,0 +1,270 @@
+/**
+ * First-attempt bench — how often is the FIRST model output already right?
+ *
+ * WHY THIS EXISTS. The pipeline hides its own failure rate. Validation
+ * self-heals up to three times, browser verification repairs, and the
+ * shippable gate regenerates up to three times — and a story that cost four
+ * model calls and two rewrites reports exactly what a story that was correct
+ * immediately reports: "Verified". That is fine for the user and useless for
+ * us, because we are about to invest in PREVENTION (better pre-generation
+ * knowledge, a better prompt) and there is currently no number to move.
+ *
+ * So this bench drives the real server over the real SSE endpoint and records,
+ * per prompt, what happened BEFORE any healing:
+ *
+ *   validationAttempts   did the first model output pass static validation?
+ *   repairRan/Improved   did browser verification have to repair it, and did it help?
+ *   gateAttempts         how many full regenerations the gate spent, and why
+ *   firstAttemptClean    all three, as one boolean
+ *
+ * WHERE IT SITS AMONG THE OTHER BENCHES. resolution.mjs measures KNOWLEDGE
+ * (deterministic, free, run on every change). componentSelection.mjs measures
+ * JUDGEMENT (LLM, noisy, run rarely). This one measures the PIPELINE — it
+ * costs real model calls and minutes, so it is a before/after instrument for a
+ * prevention change, not something to run on every commit.
+ *
+ * ABSENT IS NOT ZERO. Every number this bench cannot measure is recorded as
+ * null and printed as `?`, never as 0 and never as "clean". A run verification
+ * could not judge is counted in neither column; the percentage is over what
+ * was judged, and the count of unjudged runs is printed beside it.
+ *
+ *   node bench/firstAttempt.mjs --server http://localhost:4109 --storybook http://localhost:6109
+ *   node bench/firstAttempt.mjs --server http://localhost:4110 --suite 6 --keep
+ *   node bench/firstAttempt.mjs --server http://localhost:4110 --only c01,c05,w03
+ */
+
+import fs from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
+import { buildRecord, summarise, headline, formatTable, formatSummary } from './lib/firstAttemptRecord.mjs';
+
+const args = process.argv.slice(2);
+const arg = (n, d) => { const i = args.indexOf(`--${n}`); return i >= 0 && args[i + 1] ? args[i + 1] : d; };
+const flag = (n) => args.includes(`--${n}`);
+
+/** This repository, found from the script's location — never a machine path. */
+const REPO = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+
+/**
+ * Where the Storybook fixtures live. Same convention as resolution.mjs: only
+ * their LOCATION is configurable, because they are separate checkouts.
+ */
+const PROJECTS_ROOT = process.env.STORY_UI_TEST_PROJECTS
+  ? path.resolve(process.env.STORY_UI_TEST_PROJECTS)
+  : path.resolve(REPO, '..', 'test-storybooks');
+
+/**
+ * The prompt set, in the script so two runs are comparable.
+ *
+ * Ten "classic" and ten "workspace" prompts spanning simple → complex. They
+ * are only prompts; the split names where they were first collected, and is
+ * kept so a subset can be taken evenly across the range rather than off the
+ * easy end.
+ */
+export const PROMPTS = [
+  { id: 'c01', suite: 'classic', complexity: 'simple', prompt: 'A primary button labelled "Save changes" next to a secondary "Cancel" button' },
+  { id: 'c02', suite: 'classic', complexity: 'simple', prompt: 'A small card with a title, one line of text and a primary button' },
+  { id: 'c03', suite: 'classic', complexity: 'simple', prompt: 'A success alert that says "Your profile was updated" with a dismiss button' },
+  { id: 'c04', suite: 'classic', complexity: 'medium', prompt: 'Create a navigation bar with logo and menu links' },
+  { id: 'c05', suite: 'classic', complexity: 'medium', prompt: 'A login form with email, password, a "Remember me" checkbox and a submit button, with inline validation messages' },
+  { id: 'c06', suite: 'classic', complexity: 'medium', prompt: 'A pricing table with three tiers (Starter, Pro, Team), a feature list per tier and the middle tier highlighted' },
+  { id: 'c07', suite: 'classic', complexity: 'medium', prompt: 'A user profile card with avatar, name, role, three stats and Follow / Message buttons' },
+  { id: 'c08', suite: 'classic', complexity: 'complex', prompt: 'A settings page with a left sidebar of sections and a form on the right for the Profile section, with a sticky save bar' },
+  { id: 'c09', suite: 'classic', complexity: 'complex', prompt: 'A data table of orders with sortable columns, a status badge per row, row selection checkboxes and pagination' },
+  { id: 'c10', suite: 'classic', complexity: 'complex', prompt: 'An analytics dashboard with four stat tiles, a chart placeholder area, a recent activity list and a date range filter' },
+  { id: 'w01', suite: 'workspace', complexity: 'simple', prompt: 'A badge that says "New" in the brand colour' },
+  { id: 'w02', suite: 'workspace', complexity: 'simple', prompt: 'A text input labelled "Email address" with helper text and an error state' },
+  { id: 'w03', suite: 'workspace', complexity: 'simple', prompt: 'A modal dialog titled "Delete project?" with a warning message, Cancel and a destructive Delete button' },
+  { id: 'w04', suite: 'workspace', complexity: 'medium', prompt: 'A hero section with a headline, supporting text, a primary and a secondary call to action, and an image placeholder' },
+  { id: 'w05', suite: 'workspace', complexity: 'medium', prompt: 'A newsletter signup card with a heading, an email field and a subscribe button, with a success state' },
+  { id: 'w06', suite: 'workspace', complexity: 'medium', prompt: 'A notifications list with five items, unread items emphasised, and a "Mark all as read" action' },
+  { id: 'w07', suite: 'workspace', complexity: 'medium', prompt: 'A product card grid, three columns, each with image, name, price, rating and an add-to-cart button' },
+  { id: 'w08', suite: 'workspace', complexity: 'complex', prompt: 'A three-step checkout wizard with a stepper, a shipping form on step one, and Back / Continue buttons' },
+  { id: 'w09', suite: 'workspace', complexity: 'complex', prompt: 'A kanban board with three columns (To do, In progress, Done) and cards with title, assignee avatar and a priority tag' },
+  { id: 'w10', suite: 'workspace', complexity: 'complex', prompt: 'An inbox layout with a message list on the left, the selected message on the right, a reply box, and a toolbar with archive and delete' },
+];
+
+/**
+ * A subset of n prompts, taken EVENLY across the ordered set.
+ *
+ * Taking the first n would take the three simple classics and call the result
+ * a first-attempt rate; the complexity range is the point of the set.
+ */
+export function selectSuite(prompts, n) {
+  if (!n || n >= prompts.length) return prompts;
+  const step = prompts.length / n;
+  return Array.from({ length: n }, (_, i) => prompts[Math.floor(i * step)]);
+}
+
+// ============================================================
+// Driving one generation
+// ============================================================
+
+/**
+ * POST /mcp/generate-story-stream and collect every SSE event.
+ *
+ * The request shape is the panel's (templates/StoryUI/StoryUIPanel.tsx): a
+ * fresh story, no conversation, no images, `storybookUrl` sent unconditionally
+ * so browser verification knows where to look. Without it the server verifies
+ * against port 6006 by convention and reports a story that indexed fine as
+ * missing — which would show up here as a fake gate regeneration.
+ */
+async function generate({ server, storybook, prompt, timeoutMs }) {
+  const events = [];
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), timeoutMs);
+  const startedAt = Date.now();
+  try {
+    const res = await fetch(`${server}/mcp/generate-story-stream`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        prompt: prompt.prompt,
+        conversation: [{ role: 'user', content: prompt.prompt }],
+        isUpdate: false,
+        storybookUrl: storybook || undefined,
+        useStorybookMcp: false,
+      }),
+      signal: controller.signal,
+    });
+    if (!res.ok) {
+      return { events, durationMs: Date.now() - startedAt, transportError: { code: `HTTP_${res.status}`, message: await res.text().catch(() => res.statusText) } };
+    }
+    const reader = res.body.getReader();
+    const decoder = new TextDecoder();
+    let buffer = '';
+    for (;;) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      buffer += decoder.decode(value, { stream: true });
+      const lines = buffer.split('\n');
+      buffer = lines.pop() ?? '';
+      for (const line of lines) {
+        if (!line.startsWith('data: ')) continue;
+        try { events.push(JSON.parse(line.slice(6))); } catch { /* a partial frame; the next chunk completes it */ }
+      }
+    }
+    return { events, durationMs: Date.now() - startedAt, transportError: null };
+  } catch (err) {
+    const aborted = err?.name === 'AbortError';
+    return {
+      events,
+      durationMs: Date.now() - startedAt,
+      transportError: { code: aborted ? 'TIMEOUT' : 'TRANSPORT', message: aborted ? `no completion within ${Math.round(timeoutMs / 1000)}s` : String(err?.message ?? err) },
+    };
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+/**
+ * Remove what the run wrote, so the project is left as it was found.
+ *
+ * DELETE /story-ui/stories/:id removes the file AND the manifest entry, and it
+ * resolves the id the same way the panel does. A story left behind changes the
+ * next run's Storybook index, so cleanup is part of the measurement, not tidying.
+ */
+async function deleteStory(server, record) {
+  const id = record.fileName || record.storyId;
+  if (!id) return { deleted: false, reason: 'run produced no file' };
+  try {
+    const res = await fetch(`${server}/story-ui/stories/${encodeURIComponent(id)}`, { method: 'DELETE' });
+    if (res.ok) return { deleted: true };
+    return { deleted: false, reason: `HTTP ${res.status}` };
+  } catch (err) {
+    return { deleted: false, reason: String(err?.message ?? err) };
+  }
+}
+
+// ============================================================
+// Run
+// ============================================================
+
+async function main() {
+  const server = (arg('server', 'http://localhost:4001')).replace(/\/$/, '');
+  const storybook = (arg('storybook', '')).replace(/\/$/, '');
+  const projectArg = arg('project', '');
+  const project = projectArg
+    ? (path.isAbsolute(projectArg) ? projectArg : path.resolve(PROJECTS_ROOT, projectArg))
+    : null;
+  const timeoutMs = Number(arg('timeout', '600')) * 1000;
+  const keep = flag('keep');
+
+  const only = arg('only', '');
+  let prompts = only
+    ? PROMPTS.filter(p => only.split(',').map(s => s.trim()).includes(p.id))
+    : selectSuite(PROMPTS, Number(arg('suite', '0')) || 0);
+  if (prompts.length === 0) {
+    console.error(`No prompts selected. Known ids: ${PROMPTS.map(p => p.id).join(', ')}`);
+    process.exit(2);
+  }
+
+  // A server that is not there must fail loudly and immediately, not as
+  // twenty transport errors that look like twenty bad generations.
+  try {
+    const probe = await fetch(`${server}/mcp/components`, { signal: AbortSignal.timeout(10000) });
+    if (!probe.ok) throw new Error(`HTTP ${probe.status}`);
+  } catch (err) {
+    console.error(`Story UI server unreachable at ${server}/mcp/components: ${err?.message ?? err}`);
+    console.error('Start it with:  cd <project> && PORT=<port> node <story-ui>/dist/mcp-server/index.js');
+    process.exit(2);
+  }
+  if (!storybook) {
+    console.log('WARNING: no --storybook given. Browser verification will look for Storybook by convention,');
+    console.log('         so verification may report "not verified" and those runs will be UNJUDGED, not clean.');
+  }
+
+  const stamp = new Date().toISOString().replace(/[:.]/g, '-');
+  const outDir = path.join(REPO, 'bench', 'results', 'first-attempt', stamp);
+  fs.mkdirSync(outDir, { recursive: true });
+
+  const envLabel = arg('name', project ? path.basename(project) : server);
+  console.log(`first-attempt bench · ${envLabel} · ${prompts.length} prompt(s) · server ${server}${storybook ? ` · storybook ${storybook}` : ''}`);
+  console.log(`results → ${path.relative(process.cwd(), outDir) || outDir}\n`);
+
+  const records = [];
+  for (const [i, prompt] of prompts.entries()) {
+    process.stdout.write(`[${i + 1}/${prompts.length}] ${prompt.id} (${prompt.complexity}) … `);
+    const { events, durationMs, transportError } = await generate({ server, storybook, prompt, timeoutMs });
+    const record = buildRecord({ prompt, events, durationMs, env: envLabel, transportError });
+    const cleanup = keep ? { deleted: false, reason: 'kept (--keep)' } : await deleteStory(server, record);
+    record.cleanup = cleanup;
+    records.push(record);
+    /**
+     * The events are stored beside the record so a finished run can be
+     * RE-SCORED when the definition changes, instead of re-paying for it —
+     * `llm_text` excluded, because the code streams through it token by token
+     * and it is 90% of the bytes for none of the facts.
+     */
+    fs.writeFileSync(
+      path.join(outDir, `${prompt.id}.json`),
+      JSON.stringify({ ...record, events: events.filter(e => e?.type !== 'llm_text') }, null, 2),
+    );
+    const mark = record.firstAttemptClean === true ? 'CLEAN'
+      : record.firstAttemptClean === false ? 'dirty' : 'UNKNOWN';
+    console.log(`${mark}  val ${record.validation.attempts ?? '?'} · gate ${record.gate.attempts ?? '?'} · ${record.modelCalls ?? '?'} calls · ${record.seconds ?? '?'}s`);
+    if (!keep && !cleanup.deleted) console.log(`        NOT CLEANED UP: ${cleanup.reason}`);
+  }
+
+  const summary = summarise(records);
+  console.log('');
+  console.log(formatTable(records));
+  console.log('');
+  console.log(formatSummary(summary));
+
+  fs.writeFileSync(path.join(outDir, 'summary.json'), JSON.stringify({
+    env: envLabel, server, storybook: storybook || null, project,
+    startedAt: stamp, prompts: prompts.map(p => p.id), summary, headline: headline(summary),
+  }, null, 2));
+
+  // Exit code reports whether the RUN was valid, not whether the pipeline
+  // scored well: a low first-attempt rate is the finding, not a bench failure.
+  const broken = records.filter(r => r.outcome === 'transport-error' || r.outcome === 'incomplete').length;
+  if (broken) console.log(`\n${broken} run(s) never completed — this run is INCOMPLETE, not a measurement.`);
+  process.exit(broken ? 1 : 0);
+}
+
+// Importable for tests without running anything.
+if (process.argv[1] && path.resolve(process.argv[1]) === fileURLToPath(import.meta.url)) {
+  main().catch(err => { console.error(err); process.exit(1); });
+}

--- a/bench/lib/firstAttemptRecord.mjs
+++ b/bench/lib/firstAttemptRecord.mjs
@@ -1,0 +1,413 @@
+/**
+ * First-attempt bench — the pure half.
+ *
+ * Everything here is a fold over SSE events plus the completion payload. No
+ * network, no filesystem, no clock, so the shaping and the summary can be
+ * tested without a server — which matters, because the interesting cases
+ * (a run that errored mid-stream, a server too old to send `gate`) are the
+ * ones a live run will not reliably produce on demand.
+ *
+ * THE ONE RULE THIS FILE EXISTS TO ENFORCE. Absent is not zero. A field the
+ * stream did not carry becomes `null` and the record says WHY; it never
+ * becomes 0, `false`, or "clean". Three separate diagnoses on this project
+ * were wrong because a check that could not run reported the same thing as a
+ * check that found nothing.
+ */
+
+// ============================================================
+// Validation error classes — the prevention targets
+// ============================================================
+
+/**
+ * Ordered most-specific first: several of these substrings co-occur, and the
+ * first match wins. Each pattern is anchored on text a formatter in
+ * story-generator/ actually emits, not on a guess at what an error looks like.
+ */
+const ERROR_CLASSES = [
+  // Import isolation: a package outside the design system.
+  [/is not valid\s+—\s+that is an npm SCOPE/i, 'import-isolation'],
+  [/not part of (?:this|the) design system|is not in the design system|outside the design system|not an allowed import/i, 'import-isolation'],
+  // Import resolution and export existence.
+  [/does not resolve to a file/i, 'import-unresolved'],
+  [/does not export/i, 'import-missing-export'],
+  [/is an unknown component \(not in the catalog/i, 'catalog-unknown-component'],
+  // Icon packages: a real package, a name it does not export.
+  [/is not exported by\b/i, 'icon-import'],
+  // Design tokens.
+  [/is not a design token in this project/i, 'token-undeclared'],
+  [/is a primitive colour; this project aliases it/i, 'token-tier'],
+  // Spacing / typography literals.
+  [/is a raw spacing value|is an arbitrary spacing value|overrides the design system's typography/i, 'inline-spacing'],
+  // Prop conformance (the project's own TypeScript) vs catalog conformance.
+  [/is not a prop this component declares/i, 'prop-undeclared'],
+  [/props are declared on the component; do not hide them behind a cast|casts away this prop's type/i, 'prop-cast'],
+  [/uses a prop this version of the library deprecates/i, 'prop-deprecated'],
+  // Two shapes from conformance.ts: a literal that is not in the enum, and an
+  // `as any` that defeats the enum. Both are "the value is not one this prop
+  // takes", so both classify the same.
+  [/not one of the values this prop accepts|\baccepts only\b/i, 'prop-bad-value'],
+  // Edit blocks that did not apply (an update, not a fresh generation).
+  [/edit block|SEARCH (?:was )?not found|appears (?:more than once|twice)/i, 'edit-block-unmatched'],
+  // Story-shape patterns the validator forbids outright.
+  [/UNSAFE_style/i, 'pattern-unsafe-style'],
+  [/export default meta|missing (?:a )?default export|no story export/i, 'pattern-story-shape'],
+  [/emoji/i, 'pattern-emoji-icon'],
+];
+
+/**
+ * Which class of mistake one error message describes.
+ *
+ * `bucket` is the pipeline's own three-way split (syntax / pattern / import),
+ * carried on the validation event so an unrecognised message still lands
+ * somewhere true rather than in a catch-all that hides what it is.
+ */
+export function classifyValidationError(message, bucket = null) {
+  const text = String(message ?? '');
+  for (const [re, cls] of ERROR_CLASSES) if (re.test(text)) return cls;
+  if (bucket === 'syntax') return 'syntax-other';
+  if (bucket === 'pattern') return 'pattern-other';
+  if (bucket === 'import') return 'import-other';
+  return 'unclassified';
+}
+
+/** Every error in one validation event, classified, keeping bucket provenance. */
+export function classifyRound(validationEvent) {
+  const byBucket = validationEvent?.errorsByBucket;
+  if (byBucket) {
+    return [
+      ...(byBucket.syntax ?? []).map(m => ({ message: m, bucket: 'syntax', class: classifyValidationError(m, 'syntax') })),
+      ...(byBucket.pattern ?? []).map(m => ({ message: m, bucket: 'pattern', class: classifyValidationError(m, 'pattern') })),
+      ...(byBucket.import ?? []).map(m => ({ message: m, bucket: 'import', class: classifyValidationError(m, 'import') })),
+    ];
+  }
+  // Older server: the buckets were flattened before they reached us. Say so,
+  // rather than inventing a bucket.
+  return (validationEvent?.errors ?? []).map(m => ({ message: m, bucket: null, class: classifyValidationError(m, null) }));
+}
+
+// ============================================================
+// The fold over one run's stream
+// ============================================================
+
+const SELF_HEALING = /self-healing/i;
+
+/**
+ * Split a run's events by GATE attempt and pull out what happened in each.
+ *
+ * The gate re-runs the whole pipeline, so validation and verification events
+ * repeat. Attempt boundaries are the `gate_retry` progress events; everything
+ * before the first one belongs to attempt 1, which is the only attempt this
+ * bench's headline number is about.
+ */
+export function foldStream(events) {
+  const attempts = [{ validations: [], retries: [], phases: [], gateFailureReason: null }];
+  let completion = null;
+  let error = null;
+  let started = null;
+
+  for (const ev of events) {
+    const d = ev?.data ?? {};
+    switch (ev?.type) {
+      case 'started': started = d.generationId ?? null; break;
+      case 'progress': {
+        const cur = attempts[attempts.length - 1];
+        cur.phases.push(d.phase);
+        if (d.phase === 'gate_retry') {
+          cur.gateFailureReason = d.message ?? null;
+          attempts.push({ validations: [], retries: [], phases: [], gateFailureReason: null });
+        }
+        break;
+      }
+      case 'validation': attempts[attempts.length - 1].validations.push(d); break;
+      case 'retry': attempts[attempts.length - 1].retries.push(d); break;
+      case 'completion': completion = d; break;
+      case 'error': error = d; break;
+      default: break;
+    }
+  }
+  return { attempts, completion, error, generationId: started };
+}
+
+/**
+ * Did verification find a blocker the STORY authored, on the given attempt?
+ *
+ * true  — it rendered and nothing story-authored blocked.
+ * false — it did not render, or a story-authored blocker stood.
+ * null  — verification could not judge (no Storybook, no browser), which is
+ *         not a pass and is not a failure.
+ */
+export function storyBlockerVerdict(completion, gateAttempts) {
+  if (!completion) return { verdict: null, reason: 'no completion event' };
+  // The gate's own answer, when the server sends it: authoritative, because
+  // it is the value the pipeline actually acted on.
+  const gate = completion.gate;
+  if (gate) {
+    if (gateAttempts > 1) return { verdict: false, reason: `gate spent ${gateAttempts} attempts; attempt 1 was not shippable` };
+    if (gate.shippable) return { verdict: true, reason: gate.reason ?? 'shippable' };
+    if (/not verified|verification did not run/i.test(gate.reason ?? '')) {
+      return { verdict: null, reason: gate.reason ?? 'not verified' };
+    }
+    return { verdict: false, reason: gate.reason ?? 'not shippable' };
+  }
+  // Server without `gate` on the completion payload: reconstruct the same
+  // predicate from the findings, exactly as story-generator/verify/gate.ts does.
+  const v = completion.verification;
+  if (!v) return { verdict: null, reason: 'completion carried no verification and no gate' };
+  if (v.outcome === 'not_verified') return { verdict: null, reason: `not verified: ${v.reason ?? 'unknown'}` };
+  const findings = v.findings ?? [];
+  if (findings.some(f => String(f.id ?? '').startsWith('render-failed'))) {
+    return { verdict: false, reason: 'did not render' };
+  }
+  const candidates = findings.filter(f => f.severity === 'blocker' && f.class !== 'infrastructure');
+  const attributed = candidates.filter(f => f.repairable === true);
+  if (attributed.length > 0) return { verdict: false, reason: `${attributed.length} story blocker(s)` };
+  if (candidates.some(f => f.repairable === undefined)) {
+    // Blockers arrived without `repairable`, so "story-authored" could not be
+    // decided. Counting them as none would manufacture a clean run.
+    return { verdict: null, reason: 'blockers present but attribution (repairable) not on the stream' };
+  }
+  return { verdict: true, reason: v.outcome === 'verified' ? 'verified clean' : 'no story blockers' };
+}
+
+/** Median of numbers, ignoring nulls. Null when nothing was measured. */
+export function median(values) {
+  const xs = values.filter(v => typeof v === 'number' && Number.isFinite(v)).sort((a, b) => a - b);
+  if (xs.length === 0) return null;
+  const mid = Math.floor(xs.length / 2);
+  return xs.length % 2 ? xs[mid] : (xs[mid - 1] + xs[mid]) / 2;
+}
+
+/**
+ * One prompt's record: what happened BEFORE any healing, repair or regeneration.
+ */
+export function buildRecord({ prompt, events, durationMs, env, transportError = null }) {
+  const { attempts, completion, error } = foldStream(events ?? []);
+  const first = attempts[0];
+
+  // ---- validation, gate attempt 1 -------------------------------------
+  const firstValidation = first.validations[0] ?? null;
+  const healingRetries = first.retries.filter(r => SELF_HEALING.test(r.reason ?? ''));
+  const otherRetries = first.retries.filter(r => !SELF_HEALING.test(r.reason ?? ''));
+
+  const validationAttempts = firstValidation ? 1 + healingRetries.length : null;
+  const passedFirstRound = firstValidation ? firstValidation.isValid === true : null;
+
+  const rounds = [];
+  if (firstValidation) rounds.push({ round: 1, isValid: firstValidation.isValid === true, errors: classifyRound(firstValidation) });
+  healingRetries.forEach((r, i) => {
+    const next = first.validations[i + 1];
+    rounds.push({
+      round: i + 2,
+      isValid: next ? next.isValid === true : null,
+      errors: next ? classifyRound(next) : (r.errors ?? []).map(m => ({ message: m, bucket: null, class: classifyValidationError(m) })),
+    });
+  });
+
+  // ---- gate ------------------------------------------------------------
+  const gateRetryEvents = attempts.length - 1;
+  const gateAttempts = completion?.gate?.attempts ?? (completion || error ? gateRetryEvents + 1 : null);
+  const gateFailures = attempts.slice(0, -1).map((a, i) => ({ attempt: i + 1, reason: a.gateFailureReason }));
+
+  // ---- verification and repair, gate attempt 1 -------------------------
+  /**
+   * `verify_inconclusive` is a terminal phase: verification reached an answer,
+   * and the answer is that it could not judge. Repair definitively did not run.
+   * Only a run that never reached ANY terminal verify phase leaves this null.
+   */
+  const VERIFY_TERMINAL = ['verified', 'verify_issues', 'verify_repair_failed', 'verify_inconclusive'];
+  const repairRan = first.phases.includes('verify_repairing')
+    ? true
+    : (first.phases.some(p => VERIFY_TERMINAL.includes(p)) ? false : null);
+  let repairImproved = null;
+  if (repairRan === true) {
+    if (first.phases.includes('verify_repaired')) repairImproved = true;
+    else if (first.phases.includes('verify_repair_failed')) repairImproved = false;
+  }
+
+  const blocker = storyBlockerVerdict(completion, gateAttempts ?? 1);
+
+  /**
+   * The verification leg, read honestly.
+   *
+   * `blocker.verdict` describes the report the gate acted on, which is the
+   * report AFTER repair. A story whose first output had two blockers that a
+   * repair pass removed reports `shippable` — indistinguishable from one that
+   * had none. So a repair having RUN is itself proof that verification found
+   * a story-authored blocker in the first output, and it fails this leg.
+   */
+  const verificationLeg = repairRan === null ? null : (repairRan === false && blocker.verdict === true ? true : (blocker.verdict === null ? null : false));
+
+  // ---- the headline ----------------------------------------------------
+  let firstAttemptClean = null;
+  const unknownReasons = [];
+  if (passedFirstRound === null) unknownReasons.push('validation never reported (run did not reach validation)');
+  if (verificationLeg === null) {
+    unknownReasons.push(repairRan === null
+      ? 'verification never reached an outcome, so whether a repair was needed is unknown'
+      : `verification inconclusive: ${blocker.reason}`);
+  }
+  if (gateAttempts === null) unknownReasons.push('gate attempts unknown (stream ended without completion or error)');
+  if (unknownReasons.length === 0) {
+    firstAttemptClean = passedFirstRound === true && verificationLeg === true && gateAttempts === 1;
+  } else if (passedFirstRound === false || verificationLeg === false || (gateAttempts !== null && gateAttempts > 1)) {
+    // One leg is definitively false, so the conjunction is false whatever the
+    // unknown legs turn out to be. Not clean, and not unknown.
+    firstAttemptClean = false;
+  }
+
+  const outcome = transportError ? 'transport-error'
+    : error ? 'error'
+    : !completion ? 'incomplete'
+    : completion.summary?.action ?? (completion.success ? 'created' : 'failed');
+
+  return {
+    id: prompt.id,
+    suite: prompt.suite ?? null,
+    complexity: prompt.complexity ?? null,
+    prompt: prompt.prompt,
+    env: env ?? null,
+    outcome,
+    firstAttemptClean,
+    unknown: firstAttemptClean === null ? unknownReasons : null,
+    durationMs: durationMs ?? null,
+    seconds: typeof durationMs === 'number' ? Math.round(durationMs / 100) / 10 : null,
+    // The count the SERVER kept, across every gate attempt. Null, never 0,
+    // when the run did not complete.
+    modelCalls: completion?.metrics?.llmCallsCount ?? null,
+    validation: {
+      attempts: validationAttempts,
+      passedFirstRound,
+      rounds,
+      // The completion's number describes the attempt the gate KEPT, which is
+      // a different question from "did attempt 1 pass". Both are recorded.
+      keptAttemptAttempts: completion?.validation?.attempts ?? null,
+      keptAttemptSelfHealed: completion?.validation?.selfHealingUsed ?? null,
+      nonHealingRetries: otherRetries.map(r => r.reason),
+    },
+    verification: {
+      outcome: completion?.verification?.outcome ?? null,
+      reason: completion?.verification?.reason ?? null,
+      // After repair — the report the gate acted on.
+      storyBlockerFree: blocker.verdict,
+      storyBlockerReason: blocker.reason,
+      /** The leg the headline uses: no repair was needed AND none stood after. */
+      firstOutputClean: verificationLeg,
+      findingsByClass: countBy(completion?.verification?.findings ?? [], f => `${f.severity}/${f.class}`),
+      repairRan,
+      repairImproved,
+    },
+    gate: {
+      attempts: gateAttempts,
+      bestAttempt: completion?.gate?.bestAttempt ?? null,
+      shippable: completion?.gate?.shippable ?? null,
+      reason: completion?.gate?.reason ?? null,
+      // Present only when the server forwards `gate`; otherwise the count came
+      // from counting gate_retry progress events, which is stated here.
+      source: completion?.gate ? 'completion.gate' : (completion || error ? 'gate_retry progress events' : 'unknown'),
+      earlierFailures: gateFailures,
+    },
+    storyId: completion?.storyId ?? null,
+    fileName: completion?.fileName ?? null,
+    error: transportError ?? (error ? { code: error.code, message: error.message } : null),
+  };
+}
+
+function countBy(items, key) {
+  const out = {};
+  for (const it of items) { const k = key(it); out[k] = (out[k] ?? 0) + 1; }
+  return out;
+}
+
+// ============================================================
+// Summary
+// ============================================================
+
+/** The number this bench exists to produce, plus what it could not measure. */
+export function summarise(records) {
+  const total = records.length;
+  const clean = records.filter(r => r.firstAttemptClean === true).length;
+  const dirty = records.filter(r => r.firstAttemptClean === false).length;
+  const unknown = records.filter(r => r.firstAttemptClean === null).length;
+  // The percentage is over what could be JUDGED. A run nobody could judge is
+  // not evidence of a clean rate and is not evidence against one.
+  const judged = clean + dirty;
+  const classCounts = {};
+  for (const r of records) {
+    for (const round of r.validation.rounds) {
+      if (round.round !== 1) continue; // prevention targets the FIRST output
+      for (const e of round.errors) classCounts[e.class] = (classCounts[e.class] ?? 0) + 1;
+    }
+  }
+  const promptsWithClass = {};
+  for (const r of records) {
+    const seen = new Set((r.validation.rounds.find(x => x.round === 1)?.errors ?? []).map(e => e.class));
+    for (const c of seen) promptsWithClass[c] = (promptsWithClass[c] ?? 0) + 1;
+  }
+  return {
+    total, clean, dirty, unknown, judged,
+    percent: judged ? Math.round((clean / judged) * 1000) / 10 : null,
+    medianModelCalls: median(records.map(r => r.modelCalls)),
+    medianSeconds: median(records.map(r => r.seconds)),
+    validationClasses: Object.entries(classCounts).sort((a, b) => b[1] - a[1]),
+    promptsPerValidationClass: promptsWithClass,
+    repairRan: records.filter(r => r.verification.repairRan === true).length,
+    repairImproved: records.filter(r => r.verification.repairImproved === true).length,
+    gateRegenerated: records.filter(r => typeof r.gate.attempts === 'number' && r.gate.attempts > 1).length,
+    selfHealed: records.filter(r => typeof r.validation.attempts === 'number' && r.validation.attempts > 1).length,
+  };
+}
+
+/** The one line we track over time. */
+export function headline(s) {
+  const pct = s.percent === null ? 'n/a' : `${s.percent}%`;
+  const mc = s.medianModelCalls === null ? 'unknown' : s.medianModelCalls;
+  const sec = s.medianSeconds === null ? 'unknown' : s.medianSeconds;
+  const denom = s.judged === s.total ? s.total : `${s.judged} judged of ${s.total}`;
+  return `first-attempt clean: ${s.clean}/${denom} (${pct}) · median model calls ${mc} · median ${sec}s`;
+}
+
+const CLEAN_MARK = { true: 'CLEAN', false: 'dirty', null: 'UNKNOWN' };
+
+/** Fixed-width table. `?` never stands for 0 — it stands for not measured. */
+export function formatTable(records) {
+  const col = (s, w) => String(s ?? '').padEnd(w).slice(0, w);
+  const num = (v, w) => String(v === null || v === undefined ? '?' : v).padStart(w);
+  const lines = [];
+  lines.push(`${col('id', 5)} ${col('cplx', 8)} ${col('first', 7)} ${num('val', 4)} ${num('gate', 5)} ${num('calls', 6)} ${num('secs', 6)} ${col('verify', 13)} ${col('repair', 11)} first-round error classes`);
+  lines.push('-'.repeat(110));
+  for (const r of records) {
+    const first = r.validation.rounds.find(x => x.round === 1);
+    const classes = first ? [...new Set(first.errors.map(e => e.class))].join(',') : (r.validation.passedFirstRound === null ? '(not measured)' : '');
+    const repair = r.verification.repairRan === null ? '?'
+      : r.verification.repairRan === false ? 'no'
+      : r.verification.repairImproved === true ? 'yes/better'
+      : r.verification.repairImproved === false ? 'yes/no-gain' : 'yes/?';
+    lines.push([
+      col(r.id, 5), col(r.complexity, 8),
+      col(CLEAN_MARK[String(r.firstAttemptClean)], 7),
+      num(r.validation.attempts, 4), num(r.gate.attempts, 5),
+      num(r.modelCalls, 6), num(r.seconds, 6),
+      col(r.verification.outcome ?? '?', 13), col(repair, 11),
+      classes,
+    ].join(' '));
+  }
+  return lines.join('\n');
+}
+
+/** The lines printed under the table: the metric, then the prevention targets. */
+export function formatSummary(s) {
+  const lines = [headline(s)];
+  if (s.unknown > 0) {
+    lines.push(`${s.unknown} run(s) NOT JUDGED — verification or validation could not report. Not counted as clean and not counted as dirty.`);
+  }
+  lines.push(`self-healed: ${s.selfHealed} · verification repair ran: ${s.repairRan} (improved ${s.repairImproved}) · gate regenerated: ${s.gateRegenerated}`);
+  if (s.validationClasses.length === 0) {
+    lines.push('first-round validation errors: none observed.');
+  } else {
+    lines.push('top first-round validation error classes (the prevention targets):');
+    for (const [cls, n] of s.validationClasses.slice(0, 8)) {
+      lines.push(`  ${String(n).padStart(4)}  ${cls}  (in ${s.promptsPerValidationClass[cls]} prompt${s.promptsPerValidationClass[cls] === 1 ? '' : 's'})`);
+    }
+  }
+  return lines.join('\n');
+}

--- a/mcp-server/routes/generateStoryStream.ts
+++ b/mcp-server/routes/generateStoryStream.ts
@@ -226,9 +226,17 @@ export async function generateStoryFromPromptStream(req: Request, res: Response)
         findings: outcome.verification.findings.map(f => ({
           id: f.id, severity: f.severity, class: f.class,
           message: f.message, evidence: f.evidence, selector: f.selector,
+          // Without this a client cannot tell a blocker the story authored
+          // from one the library rendered; the gate distinguishes them and
+          // only the first is the generator's fault.
+          repairable: f.repairable,
         })),
         metrics: outcome.verification.metrics,
       } : undefined,
+      // What the gate did. Computed by the pipeline and previously dropped
+      // here, which made "right first time" and "right on the third
+      // regeneration" report identically.
+      gate: outcome.gate,
       // Only surface runtime results the user should act on: a pass, or a
       // genuine in-Storybook crash. Inconclusive infra results (story not
       // indexed yet, Storybook unreachable) would show a false alarm.
@@ -247,6 +255,8 @@ export async function generateStoryFromPromptStream(req: Request, res: Response)
         warnings: outcome.validation.warnings,
         autoFixApplied: outcome.validation.autoFixApplied,
         fixDetails: outcome.validation.fixDetails,
+        attempts: outcome.validation.attempts,
+        selfHealingUsed: outcome.validation.selfHealingUsed,
       },
       code: outcome.code,
     });

--- a/mcp-server/routes/generationCore.ts
+++ b/mcp-server/routes/generationCore.ts
@@ -1611,6 +1611,14 @@ async function runStoryGenerationPipeline(
       ],
       warnings: [],
       autoFixApplied: !!astResult?.fixedCode,
+      // Kept in buckets as well as flattened: which KIND of error the first
+      // model output produced is the thing prevention work aims at, and the
+      // flat list cannot answer it.
+      errorsByBucket: {
+        syntax: currentErrors.syntaxErrors,
+        pattern: currentErrors.patternErrors,
+        import: currentErrors.importErrors,
+      },
     });
 
     finalErrors = currentErrors;

--- a/mcp-server/routes/streamTypes.ts
+++ b/mcp-server/routes/streamTypes.ts
@@ -71,6 +71,26 @@ export interface ValidationFeedback {
   warnings: string[];
   autoFixApplied: boolean;
   fixDetails?: string[];
+  /**
+   * How many model calls the self-healing loop spent on this pipeline run,
+   * counting the first. Present only on the completion event's validation
+   * block — the in-flight `validation` events describe one round each.
+   *
+   * Reported so a measurement can tell "passed on the first attempt" from
+   * "passed after two corrections". Both end with `isValid: true`, and
+   * without this number they are indistinguishable to any client.
+   */
+  attempts?: number;
+  /** Whether any correction round ran at all. `attempts > 1`, stated plainly. */
+  selfHealingUsed?: boolean;
+  /**
+   * The same errors, still in the three buckets the pipeline validates in.
+   * `errors` flattens them, which loses the one fact a measurement of
+   * PREVENTION needs: whether the model wrote unparseable code, used a
+   * forbidden pattern, or reached for something the design system does not
+   * have. Absent on events emitted outside the healing loop.
+   */
+  errorsByBucket?: { syntax: string[]; pattern: string[]; import: string[] };
 }
 
 // Retry information
@@ -160,12 +180,30 @@ export interface CompletionFeedback {
       message: string;
       evidence?: string;
       selector?: string;
+      /**
+       * Whether a bounded repair could plausibly fix this. The gate treats
+       * `false` as "the library authored it, not the story", so a client
+       * cannot tell a story-authored blocker from a library-authored one
+       * without this field.
+       */
+      repairable?: boolean;
     }>;
     metrics?: Record<string, number | string | boolean | string[]>;
   };
 
   // Validation status
   validation: ValidationFeedback;
+
+  /**
+   * What the shippable gate did: how many full regenerations it spent, which
+   * attempt was kept, and why.
+   *
+   * The pipeline has computed this all along and the SSE route dropped it, so
+   * a story that took three regenerations reported exactly what a story that
+   * was right immediately reported. Absent when the outcome carried no gate
+   * result, which a client must read as unknown rather than as one attempt.
+   */
+  gate?: { attempts: number; bestAttempt: number; shippable: boolean; reason: string };
 
   // The generated code
   code: string;


### PR DESCRIPTION
The pipeline hides its own failure rate. Validation self-heals up to three
times, browser verification repairs, and the shippable gate regenerates up to
three times — so a story that cost four model calls and two rewrites reports
exactly what a story that was correct immediately reports: "Verified". That is
right for the user and useless for judging PREVENTION work, which is about the
first output, not the recovery.

bench/firstAttempt.mjs drives the real server over the SSE endpoint and records
what happened BEFORE any healing: whether the first model output passed static
validation and with what errors, whether verification needed a repair pass and
whether it helped, how many full regenerations the gate spent and why each
earlier attempt failed. It prints one line to track:

  first-attempt clean: N/20 (X%) · median model calls M · median Ns

plus the first round's error classes, which are the prevention targets.

The repair clause in that boolean is load-bearing. The gate's verdict is
computed on the report taken AFTER repair, so `shippable` alone cannot tell a
story that was right from one that was made right; a repair having run is
itself proof that verification found a story-authored blocker in the first
output. On carbon this was the difference between 4/6 and 2/6.

Absent is never zero, per the rule this repository learned three times: a leg
the stream could not report is null, printed as `?` and UNKNOWN, and counted in
neither column — the percentage is over what was judged, with the unjudged
count printed beside it. A conjunction with one definitely-false leg is still
false, though, even when another leg is unknown.

Three facts the pipeline computed and the SSE route dropped are now forwarded,
because parsing logs for them would be worse:

  - `completion.gate` — attempts, kept attempt, shippable, reason
  - `validation.attempts` / `selfHealingUsed` on the completion
  - `repairable` on each verification finding, without which a client cannot
    tell a story-authored blocker from one the library rendered
  - `errorsByBucket` on the in-flight validation event, keeping the pipeline's
    own syntax/pattern/import split that `errors` flattens away

The record shaping and summary are a pure module with no network, filesystem or
clock, so the cases a live run will not produce on demand — a stream that ends
without a completion, a server too old to send `gate`, blockers with no
attribution — are unit tested. Each run stores its SSE events beside the record
so a finished run can be re-scored when the definition changes instead of being
re-paid for.

Measured on carbon (7 prompts): 0 of 4 judged clean, 3 unjudged because
Storybook did not index the new story in time; top first-round error classes
prop-undeclared (4 in 2 prompts) and prop-bad-value (1). react-mantine cannot
load newly created stories at all, so every run there is unjudged; the README
says so.

https://claude.ai/code/session_0158a8zxX4SKPdxm7DLfgqp4