### PR TITLE
fix(generator): say that undeclared props are rejected, because the model was never told

### DIFF
--- a/__tests__/loader-failure.test.ts
+++ b/__tests__/loader-failure.test.ts
@@ -110,5 +110,10 @@ describe('the prompt bounds scope instead of encouraging it', () => {
     expect(text).toContain('Completeness means BEHAVIOUR, not scope');
     expect(text).toContain('Build what was asked for');
     expect(text).toContain('a navigation bar is a navigation bar');
+    // The bench found every Carbon first-round failure was an undeclared prop
+    // or an out-of-union value; the model was never told either is rejected.
+    expect(text).toContain('REJECTED before the story is saved');
+    expect(text).toContain('never `ariaLabel`');
+    expect(text).toContain("prop's VALUE");
   });
 });

--- a/story-generator/promptGenerator.ts
+++ b/story-generator/promptGenerator.ts
@@ -330,6 +330,14 @@ export async function buildFrameworkAwarePrompt(
     // demands operability; this one bounds what is built, so the two cannot
     // be confused.
     '- Completeness means BEHAVIOUR, not scope: what the story does include must be fully operable, with real state and handlers. It does not mean adding more.',
+    // Measured with bench/firstAttempt.mjs on Carbon: EVERY first-round
+    // validation failure was a prop the library does not declare
+    // (`ariaLabel` where it takes `aria-label`, `label` on a row that takes
+    // none) or a value outside a prop's union. The catalog already lists the
+    // props; what it never said is that anything else is rejected, so the
+    // model had no reason not to guess. A retry costs a full model call.
+    '- Use only the props this catalog lists for a component. A prop the component does not declare is REJECTED before the story is saved and the whole generation is retried — so do not invent one, do not guess a camelCase spelling of an HTML attribute (`aria-label` is written exactly that way, never `ariaLabel`), and do not carry a prop over from a different library. If the prop you want is not listed, use one that is, or leave it out.',
+    '- The same applies to a prop\'s VALUE: when the catalog shows a prop\'s accepted values, use one of them exactly. A value outside that set is rejected the same way.',
     '- Build what was asked for, and what that plainly requires — nothing else. A request for a navigation bar is a navigation bar, not a page built around one. Do not add regions, panels or features the request did not ask for (a search field, a filter bar, a notification centre, an activity feed, a toast system). When a request is broad ("a dashboard"), build the parts it names or plainly implies and make those excellent, rather than adding others to look thorough.',
     // Verification blocks on this and the prompt never mentioned it, so the
     // model was being failed for a rule it was never given. Measured on one


### PR DESCRIPTION

The first-attempt bench measured Carbon: every single first-round validation
failure was a prop the library does not declare (`ariaLabel` where it takes
`aria-label`, `label` on a row that takes none) or a value outside a prop's
union (`kind="danger--ghost"`). Zero of seven prompts were clean on the first
try, at a median of four model calls.

The catalog already lists each component's props. What it never said is that
anything else is rejected — so the model had no reason not to guess, and each
guess costs a full retry through the healing loop. Prop conformance has
enforced this since 5.2.0; the prompt simply never mentioned it.

Two rules now state it: use only the props the catalog lists, with the
camelCase-of-an-HTML-attribute trap named explicitly, and use a prop's
accepted values exactly when the catalog shows them.



https://claude.ai/code/session_0158a8zxX4SKPdxm7DLfgqp4
