### PR TITLE
feat(generator): read what a container does to its children from the stylesheet

### DIFF
--- a/__tests__/layout-behaviour.test.ts
+++ b/__tests__/layout-behaviour.test.ts
@@ -1,0 +1,108 @@
+/**
+ * What a container does to its children, read from the design system's own
+ * stylesheet rather than assumed.
+ *
+ * Three of the six non-clean stories in a 20-prompt Carbon bench were one
+ * defect: a control stretched by its parent — two buttons pulled to opposite
+ * ends of a row, a tag rendered 121px wide. The prompt already carried a rule
+ * about it, phrased as a convention ("a vertical stack stretches its
+ * children"). The fact itself is one declaration in a file the token reader
+ * already opens:
+ *
+ *     .cds--stack-vertical { display: grid; grid-auto-flow: row; }
+ *
+ * These tests pin the two things that make that derivation trustworthy: it
+ * must find the real container, and it must stay silent rather than guess.
+ */
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import { readLayoutBehaviour, formatLayoutBehaviour } from '../story-generator/knowledge/stylingFacts.js';
+
+let dir: string;
+let sheet: string;
+
+beforeAll(() => {
+  dir = fs.mkdtempSync(path.join(os.tmpdir(), 'layoutcss-'));
+  sheet = path.join(dir, 'styles.css');
+  fs.writeFileSync(sheet, [
+    // The real thing, copied from @carbon/styles.
+    '.cds--stack-vertical { display: grid; grid-auto-flow: row; row-gap: var(--cds-stack-gap, 0); }',
+    '.cds--stack-horizontal { display: inline-grid; grid-auto-flow: column; }',
+    '.cds--css-grid { display: grid; grid-template-columns: repeat(16, 1fr); }',
+    // Inner nodes that merely contain the component name.
+    '.cds--modal-container { display: grid; grid-template-rows: auto 1fr auto; }',
+    '.cds--toggletip-content { display: grid; }',
+    '.cds--toggle__appearance { display: inline-grid; }',
+    // A rule that is not a single class, and one with no layout at all.
+    '.cds--btn .cds--btn__icon { display: flex; }',
+    '.cds--tag { border-radius: 1rem; }',
+  ].join('\n'));
+});
+
+afterAll(() => fs.rmSync(dir, { recursive: true, force: true }));
+
+const carbon = [
+  { name: 'Stack', propTypes: ["'horizontal' | 'vertical'", 'string'] },
+  { name: 'Grid', propTypes: ['boolean'] },
+  { name: 'Modal', propTypes: ['boolean'] },
+  { name: 'Toggletip', propTypes: ['boolean'] },
+  { name: 'Toggle', propTypes: ['boolean'] },
+  { name: 'Tag', propTypes: ['string'] },
+];
+
+describe('readLayoutBehaviour', () => {
+  it('finds the container and reads its stretching from the declaration', () => {
+    const out = readLayoutBehaviour([sheet], carbon);
+    const stack = out.behaviours.find(b => b.component === 'Stack' && b.className === 'cds--stack-vertical');
+    expect(stack).toBeDefined();
+    expect(stack!.display).toBe('grid');
+    expect(stack!.autoFlow).toBe('row');
+    expect(stack!.stretchesChildren).toBe(true);
+    // Flowing along the inline axis does not stretch a child's width.
+    const horizontal = out.behaviours.find(b => b.className === 'cds--stack-horizontal');
+    expect(horizontal!.stretchesChildren).toBe(false);
+  });
+
+  it('refuses a class that is an inner node rather than the component root', () => {
+    // Each of these contains a component's name and declares display:grid, and
+    // each names a box the story author never puts children into directly. The
+    // first version of this reader emitted confident advice about all three.
+    const out = readLayoutBehaviour([sheet], carbon);
+    const named = out.behaviours.map(b => b.className);
+    expect(named).not.toContain('cds--modal-container');
+    expect(named).not.toContain('cds--toggletip-content');
+    expect(named).not.toContain('cds--toggle__appearance');
+    // The trailing segment is admitted only when the component declares it as
+    // a value: Stack accepts orientation "vertical", Modal accepts no
+    // "container".
+    expect(named).toContain('cds--stack-vertical');
+  });
+
+  it('separates "matched nothing" from "read nothing"', () => {
+    // A design system with hashed class names (CSS modules) matches nothing,
+    // and that is a different fact from having no stylesheet at all. Both
+    // produce no prompt text; only the log can tell them apart, so the log
+    // line has to carry the difference.
+    const hashed = path.join(dir, 'hashed.css');
+    fs.writeFileSync(hashed, '.m-6d731127 { display: flex; flex-direction: column; }');
+    const matchedNone = readLayoutBehaviour([hashed], carbon);
+    expect(matchedNone.behaviours).toEqual([]);
+    expect(matchedNone.rulesSeen).toBe(1);
+    expect(matchedNone.source).toContain('1 single-class layout rule');
+
+    const readNone = readLayoutBehaviour([], carbon);
+    expect(readNone.rulesSeen).toBe(0);
+    expect(readNone.source).toContain('no stylesheet was read');
+    expect(formatLayoutBehaviour(readNone)).toBe('');
+  });
+
+  it('states the fact with the class it came from', () => {
+    const text = formatLayoutBehaviour(readLayoutBehaviour([sheet], carbon));
+    expect(text).toContain('<Stack>');
+    expect(text).toContain('.cds--stack-vertical');
+    expect(text).toContain('display: grid');
+    expect(text).toContain('EVERY direct child stretches');
+  });
+});

