### PR TITLE
fix(generator): rule out the container that spreads an action row

### DIFF
--- a/__tests__/spacing-vocabulary.test.ts
+++ b/__tests__/spacing-vocabulary.test.ts
@@ -70,6 +70,12 @@ describe('deriveSpacingVocabulary', () => {
     expect(rules).toContain('<Stack gap=');
     expect(rules).toContain('a step from the spacing scale');
     expect(rules).not.toContain('padding: "24px"');
+    // The action row must be ruled out as well as ruled in: two of three
+    // first-attempt failures measured on Carbon were a Cancel/Save pair in a
+    // container that handed each button a share of the spare width.
+    expect(rules).toContain('SIZE TO ITS CONTENT');
+    expect(rules).toContain('space-between/space-around/space-evenly');
+    expect(rules).toContain('Spare width belongs OUTSIDE the group');
   });
 
   it('reads the spacing scale from tokens whose name says spacing AND whose value is a length, sorted by size', () => {

--- a/story-generator/knowledge/spacingFacts.ts
+++ b/story-generator/knowledge/spacingFacts.ts
@@ -562,6 +562,16 @@ export function formatSpacingRules(
   lines.push('3. BUTTONS & ACTION ROWS: a row primitive with a small gap; actions sit in the same parent');
   lines.push('   stack as the fields, so the space above them is that stack\'s gap, not a marginTop.');
   lines.push(`   Pattern: ${rowExample}`);
+  // The measured first-attempt failure on Carbon, twice out of three: a
+  // Cancel/Save pair placed in a container that hands each button a share of
+  // the spare width, leaving a 300px void between two buttons. Rule 3 named
+  // the right container and never ruled out the wrong one, so this states the
+  // prohibition in the same words the layout probe uses when it catches it.
+  lines.push('   The row must SIZE TO ITS CONTENT. Never let a container distribute its spare width');
+  lines.push('   between the buttons — no space-between/space-around/space-evenly on a row of two or');
+  lines.push('   three controls, and no grid whose auto tracks stretch to fill the container. Both put');
+  lines.push('   a void between Cancel and Save; the gap between them is the container\'s gap and');
+  lines.push('   nothing else. Spare width belongs OUTSIDE the group, not inside it.');
   if (recipe) {
     lines.push('4. MULTI-COLUMN LAYOUT: this catalog has no grid component, so use this recipe with the');
     lines.push('   spacing scale — minmax(0, 1fr) and border-box keep every column the same width:');


### PR DESCRIPTION

Two of the three first-attempt failures in the Carbon bench were the same
shape: a Cancel/Save pair placed in a container that hands each button a share
of the spare width, leaving a 300px void between two buttons that belong
together. The layout probe catches it and the generation is repaired, at the
cost of a full extra round trip each time.

The spacing rules already named the right container for an action row. They
never ruled out the wrong one, and the wrong one is what a model reaches for:
space-between on a flex row, or a grid whose auto tracks stretch. Both are now
prohibited in the same words the probe uses when it reports them, so the rule
the model reads and the check that judges it describe one thing.



https://claude.ai/code/session_0158a8zxX4SKPdxm7DLfgqp4
