### PR TITLE
fix(cli): set WATCHPACK_POLLING where watchpack can still read it

### DIFF
--- a/__tests__/loader-failure.test.ts
+++ b/__tests__/loader-failure.test.ts
@@ -115,5 +115,13 @@ describe('the prompt bounds scope instead of encouraging it', () => {
     expect(text).toContain('REJECTED before the story is saved');
     expect(text).toContain('never `ariaLabel`');
     expect(text).toContain("prop's VALUE");
+
+    // One prompt used to carry two image rules: the derived IMAGE RULES said a
+    // placeholder is never a remote URL, and the reminder block said every image
+    // uses picsum.photos. The reminder won, being later in the prompt.
+    expect(text).not.toContain('use https://picsum.photos/)');
+    expect(text).toContain('decided by the IMAGE RULES section');
+    // And the adapter's own card example no longer teaches a remote placeholder.
+    expect(text).not.toMatch(/src=["']https:\/\/picsum/);
   });
 });

--- a/__tests__/storybook-watcher.test.ts
+++ b/__tests__/storybook-watcher.test.ts
@@ -18,7 +18,8 @@ import path from 'path';
 import {
   installedVersion, watchpackPolling, storybookWatcherAdvice, storybookWatcherHint,
   probeStorybookWatcher, removeStaleProbes, POLLING_FIX,
-  ensureWatcherPolling, mainConfiguresPolling, WATCHER_POLLING_MARKER,
+  ensureWatcherLauncher, pollingIsConfigured, WATCHER_POLLING_MARKER,
+  WATCHER_LAUNCHER_FILE, routeScriptThroughLauncher, removeWatcherPollingPreamble,
 } from '../story-generator/verify/storybookWatcher.js';
 
 const project = (storybookVersion: string | null) => {
@@ -166,38 +167,87 @@ describe('removeStaleProbes', () => {
   });
 });
 