--- a/mcp-server/routes/generationCore.ts
+++ b/mcp-server/routes/generationCore.ts
@@ -107,7 +107,7 @@ import { saysMoreThanName } from '../../story-generator/knowledge/descriptionQua
 const GEOMETRY_PROP = /^(sm|md|lg|xl|xxl|max|xs|span|offset|start|end|gap|columns|narrow|condensed|fullWidth|orientation)$/;
 const LAYOUT_PROSE = /\b(column|columns|grid|breakpoint|gutter|span|spacing|width|row|layout)\b/i;
 import { enrichWithSourceFacts, withLocalPropFacts } from '../../story-generator/knowledge/sourceFacts.js';
-import { readStylingFacts, formatStylingGuidance, readDesignTokens } from '../../story-generator/knowledge/stylingFacts.js';
+import { readStylingFacts, formatStylingGuidance, readDesignTokens, readLayoutBehaviour, formatLayoutBehaviour } from '../../story-generator/knowledge/stylingFacts.js';
 import type { StylingFacts } from '../../story-generator/knowledge/stylingFacts.js';
 import {
   deriveSpacingVocabulary, checkInlineSpacing, checkTokenTiers, checkRawColors, formatSpacingErrors, formatTierErrors, formatColorErrors, repairSpacingNote,
@@ -3042,6 +3042,28 @@ async function buildClaudePromptWithContext(
           ? `🎨 No styling guidance: examined NO stylesheets (${config.importPath ?? 'no importPath'} declares none and the project has none) — tokens unknown, not zero`
           : `🎨 No styling guidance: examined ${src.projectFiles} project + ${src.packageFiles} package file(s) (${src.declaredFiles} declared) and found ${src.tokens} token(s)`,
       );
+    }
+    /**
+     * What the design system's own stylesheet says its containers do to their
+     * children — the third of six non-clean stories in the Carbon bench, and
+     * the one the prompt could only assert generically. `.cds--stack-vertical`
+     * declares `display: grid` with no `justify-items`, so a Button placed
+     * directly in a Stack comes out full width. That is a fact in a file we
+     * already read, not a convention to be assumed.
+     */
+    const layout = readLayoutBehaviour(styling.stylesheetFiles, (components || []).map((c: any) => ({
+      name: c.name,
+      propValues: (c.propTypes || []).flatMap((p: any) => p.options || []),
+      propTypes: (c.propTypes || []).map((p: any) => p.type || ''),
+    })));
+    const layoutSection = formatLayoutBehaviour(layout);
+    if (layoutSection) {
+      logger.log(`📦 Container behaviour: ${layout.behaviours.filter(b => b.stretchesChildren).length} stretching container(s) — ${layout.source}`);
+      prompt = injectBeforeUserRequest(prompt, layoutSection);
+    } else {
+      // Zero matched and nothing read must not read alike: a hashed-class
+      // design system (CSS modules) legitimately matches nothing.
+      logger.log(`📦 No container behaviour derived: ${layout.source}`);
     }
   } catch (error) {
     logger.log(`⚠️ Could not read styling facts: ${error}`);

--- a/story-generator/knowledge/stylingFacts.ts
+++ b/story-generator/knowledge/stylingFacts.ts
@@ -645,3 +645,197 @@ export function formatStylingGuidance(facts: StylingFacts, maxPerGroup = 24): st
 
   return lines.join('\n');
 }
