### PR TITLE
fix(generator): say which way the repair-recompile wait failed

### DIFF
--- a/__tests__/recompile-wait.test.ts
+++ b/__tests__/recompile-wait.test.ts
@@ -1,0 +1,69 @@
+/**
+ * The repair loop writes a fix and re-verifies it. Judging the PREVIOUS render
+ * makes a correct repair look useless, so the loop waits for the dev server to
+ * serve new module text first.
+ *
+ * The ways that wait can fail are not one thing, and they used to be logged as
+ * one line: "Storybook did not recompile in time". A run of the Carbon bench
+ * showed that line three times, which sent an investigation after the dev
+ * server — while one of the three cases is simply that the poll had no
+ * baseline to compare against and never waited at all. These tests pin each
+ * outcome apart, because a check that cannot run must not look like a check
+ * that ran and found nothing.
+ */
+import { describe, it, expect, afterEach } from 'vitest';
+import http from 'http';
+import { waitForRecompile, moduleText } from '../story-generator/verify/renderHarness.js';
+
+let server: http.Server | undefined;
+
+async function serve(handler: http.RequestListener): Promise<string> {
+  server = http.createServer(handler);
+  await new Promise<void>(r => server!.listen(0, '127.0.0.1', r));
+  const { port } = server!.address() as { port: number };
+  return `http://127.0.0.1:${port}`;
+}
+
+afterEach(async () => {
+  if (server) await new Promise<void>(r => server!.close(() => r()));
+  server = undefined;
+});
+
+describe('waitForRecompile', () => {
+  it('reports the change as soon as the served text differs', async () => {
+    let body = 'before';
+    const url = await serve((_req, res) => { res.writeHead(200); res.end(body); });
+    const before = await moduleText(url, 'src/x.stories.tsx');
+    expect(before).toBe('before');
+    setTimeout(() => { body = 'after the repair'; }, 60);
+    const out = await waitForRecompile(url, 'src/x.stories.tsx', before, 3000, 25);
+    expect(out.live).toBe(true);
+    expect(out.reason).toBe('changed');
+    expect(out.beforeBytes).toBe(6);
+    expect(out.afterBytes).toBe('after the repair'.length);
+  });
+
+  it('never waits when there is no baseline, and says so', async () => {
+    const url = await serve((_req, res) => { res.writeHead(200); res.end('anything'); });
+    const out = await waitForRecompile(url, 'src/x.stories.tsx', null, 3000, 25);
+    expect(out.live).toBe(false);
+    expect(out.reason).toBe('no_baseline');
+    // The distinction that matters: this is zero elapsed time, not a timeout.
+    expect(out.waitedMs).toBe(0);
+  });
+
+  it('separates a served-but-unchanged module from one that never served', async () => {
+    const stable = await serve((_req, res) => { res.writeHead(200); res.end('same'); });
+    const timedOut = await waitForRecompile(stable, 'src/x.stories.tsx', 'same', 150, 25);
+    expect(timedOut.reason).toBe('timeout');
+    expect(timedOut.beforeBytes).toBe(4);
+    expect(timedOut.afterBytes).toBe(4);
+    await new Promise<void>(r => server!.close(() => r()));
+
+    server = undefined;
+    const missing = await serve((_req, res) => { res.writeHead(404); res.end('nope'); });
+    const unreachable = await waitForRecompile(missing, 'src/x.stories.tsx', 'same', 150, 25);
+    expect(unreachable.reason).toBe('unreachable');
+    expect(unreachable.status).toBe(404);
+  });
+});