-describe('polling preamble in .storybook/main', () => {
+describe('the launcher that actually sets WATCHPACK_POLLING', () => {
   const main = `import type { StorybookConfig } from '@storybook/react-vite';
-import {
-  mergeConfig,
-} from 'vite';
+
+// Story UI: keep the story-index watcher alive. On macOS, Storybook's story-index watcher
+// drops events silently.
+if (process.platform === 'darwin' && !process.env.WATCHPACK_POLLING) process.env.WATCHPACK_POLLING = '1000';
 
 const config: StorybookConfig = {
   stories: ['../src/**/*.stories.tsx'],
 };
 export default config;
 `;
-  it('goes after the last import, once, and only on macOS at runtime', () => {
-    const out = ensureWatcherPolling(main)!;
-    expect(out).not.toBeNull();
-    const at = out.indexOf(WATCHER_POLLING_MARKER);
-    expect(at).toBeGreaterThan(out.indexOf("from 'vite';"));
-    expect(at).toBeLessThan(out.indexOf('const config'));
-    expect(out).toContain("if (process.platform === 'darwin' && !process.env.WATCHPACK_POLLING) process.env.WATCHPACK_POLLING = '1000';");
-    expect(ensureWatcherPolling(out)).toBeNull();
-    expect(ensureWatcherPolling("process.env.WATCHPACK_POLLING = '500';\n" + main)).toBeNull();
-  });
 
-  it('goes first in a file without imports', () => {
-    const out = ensureWatcherPolling("module.exports = { stories: [] };\n")!;
-    expect(out.startsWith('// ' + WATCHER_POLLING_MARKER)).toBe(true);
-  });
-
-  it('is read back from the project', () => {
-    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'sbmain-'));
+  const project = (scripts: Record<string, string>) => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'launcher-'));
     fs.mkdirSync(path.join(dir, '.storybook'));
-    expect(mainConfiguresPolling(dir)).toBe(false);
-    fs.writeFileSync(path.join(dir, '.storybook', 'main.ts'), ensureWatcherPolling(main)!);
-    expect(mainConfiguresPolling(dir)).toBe(true);
+    fs.writeFileSync(path.join(dir, 'package.json'), JSON.stringify({ name: 'p', scripts }, null, 2));
+    return dir;
+  };
+
+  it('rewrites only the storybook invocation, keeping every flag', () => {
+    expect(routeScriptThroughLauncher('storybook dev -p 6109 --no-open'))
+      .toBe(`node ./.storybook/${WATCHER_LAUNCHER_FILE} dev -p 6109 --no-open`);
+    expect(routeScriptThroughLauncher('npx storybook dev -p 6006'))
+      .toBe(`node ./.storybook/${WATCHER_LAUNCHER_FILE} dev -p 6006`);
+    // A build is not a watch, and a script that calls another script inherits
+    // the environment the launcher sets, so neither is touched.
+    expect(routeScriptThroughLauncher('storybook build')).toBeNull();
+    expect(routeScriptThroughLauncher('concurrently "npm run storybook" "npm run story-ui"')).toBeNull();
+    // Idempotent.
+    const once = routeScriptThroughLauncher('storybook dev -p 6006')!;
+    expect(routeScriptThroughLauncher(once)).toBeNull();
+  });
+
+  it('installs the launcher, points the script at it, and reports it', () => {
+    const dir = project({ storybook: 'storybook dev -p 6006', build: 'storybook build' });
+    const result = ensureWatcherLauncher(dir);
+    expect(result.file).toBe('created');
+    expect(result.scripts).toEqual(['storybook']);
+    const scripts = JSON.parse(fs.readFileSync(path.join(dir, 'package.json'), 'utf8')).scripts;
+    expect(scripts.storybook).toContain(WATCHER_LAUNCHER_FILE);
+    expect(scripts.build).toBe('storybook build');
+    // The launcher must set the variable BEFORE it imports Storybook — the whole
+    // point of the file. Anything else is the bug it exists to fix.
+    const src = fs.readFileSync(path.join(dir, '.storybook', WATCHER_LAUNCHER_FILE), 'utf8');
+    expect(src.indexOf('WATCHPACK_POLLING')).toBeLessThan(src.indexOf("require.resolve('storybook/package.json'"));
+    // Running it again changes nothing.
+    const again = ensureWatcherLauncher(dir);
+    expect(again.file).toBe('unchanged');
+    expect(again.scripts).toEqual([]);
+    expect(pollingIsConfigured(dir)).toBe(true);
+  });
+
+  it('says so when no script starts Storybook directly', () => {
+    const dir = project({ dev: 'vite' });
+    const result = ensureWatcherLauncher(dir);
+    expect(result.scripts).toEqual([]);
+    expect(result.note).toContain('No package script starts Storybook directly');
+    expect(pollingIsConfigured(dir)).toBe(false);
+  });
+
+  it('deletes the preamble that never worked, so nothing reads it as a fix', () => {
+    const dir = project({ storybook: 'storybook dev' });
+    fs.writeFileSync(path.join(dir, '.storybook', 'main.ts'), main);
+    const result = ensureWatcherLauncher(dir);
+    expect(result.removedDeadPreamble).toBe('main.ts');
+    const after = fs.readFileSync(path.join(dir, '.storybook', 'main.ts'), 'utf8');
+    expect(after).not.toContain('WATCHPACK_POLLING');
+    expect(after).not.toContain(WATCHER_POLLING_MARKER);
+    // The rest of the config survives intact.
+    expect(after).toContain("stories: ['../src/**/*.stories.tsx']");
+    expect(after).toContain("import type { StorybookConfig }");
+    expect(removeWatcherPollingPreamble(after)).toBeNull();
+  });
+
+  it('does not count the dead preamble as polling', () => {
+    // This is the regression that mattered: `check` reported polling configured
+    // because the marker was in the config, while watchpack had read the
+    // variable before that line ever ran.
+    const dir = project({ storybook: 'storybook dev' });
+    fs.writeFileSync(path.join(dir, '.storybook', 'main.ts'), main);
+    expect(pollingIsConfigured(dir)).toBe(false);
   });
 });

--- a/cli/check.ts
+++ b/cli/check.ts
@@ -19,7 +19,7 @@ import { relativeImportResolves, localImportForComponents } from '../story-gener
 import { resolveHostTooling, canLaunchBrowser } from '../story-generator/verify/hostTooling.js';
 import { closeBrowserSession } from '../story-generator/verify/browserSession.js';
 import { describeLaunchFailure } from '../story-generator/verify/verifyStory.js';