+
+/* ------------------------------------------------------------------ */
+/* Layout behaviour a design system states in its own stylesheet        */
+/* ------------------------------------------------------------------ */
+
+/**
+ * What a container component does to its children, read from the CSS.
+ *
+ * The measured failure: three of six non-clean stories in the Carbon bench
+ * were a control stretched by its parent — two buttons pulled to opposite ends
+ * of a row, a tag rendered 121px wide. The prompt already carried a rule about
+ * it, phrased generically ("a vertical stack stretches its children"), which
+ * is an inference from convention: true for Carbon, unsourced, and exactly the
+ * failure mode this project keeps finding. The fact is not a convention. It is
+ * one declaration in a file the token reader already opens:
+ *
+ *     .cds--stack-vertical { display: grid; grid-auto-flow: row; }
+ *
+ * A grid with no `justify-items` stretches every item to its column, so a
+ * Button placed directly in a Stack fills the Stack. That is derivable, and
+ * once derived it can be stated per component with the class it came from.
+ */
+export interface LayoutBehaviour {
+  /** The catalog component this rule was matched to. */
+  component: string;
+  /** The class selector the rule was read from, for the prompt to cite. */
+  className: string;
+  display: string;
+  autoFlow?: string;
+  templateColumns?: string;
+  flexDirection?: string;
+  /** Children are stretched across the container's inline axis by default. */
+  stretchesChildren: boolean;
+}
+
+export interface LayoutBehaviourResult {
+  behaviours: LayoutBehaviour[];
+  /** Components asked about, and how many matched — so absent and zero differ. */
+  askedAbout: number;
+  /** Single-class layout rules found in the stylesheets at all. */
+  rulesSeen: number;
+  /** One line for the log. */
+  source: string;
+}
+
+const LAYOUT_DECL = /(display|grid-auto-flow|grid-template-columns|flex-direction|align-items|justify-items|justify-content)\s*:\s*([^;{}]+)/g;
+/** A selector naming exactly one class and nothing else: `.cds--stack-vertical`. */
+const SINGLE_CLASS = /^\.([A-Za-z_][\w-]*)$/;
+
+/** The word segments of a class name, for whole-segment matching against a component name. */
+function classSegments(className: string): string[] {
+  return className
+    .split(/[^A-Za-z0-9]+|(?<=[a-z0-9])(?=[A-Z])/)
+    .filter(Boolean)
+    .map(s => s.toLowerCase());
+}
+
+/**
+ * Layout rules the stylesheet states for the catalog's own components.
+ *
+ * The component-to-class link is a HYPOTHESIS checked against the file, never
+ * an assumption: a class is accepted only when one of its own word segments is
+ * exactly the component's name and the rule it carries actually declares a
+ * layout property. Nothing is emitted for a component with no such rule, and
+ * the result reports how many were asked about, so a design system whose
+ * classes are hashed (CSS modules) reads as "none matched" rather than as
+ * "nothing to say".
+ */
+export interface LayoutComponent {
+  name: string;
+  /** String values this component's own props accept, e.g. vertical/horizontal. */
+  propValues?: string[];
+  /**
+   * Raw declared prop types, because that is where the values usually are.
+   * Carbon's Stack carries `orientation?: 'horizontal' | 'vertical'` as a type
+   * string with no separate options list, and reading only the options list
+   * dropped the one component this whole derivation exists to describe.
+   */
+  propTypes?: string[];
+}
+
+/** The quoted literals of a union type: `'horizontal' | 'vertical'` -> both. */
+function literalsOfType(type: string): string[] {
+  return [...type.matchAll(/['"]([A-Za-z][\w-]*)['"]/g)].map(m => m[1].toLowerCase());
+}
+
+export function readLayoutBehaviour(
+  stylesheetFiles: string[] | undefined,
+  components: Array<LayoutComponent | string>,
+  limitPerComponent = 2,
+): LayoutBehaviourResult {
+  const files = stylesheetFiles || [];
+  const wanted = new Map<string, string>();
+  const valuesOf = new Map<string, Set<string>>();
+  for (const c of components) {
+    const name = typeof c === 'string' ? c : c.name;
+    wanted.set(name.toLowerCase(), name);
+    const declared = typeof c === 'string'
+      ? []
+      : [...(c.propValues || []).map(v => v.toLowerCase()), ...(c.propTypes || []).flatMap(literalsOfType)];
+    valuesOf.set(name, new Set(declared));
+  }
+  const componentNames = components.map(c => (typeof c === 'string' ? c : c.name));
+  const behaviours: LayoutBehaviour[] = [];
+  const perComponent = new Map<string, number>();
+  let rulesSeen = 0;
+
+  for (const file of files) {
+    let css: string;
+    try { css = fs.readFileSync(file, 'utf8'); } catch { continue; }
+    // Rule bodies, unanchored: a minified sheet is one line.
+    for (const m of css.matchAll(/([^{}]+)\{([^{}]*)\}/g)) {
+      const selector = m[1].trim();
+      const body = m[2];
+      if (!/display\s*:/.test(body) && !/grid-auto-flow\s*:/.test(body)) continue;
+      const single = SINGLE_CLASS.exec(selector);
+      if (!single) continue;
+      const decls: Record<string, string> = {};
+      for (const d of body.matchAll(LAYOUT_DECL)) decls[d[1]] = d[2].trim();
+      const display = decls.display || '';
+      if (!/^(inline-)?(grid|flex)$/.test(display)) continue;
+      rulesSeen++;
+      const className = single[1];
+      /**
+       * A BEM element class (`cds--toggle__appearance`) names a node INSIDE the
+       * component, not the element the story puts children into, so advice
+       * derived from it would be about markup the author never writes. The
+       * double underscore says so in the class's own grammar.
+       */
+      if (className.includes('__')) continue;
+      const segments = classSegments(className);
+      const at = segments.findIndex(seg => wanted.has(seg));
+      if (at < 0) continue;
+      const hit = wanted.get(segments[at])!;
+      /**
+       * The class must be the component's own root, and the check for that is
+       * the component's own prop values: `.cds--stack-vertical` is Stack with
+       * `orientation="vertical"`, a value Stack declares, while
+       * `.cds--modal-container` and `.cds--toggletip-content` are inner nodes
+       * whose trailing segment matches nothing the component accepts. Without
+       * this the reader emitted confident advice about placing buttons inside a
+       * Toggletip's content box.
+       */
+      const trailing = segments.slice(at + 1);
+      const legal = valuesOf.get(hit)!;
+      if (trailing.length && !trailing.every(seg => legal.has(seg))) continue;
+      const seen = perComponent.get(hit) || 0;
+      if (seen >= limitPerComponent) continue;
+      perComponent.set(hit, seen + 1);
+      const isGrid = /grid$/.test(display);
+      const autoFlow = decls['grid-auto-flow'];
+      // A grid item with no justify-items stretches across its column; a flex
+      // item with no align-items stretches across the cross axis. Either way a
+      // hug-content control placed directly inside comes out full width when
+      // the flow runs down the block axis.
+      const alongBlock = isGrid ? (!autoFlow || /row/.test(autoFlow)) : /column/.test(decls['flex-direction'] || '');
+      const stretchesChildren = alongBlock
+        && (isGrid ? !decls['justify-items'] || decls['justify-items'] === 'stretch'
+                   : !decls['align-items'] || decls['align-items'] === 'stretch');
+      behaviours.push({
+        component: hit,
+        className,
+        display,
+        autoFlow,
+        templateColumns: decls['grid-template-columns'],
+        flexDirection: decls['flex-direction'],
+        stretchesChildren,
+      });
+    }
+  }
+
+  const source = files.length === 0
+    ? 'no stylesheet was read, so no layout behaviour could be derived'
+    : `${behaviours.length} rule(s) matched ${perComponent.size} of ${componentNames.length} catalog component(s) across ${rulesSeen} single-class layout rule(s) in ${files.length} stylesheet(s)`;
+  return { behaviours, askedAbout: componentNames.length, rulesSeen, source };
+}
+
+/** The prompt lines for what the stylesheet says these containers do. */
+export function formatLayoutBehaviour(result: LayoutBehaviourResult): string {
+  const stretching = result.behaviours.filter(b => b.stretchesChildren);
+  if (!stretching.length) return '';
+  const lines = ['WHAT THESE CONTAINERS DO TO THEIR CHILDREN (read from this project\'s own stylesheet):'];
+  const seen = new Set<string>();
+  for (const b of stretching) {
+    if (seen.has(b.component)) continue;
+    seen.add(b.component);
+    lines.push(
+      `- <${b.component}> renders \`display: ${b.display}\`${b.autoFlow ? `, \`grid-auto-flow: ${b.autoFlow}\`` : ''} (.${b.className}) and sets no ` +
+      `${/grid$/.test(b.display) ? 'justify-items' : 'align-items'}, so EVERY direct child stretches to its full width. ` +
+      `A button, tag, badge or chip placed directly inside comes out full width. Put such controls in a row that sizes to its content instead.`,
+    );
+  }
+  return lines.join('\n');
+}


### PR DESCRIPTION

Three of the six non-clean stories in a 20-prompt Carbon run were one defect:
a control stretched by its parent. Two buttons pulled to opposite ends of a
row, a tag rendered 121px wide. The prompt already carried a rule for it, and
the rule was a convention: "a vertical stack stretches its children." True
here, unsourced, and stated the same way to every design system.

The fact is one declaration in a file the token reader already opens:

    .cds--stack-vertical { display: grid; grid-auto-flow: row; }

A grid that sets no justify-items stretches every item to its column, so a
Button placed directly in a Stack fills the Stack. That is now derived and
stated per component with the class it was read from.

The component-to-class link is a hypothesis checked against the file, never a
guess. A class is accepted only when one of its own word segments is exactly
the component's name, it carries no BEM element separator, and any trailing
segment is a value that component's own prop types declare. Without the last
condition the reader offered advice about placing buttons inside a Toggletip's
content box; with it, Carbon yields exactly Stack and Grid out of 167
single-class layout rules.

A design system with hashed class names matches nothing, which is a different
fact from having no stylesheet, and the log distinguishes them.



https://claude.ai/code/session_0158a8zxX4SKPdxm7DLfgqp4