--- a/mcp-server/routes/generationCore.ts
+++ b/mcp-server/routes/generationCore.ts
@@ -2376,9 +2376,19 @@ async function runStoryGenerationPipeline(
               } else {
                 const before = await moduleText(verifyUrl, relModule);
                 writeStory(finalized);
-                const live = await waitForRecompile(verifyUrl, relModule, before);
-                if (!live) {
-                  logger.warn('⚠️ Storybook did not recompile in time — the repair check may read a stale render');
+                const recompile = await waitForRecompile(verifyUrl, relModule, before);
+                if (!recompile.live) {
+                  // Say WHICH failure this is. The three read identically in a
+                  // render and were logged identically, which sent one
+                  // investigation after the dev server when the poll simply had
+                  // no baseline to compare against.
+                  const why = {
+                    no_baseline: `the module could not be read from ${verifyUrl}/${relModule} before the write, so no comparison was possible`,
+                    unreachable: `the module never returned 200 from ${verifyUrl}/${relModule}${recompile.status ? ` (last status ${recompile.status})` : ''}`,
+                    timeout: `the served module was byte-identical for ${Math.round(recompile.waitedMs / 1000)}s (${recompile.beforeBytes} bytes before, ${recompile.afterBytes} after) although the file on disk changed`,
+                    changed: '',
+                  }[recompile.reason];
+                  logger.warn(`⚠️ The repair check may read a stale render: ${why}`);
                 }
               }
               return verifyStory({

--- a/story-generator/verify/renderHarness.ts
+++ b/story-generator/verify/renderHarness.ts
@@ -548,9 +548,26 @@ export function describeFetchError(err: unknown): string {
  * path, so the honest signal is the module TEXT changing — which needs no
  * guess about what the change should look like, only that one happened.
  *
- * Returns true when the change is live, false on timeout. A timeout is not an
- * error: the caller proceeds and simply risks the stale reading it always had.
+ * Returns the outcome, never a bare boolean, because the ways this can fail
+ * are not one thing and were reported as one. `no_baseline` means the module
+ * could not be read BEFORE the write, so there is nothing to compare and the
+ * wait never happened; `timeout` means it was read and did not change. Both
+ * used to log "Storybook did not recompile in time", which sent an
+ * investigation after the dev server when the real answer was that the poll
+ * had no baseline. The caller proceeds either way and simply risks the stale
+ * reading it always had — but it now says which risk it is taking.
  */
+export interface RecompileResult {
+  live: boolean;
+  reason: 'changed' | 'timeout' | 'no_baseline' | 'unreachable';
+  waitedMs: number;
+  /** Bytes seen before and last seen after, for a log line that can be acted on. */
+  beforeBytes: number | null;
+  afterBytes: number | null;
+  /** HTTP status of the last poll, when one completed. */
+  status?: number;
+}
+
 export async function waitForRecompile(
   storybookUrl: string,
   /** Path relative to the project root, e.g. `src/stories/generated/x.stories.tsx`. */
@@ -559,25 +576,43 @@ export async function waitForRecompile(
   previousText: string | null,
   timeoutMs = 25000,
   intervalMs = 500,
-): Promise<boolean> {
-  if (previousText === null) return false;
+): Promise<RecompileResult> {
+  const started = Date.now();
+  if (previousText === null) {
+    return { live: false, reason: 'no_baseline', waitedMs: 0, beforeBytes: null, afterBytes: null };
+  }
   const base = storybookUrl.replace(/\/+$/, '');
   const url = `${base}/${modulePath.replace(/^\/+/, '')}`;
-  const deadline = Date.now() + timeoutMs;
+  const deadline = started + timeoutMs;
+  let afterBytes: number | null = null;
+  let status: number | undefined;
+  let everReached = false;
 
   while (Date.now() < deadline) {
     try {
       const res = await fetch(`${url}?t=${Date.now()}`, { headers: { 'Cache-Control': 'no-cache' } });
+      status = res.status;
       if (res.ok) {
+        everReached = true;
         const text = await res.text();
-        if (text !== previousText) return true;
+        afterBytes = text.length;
+        if (text !== previousText) {
+          return { live: true, reason: 'changed', waitedMs: Date.now() - started, beforeBytes: previousText.length, afterBytes, status };
+        }
       }
     } catch {
       // Dev server busy recompiling; keep polling until the deadline.
     }
     await new Promise(r => setTimeout(r, intervalMs));
   }
-  return false;
+  return {
+    live: false,
+    reason: everReached ? 'timeout' : 'unreachable',
+    waitedMs: Date.now() - started,
+    beforeBytes: previousText.length,
+    afterBytes,
+    status,
+  };
 }
 
 /** The dev server's current transformed text for a module, or null. */


### PR DESCRIPTION

The repair loop waits for the dev server to serve new module text before it
re-verifies, so a correct repair is not judged against the previous render.
Three different outcomes were logged as one line, "Storybook did not recompile
in time": the module was read and did not change, the module never returned
200, and the module could not be read before the write at all. The third one
never waits — it returns immediately — so the line claimed a timeout that had
not happened, and a bench run showing it three times sent the investigation
after the dev server.

waitForRecompile now returns the outcome with the elapsed time, the byte
counts either side and the last HTTP status, and the caller writes what
actually happened. Same behaviour, same risk taken, but the log now names
which risk it is.



https://claude.ai/code/session_0158a8zxX4SKPdxm7DLfgqp4