-import { storybookWatcherAdvice, watchpackPolling, installedVersion, probeStorybookWatcher, removeStaleProbes, mainConfiguresPolling } from '../story-generator/verify/storybookWatcher.js';
+import { storybookWatcherAdvice, watchpackPolling, installedVersion, probeStorybookWatcher, removeStaleProbes, pollingIsConfigured } from '../story-generator/verify/storybookWatcher.js';
 
 /** a < b for dotted versions; prerelease tags ignored. */
 import { semverLt } from '../story-generator/semver.js';
@@ -218,7 +218,7 @@ export async function runChecks(opts: { server?: string; storybook?: string; cwd
     const generatedDir = path.resolve(cwd, config.generatedStoriesPath || './src/stories/generated/');
     const env = { ...readEnv(cwd), ...process.env } as Record<string, string | undefined>;
     const sbVersion = installedVersion(cwd, 'storybook');
-    const advice = storybookWatcherAdvice({ platform: process.platform, storybookVersion: sbVersion, polling: watchpackPolling(env.WATCHPACK_POLLING) || (mainConfiguresPolling(cwd) ? 1000 : false) });
+    const advice = storybookWatcherAdvice({ platform: process.platform, storybookVersion: sbVersion, polling: watchpackPolling(env.WATCHPACK_POLLING) || (pollingIsConfigured(cwd) ? 1000 : false) });
     const storybookUrl = opts.storybook || env.STORYBOOK_URL || (env.STORYBOOK_PORT ? `http://localhost:${env.STORYBOOK_PORT}` : undefined);
     if (!storybookUrl || !sbVersion) {
       items.push({

--- a/cli/setup.ts
+++ b/cli/setup.ts
@@ -1,5 +1,5 @@
 import fs from 'fs';
-import { ensureWatcherPolling } from '../story-generator/verify/storybookWatcher.js';
+import { ensureWatcherLauncher, WATCHER_LAUNCHER_FILE } from '../story-generator/verify/storybookWatcher.js';
 import path from 'path';
 import inquirer from 'inquirer';
 import chalk from 'chalk';
@@ -2239,12 +2239,14 @@ export default registry;
     let configUpdated = false;
 
     // Keep Storybook's story-index watcher alive on macOS (storybookWatcher.ts).
-    const polled = ensureWatcherPolling(mainContent);
-    if (polled) {
-      mainContent = polled;
-      configUpdated = true;
-      console.log(chalk.green(`✅ Added WATCHPACK_POLLING to ${path.basename(actualMainPath)} — on macOS Storybook finds new stories by polling`));
+    // The variable has to be set before Node loads Storybook, so this installs a
+    // launcher and points the storybook script at it — a line in this config file
+    // runs after watchpack has already read the variable.
+    const launcher = ensureWatcherLauncher(process.cwd());
+    if (launcher.file !== 'unchanged' || launcher.scripts.length) {
+      console.log(chalk.green(`✅ Storybook starts through .storybook/${WATCHER_LAUNCHER_FILE}${launcher.scripts.length ? ` (${launcher.scripts.join(', ')})` : ''} — on macOS it finds new stories by polling`));
     }
+    if (launcher.note) console.log(chalk.yellow(`⚠️  ${launcher.note}`));
 
     // Check if StoryUI config already exists
     if (mainContent.includes('@tpitre/story-ui') || mainContent.includes('StoryUIPanel')) {

--- a/cli/update.ts
+++ b/cli/update.ts
@@ -5,7 +5,7 @@ import chalk from 'chalk';
 import { fileURLToPath } from 'url';
 import inquirer from 'inquirer';
 import { createRequire } from 'module';
-import { ensureWatcherPolling } from '../story-generator/verify/storybookWatcher.js';
+import { ensureWatcherLauncher, WATCHER_LAUNCHER_FILE } from '../story-generator/verify/storybookWatcher.js';
 import { mergeEnv } from './envFile.js';
 import { ensurePreviewRootCss } from './setup.js';
 import { ensureManagerAddonWiring, ensureStoriesGlobCoversMdx, missingReactStorybookDep, ensureManagerHeadPort, readConfiguredPort, ensureScriptPort, viteFinalConfigSnippet, insertConfigProperty, missingViteCjsIncludes } from './setup.js';
@@ -588,12 +588,15 @@ export async function updateCommand(options: UpdateOptions = {}): Promise<Update
         .map(f => path.join(sbDir, f)).find(f => fs.existsSync(f));
       // Polling keeps the story-index watcher alive on macOS (storybookWatcher.ts);
       // applies to webpack Storybooks too, which watch through watchpack as well.
-      if (mainPath) {
-        const polled = ensureWatcherPolling(fs.readFileSync(mainPath, 'utf8'));
-        if (polled) {
-          fs.writeFileSync(mainPath, polled);
-          console.log(chalk.green(`   ✅ Added WATCHPACK_POLLING to .storybook/${path.basename(mainPath)} — on macOS Storybook finds new stories by polling (restart it)`));
+      {
+        const launcher = ensureWatcherLauncher(process.cwd());
+        if (launcher.file !== 'unchanged' || launcher.scripts.length) {
+          console.log(chalk.green(`   ✅ Storybook starts through .storybook/${WATCHER_LAUNCHER_FILE}${launcher.scripts.length ? ` (${launcher.scripts.join(', ')})` : ''} — on macOS it finds new stories by polling (restart it)`));
         }
+        if (launcher.removedDeadPreamble) {
+          console.log(chalk.yellow(`   ⚠️  Removed the WATCHPACK_POLLING line from .storybook/${launcher.removedDeadPreamble} — it was set after watchpack had already read it, so it never enabled polling`));
+        }
+        if (launcher.note) console.log(chalk.yellow(`   ⚠️  ${launcher.note}`));
       }
       if (mainPath && !/webpack/i.test(fs.readFileSync(mainPath, 'utf8'))) {
         const mainContent = fs.readFileSync(mainPath, 'utf8');

--- a/story-generator/framework-adapters/angular-adapter.ts
+++ b/story-generator/framework-adapters/angular-adapter.ts
@@ -320,7 +320,7 @@ export const ProductCard: Story = {
   render: () => ({
     template: \`
       <app-card style="width: 300px">
-        <img appCardImage src="https://picsum.photos/300/200" alt="Product">
+        <img appCardImage src="data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' width='300' height='200'><rect width='100%' height='100%' fill='%23e5e7eb'/></svg>" alt="Product">
         <h3 appCardTitle>Product Name</h3>
         <p appCardContent>$99.00</p>
         <app-button appCardAction variant="primary">Add to Cart</app-button>

--- a/story-generator/framework-adapters/react-adapter.ts
+++ b/story-generator/framework-adapters/react-adapter.ts
@@ -341,7 +341,7 @@ type Story = StoryObj;
 export const ProductCard: Story = {
   render: () => (
     <Card style={{ width: 300 }}>
-      <img src="https://picsum.photos/300/200" alt="Product" />
+      <img src="data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' width='300' height='200'><rect width='100%' height='100%' fill='%23e5e7eb'/></svg>" alt="Product" />
       <div>Product Name</div>
       <div>$99.00</div>
       <Button variant="primary">Add to Cart</Button>

--- a/story-generator/framework-adapters/svelte-adapter.ts
+++ b/story-generator/framework-adapters/svelte-adapter.ts
@@ -301,7 +301,7 @@ ${this.getCommonRules(options)}`;
 </Story>
 
 <Story name="With Image">
-  <Card class="max-w-sm" img="https://picsum.photos/400/200">
+  <Card class="max-w-sm" img="data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' width='400' height='200'><rect width='100%' height='100%' fill='%23e5e7eb'/></svg>">
     <h5 class="text-2xl font-bold tracking-tight text-gray-900 dark:text-white">Image Card</h5>
     <p class="font-normal text-gray-700 dark:text-gray-400">Card with an image header.</p>
     <Button>Read More</Button>
@@ -309,7 +309,7 @@ ${this.getCommonRules(options)}`;
 </Story>
 
 <Story name="Horizontal">
-  <Card class="max-w-xl" horizontal img="https://picsum.photos/200/200">
+  <Card class="max-w-xl" horizontal img="data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' width='200' height='200'><rect width='100%' height='100%' fill='%23e5e7eb'/></svg>">
     <h5 class="text-2xl font-bold tracking-tight text-gray-900 dark:text-white">Horizontal</h5>
     <p class="font-normal text-gray-700 dark:text-gray-400">Horizontal card layout.</p>
   </Card>

--- a/story-generator/framework-adapters/web-components-adapter.ts
+++ b/story-generator/framework-adapters/web-components-adapter.ts
@@ -305,7 +305,7 @@ type Story = StoryObj;
 export const ProductCard: Story = {
   render: () => html\`
     <my-card style="width: 300px">
-      <img slot="media" src="https://picsum.photos/300/200" alt="Product">
+      <img slot="media" src="data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' width='300' height='200'><rect width='100%' height='100%' fill='%23e5e7eb'/></svg>" alt="Product">
       <span slot="header">Product Name</span>
       <my-text>$99.00</my-text>
       <my-button slot="footer" variant="primary">Add to Cart</my-button>

--- a/story-generator/promptGenerator.ts
+++ b/story-generator/promptGenerator.ts
@@ -309,7 +309,15 @@ export async function buildFrameworkAwarePrompt(
     '- ALWAYS use the exact import path shown in parentheses after each component',
     '- NEVER use main package imports when specific subpath imports are shown',
     '- Do NOT import story exports - these are NOT real components',
-    '- All images MUST have a src attribute with placeholder URLs (use https://picsum.photos/)',
+    // This line used to read "All images MUST have a src attribute with
+    // placeholder URLs (use https://picsum.photos/)". The same prompt already
+    // carries IMAGE RULES derived from the project (knowledge/iconFacts.ts),
+    // which say the opposite for a placeholder: render the design system's own
+    // skeleton or an inline SVG data URI, NEVER a remote URL. Two rules in one
+    // prompt, one of them near the end where adherence is highest — so every
+    // placeholder came back as a network request to picsum.photos, which is a
+    // grey box in a screenshot and a broken image with no network.
+    '- Every image MUST have a src attribute. Which KIND of src is decided by the IMAGE RULES section above, not by preference: a placeholder is the design system\'s own placeholder component or an inline SVG data URI, and a remote photo URL is only for an image the request actually asks to be a photograph.',
     '- MUST use ES modules syntax: "export default meta;" NOT "module.exports = meta;"',
     '- The file MUST have a default export for the meta object',
     // Previously: "Keep the story concise and focused - avoid overly complex

--- a/story-generator/verify/storybookWatcher.ts
+++ b/story-generator/verify/storybookWatcher.ts
@@ -65,54 +65,184 @@ export function watchpackPolling(value: string | undefined): number | boolean {
   return true;
 }
 
-export const POLLING_FIX = 'npx story-ui update (adds WATCHPACK_POLLING to .storybook/main), or start with WATCHPACK_POLLING=1000 npm run storybook';
+export const POLLING_FIX = 'npx story-ui update (routes the storybook script through a launcher that sets it), or start with WATCHPACK_POLLING=1000 npm run storybook';
 
-/** Marks the polling preamble `init`/`update` write into .storybook/main. */
+/** Marks the polling preamble older versions wrote into .storybook/main. */
 export const WATCHER_POLLING_MARKER = 'Story UI: keep the story-index watcher alive';
 
+/** The launcher `init`/`update` write into the .storybook directory. */
+export const WATCHER_LAUNCHER_FILE = 'story-ui-storybook.mjs';
+
 /**
- * The preamble. Evaluated when Storybook loads its main config, in the same
- * process and before watchpack creates a single watcher, so the variable is
- * in place for it — the same effect as the env var, without anyone having
- * to know it exists. macOS only: the drop is FSEvents'; elsewhere fs.watch
- * is fine and polling would only cost CPU.
+ * WHY A LAUNCHER AND NOT A LINE IN .storybook/main.
+ *
+ * Story UI used to write this into the Storybook config:
+ *
+ *   if (process.platform === 'darwin' && !process.env.WATCHPACK_POLLING)
+ *     process.env.WATCHPACK_POLLING = '1000';
+ *
+ * on the reasoning that the config is evaluated in Storybook's own process
+ * before any watcher is created. The second half is true and irrelevant.
+ * watchpack does not read the variable when it creates a watcher; its
+ * DirectoryWatcher module reads it ONCE, at module scope, to compute a
+ * `FORCE_POLLING` constant — and Storybook's core-server imports watchpack at
+ * ITS module scope, which happens before the user's config file is loaded.
+ *
+ * Measured, by proxying `process.env` and logging each access with a stack:
+ *
+ *   [read ] undefined  watchpack/lib/DirectoryWatcher.js <- getWatcherManager
+ *   [read ] undefined  .storybook/main.ts:1
+ *   [write] "1000"     .storybook/main.ts:1
+ *
+ * The preamble ran second. Every project that took the fix was still watching
+ * with fs.watch, while `check` reported polling was configured because the
+ * marker was in the file — a check that could not fail, on a fix that did
+ * nothing. That combination is the reason this comment is this long.
+ *
+ * The variable has to be in the environment before Node loads Storybook, so
+ * this launcher sets it and then imports Storybook's own binary, forwarding
+ * argv untouched. Storybook's dispatcher re-execs a child process, which
+ * inherits the environment, so the value reaches the process that watches.
  */
-export function watcherPollingSnippet(): string {
-  return `// ${WATCHER_POLLING_MARKER}. On macOS, Storybook's story-index watcher (watchpack over
-// fs.watch) shares one FSEvents stream rooted at your home directory, and a burst of file
-// activity anywhere under it drops events silently — a new story then never appears until
-// Storybook restarts. Polling stats the directories instead, so nothing FSEvents does can
-// reach it. Remove this if you set WATCHPACK_POLLING yourself.
-if (process.platform === 'darwin' && !process.env.WATCHPACK_POLLING) process.env.WATCHPACK_POLLING = '1000';
+export function watcherLauncherSource(): string {
+  return `#!/usr/bin/env node
+// Written by Story UI. Starts Storybook with WATCHPACK_POLLING set on macOS, where
+// Storybook's story-index watcher (watchpack over fs.watch) shares one FSEvents stream
+// rooted at your home directory: a burst of file activity anywhere under it drops events
+// silently, and a new story then never appears until Storybook restarts. Polling stats the
+// directories instead, so nothing FSEvents does can reach it.
+//
+// This has to happen before Node loads Storybook — watchpack reads the variable once, when
+// its module is first evaluated, which is before .storybook/main is read. Setting it inside
+// the config is too late and has no effect.
+//
+// Everything after the script name is passed to Storybook unchanged, so this file is a
+// drop-in for the \`storybook\` command. Delete it and restore the plain command if you set
+// WATCHPACK_POLLING yourself.
+import { createRequire } from 'node:module';
+import { pathToFileURL } from 'node:url';
+import path from 'node:path';
+
+if (process.platform === 'darwin' && !process.env.WATCHPACK_POLLING) {
+  process.env.WATCHPACK_POLLING = '1000';
+}
+
+const require = createRequire(import.meta.url);
+const pkgPath = require.resolve('storybook/package.json', { paths: [process.cwd(), import.meta.dirname] });
+const pkg = require(pkgPath);
+const bin = typeof pkg.bin === 'string' ? pkg.bin : pkg.bin.storybook;
+await import(pathToFileURL(path.join(path.dirname(pkgPath), bin)).href);
 `;
 }
 
-const IMPORT_RE = /^[ \t]*import\s+(?:type\s+)?(?:[^'";]*?\s+from\s+)?['"][^'"]+['"];?[ \t]*$/gm;
+/** The command a package script must run for the launcher to be in play. */
+const LAUNCHER_CMD = `node ./.storybook/${WATCHER_LAUNCHER_FILE}`;
 
 /**
- * Insert the preamble after the last import (imports are hoisted, so a
- * statement before them would still run after them — placing it after keeps
- * the file reading in execution order). Null when it is already there.
+ * Route a package script through the launcher.
+ *
+ * Only a script that runs Storybook's binary directly is rewritten, and only
+ * the `storybook dev` token within it — flags, ports and everything around it
+ * survive. A script that runs another script (`npm run storybook`) is left
+ * alone: it starts a child that inherits the environment the launcher sets.
+ * Returns null when there is nothing to do.
  */
-export function ensureWatcherPolling(mainContent: string): string | null {
-  if (mainContent.includes(WATCHER_POLLING_MARKER) || /WATCHPACK_POLLING/.test(mainContent)) return null;
-  let lastImportEnd = 0;
-  for (const m of mainContent.matchAll(IMPORT_RE)) lastImportEnd = m.index + m[0].length;
-  const snippet = watcherPollingSnippet();
-  if (lastImportEnd === 0) return `${snippet}\n${mainContent}`;
-  const rest = mainContent.slice(lastImportEnd).replace(/^\n+/, '\n');
-  return `${mainContent.slice(0, lastImportEnd)}\n\n${snippet}${rest}`;
+export function routeScriptThroughLauncher(script: string): string | null {
+  if (!script || script.includes(WATCHER_LAUNCHER_FILE)) return null;
+  const re = /(^|&&\s*|\|\|\s*|;\s*|"\s*)((?:npx|pnpm exec|yarn|bun x|bunx)\s+)?storybook(\s+dev\b)/;
+  const m = re.exec(script);
+  if (!m) return null;
+  return script.replace(re, `$1${LAUNCHER_CMD}$3`);
 }
 
-/** Does this project's .storybook/main already set polling? */
-export function mainConfiguresPolling(cwd: string): boolean {
-  for (const name of ['main.ts', 'main.mts', 'main.tsx', 'main.js', 'main.mjs', 'main.cjs']) {
-    try {
-      const content = fs.readFileSync(path.join(cwd, '.storybook', name), 'utf8');
-      return content.includes(WATCHER_POLLING_MARKER) || /WATCHPACK_POLLING\s*=/.test(content);
-    } catch { /* try the next name */ }
-  }
+export interface LauncherResult {
+  /** What happened to the launcher file. */
+  file: 'created' | 'updated' | 'unchanged';
+  /** Scripts rewritten to go through it. */
+  scripts: string[];
+  /** Set when .storybook/main still carried the preamble that never worked. */
+  removedDeadPreamble?: string;
+  /** Set when no script runs Storybook directly, so nothing could be routed. */
+  note?: string;
+}
+
+/**
+ * Strip the preamble older versions wrote into .storybook/main. It is inert
+ * (see above) and leaving it there makes a later reader believe polling is on.
+ * Null when the file does not carry it.
+ */
+export function removeWatcherPollingPreamble(mainContent: string): string | null {
+  if (!mainContent.includes(WATCHER_POLLING_MARKER)) return null;
+  const lines = mainContent.split('\n');
+  const start = lines.findIndex(l => l.includes(WATCHER_POLLING_MARKER));
+  let end = start;
+  // The block is the comment lines plus the single assignment that follows.
+  while (end < lines.length && (lines[end].startsWith('//') || lines[end].includes('WATCHPACK_POLLING'))) end++;
+  const kept = [...lines.slice(0, start), ...lines.slice(end)];
+  // Collapse the blank line the block leaves behind.
+  while (kept[start] === '' && kept[start - 1] === '') kept.splice(start, 1);
+  return kept.join('\n');
+}
+
+/** Do the project's own files put polling in Storybook's environment? */
+export function pollingIsConfigured(cwd: string): boolean {
+  if (!fs.existsSync(path.join(cwd, '.storybook', WATCHER_LAUNCHER_FILE))) return false;
+  try {
+    const scripts = JSON.parse(fs.readFileSync(path.join(cwd, 'package.json'), 'utf8')).scripts || {};
+    if (Object.values(scripts).some((s: any) => typeof s === 'string' && s.includes(WATCHER_LAUNCHER_FILE))) return true;
+  } catch { /* no package.json to read */ }
   return false;
+}
+
+/**
+ * Install the launcher and point the project's Storybook script at it.
+ * Idempotent: safe to run on every `update`.
+ */
+export function ensureWatcherLauncher(cwd: string): LauncherResult {
+  const sbDir = path.join(cwd, '.storybook');
+  fs.mkdirSync(sbDir, { recursive: true });
+  const target = path.join(sbDir, WATCHER_LAUNCHER_FILE);
+  const source = watcherLauncherSource();
+  let file: LauncherResult['file'] = 'created';
+  if (fs.existsSync(target)) {
+    file = fs.readFileSync(target, 'utf8') === source ? 'unchanged' : 'updated';
+  }
+  if (file !== 'unchanged') fs.writeFileSync(target, source);
+
+  const result: LauncherResult = { file, scripts: [] };
+
+  const pkgPath = path.join(cwd, 'package.json');
+  try {
+    const pkg = JSON.parse(fs.readFileSync(pkgPath, 'utf8'));
+    const scripts = pkg.scripts || {};
+    let changed = false;
+    for (const [name, cmd] of Object.entries(scripts)) {
+      if (typeof cmd !== 'string') continue;
+      const routed = routeScriptThroughLauncher(cmd);
+      if (routed) { scripts[name] = routed; result.scripts.push(name); changed = true; }
+    }
+    if (changed) {
+      pkg.scripts = scripts;
+      fs.writeFileSync(pkgPath, JSON.stringify(pkg, null, 2) + '\n');
+    } else if (!pollingIsConfigured(cwd)) {
+      result.note = `No package script starts Storybook directly, so nothing was rewritten — start it with \`${LAUNCHER_CMD} dev\` (or set WATCHPACK_POLLING=1000 yourself) for the index to keep up on macOS`;
+    }
+  } catch {
+    result.note = 'package.json could not be read, so the Storybook script was left alone';
+  }
+
+  for (const name of ['main.ts', 'main.mts', 'main.tsx', 'main.js', 'main.mjs', 'main.cjs']) {
+    const mainPath = path.join(sbDir, name);
+    if (!fs.existsSync(mainPath)) continue;
+    const stripped = removeWatcherPollingPreamble(fs.readFileSync(mainPath, 'utf8'));
+    if (stripped !== null) {
+      fs.writeFileSync(mainPath, stripped);
+      result.removedDeadPreamble = name;
+    }
+    break;
+  }
+
+  return result;
 }
 
 export function storybookWatcherAdvice(input: {
@@ -154,7 +284,7 @@ export function storybookWatcherHint(
   platform: NodeJS.Platform = process.platform,
 ): string {
   const version = installedVersion(cwd, 'storybook');
-  const polling = watchpackPolling(env.WATCHPACK_POLLING) || (mainConfiguresPolling(cwd) ? 1000 : false);
+  const polling = watchpackPolling(env.WATCHPACK_POLLING) || (pollingIsConfigured(cwd) ? 1000 : false);
   const advice = storybookWatcherAdvice({ platform, storybookVersion: version, polling });
   if (advice.risk !== 'fsevents') return '';
   return ` Storybook ${version} on macOS watches with fs.watch through one FSEvents stream rooted at your home directory; a burst of file activity anywhere under it drops events silently and the watcher does not recover. Restart Storybook with WATCHPACK_POLLING=1000 (polling, immune to this), and run npx story-ui update so it polls from then on.`;


### PR DESCRIPTION

Story UI wrote a line into .storybook/main that set WATCHPACK_POLLING, on the
reasoning that the config is evaluated in Storybook's process before any
watcher exists. watchpack does not read the variable when it creates a
watcher. Its DirectoryWatcher module reads it once, at module scope, to
compute a FORCE_POLLING constant, and Storybook's core-server imports
watchpack at its own module scope, before the user's config is loaded.

Measured by proxying process.env and logging each access with a stack:

    [read ] undefined  watchpack/lib/DirectoryWatcher.js <- getWatcherManager
    [read ] undefined  .storybook/main.ts:1
    [write] "1000"     .storybook/main.ts:1

So every project that took the fix was still watching with fs.watch, while
check reported polling configured because the marker was in the file. A check
that could not fail, on a fix that did nothing. On the Carbon fixture that
meant six generations in a row verified as UNKNOWN: the stories were written
correctly and Storybook never indexed them.

init and update now write .storybook/story-ui-storybook.mjs, which sets the
variable and then imports Storybook's own binary with argv untouched, and
point the storybook script at it. Verified end to end: watchpack reads 1000,
and a new story reaches the index in about two seconds. update also deletes
the preamble, and polling is reported from the launcher rather than the
marker, so a project carrying the dead line reads as unprotected.



https://claude.ai/code/session_0158a8zxX4SKPdxm7DLfgqp4
