### PR TITLE
fix(generator): stop waiting for a recompile the repair never triggered

### DIFF
--- a/bench/lib/firstAttemptRecord.mjs
+++ b/bench/lib/firstAttemptRecord.mjs
@@ -293,6 +293,23 @@ export function buildRecord({ prompt, events, durationMs, env, transportError = 
       /** The leg the headline uses: no repair was needed AND none stood after. */
       firstOutputClean: verificationLeg,
       findingsByClass: countBy(completion?.verification?.findings ?? [], f => `${f.severity}/${f.class}`),
+      /**
+       * The KIND, not just the class. A run that reports "warning/code: 28"
+       * says nothing about what to fix next, and reading it back meant opening
+       * a server log beside the results. The kind is what the taxonomy is
+       * built from, so record it here where the analysis actually happens.
+       */
+      findingsByKind: countBy(completion?.verification?.findings ?? [], f => f.kind || f.type || 'unnamed'),
+      /** One example message per kind, capped, so a kind can be recognised. */
+      findingExamples: Object.fromEntries(
+        Object.entries(
+          (completion?.verification?.findings ?? []).reduce((acc, f) => {
+            const k = f.kind || f.type || 'unnamed';
+            if (!acc[k]) acc[k] = String(f.message ?? '').slice(0, 160);
+            return acc;
+          }, {}),
+        ).slice(0, 12),
+      ),
       repairRan,
       repairImproved,
     },

--- a/mcp-server/routes/generationCore.ts
+++ b/mcp-server/routes/generationCore.ts
@@ -2375,20 +2375,39 @@ async function runStoryGenerationPipeline(
                 logger.log('🔧 Repair returned the story unchanged — nothing to re-verify');
               } else {
                 const before = await moduleText(verifyUrl, relModule);
+                const diskBefore = (() => { try { return fs.readFileSync(outPath, 'utf-8'); } catch { return null; } })();
                 writeStory(finalized);
-                const recompile = await waitForRecompile(verifyUrl, relModule, before);
-                if (!recompile.live) {
-                  // Say WHICH failure this is. The three read identically in a
-                  // render and were logged identically, which sent one
-                  // investigation after the dev server when the poll simply had
-                  // no baseline to compare against.
-                  const why = {
-                    no_baseline: `the module could not be read from ${verifyUrl}/${relModule} before the write, so no comparison was possible`,
-                    unreachable: `the module never returned 200 from ${verifyUrl}/${relModule}${recompile.status ? ` (last status ${recompile.status})` : ''}`,
-                    timeout: `the served module was byte-identical for ${Math.round(recompile.waitedMs / 1000)}s (${recompile.beforeBytes} bytes before, ${recompile.afterBytes} after) although the file on disk changed`,
-                    changed: '',
-                  }[recompile.reason];
-                  logger.warn(`⚠️ The repair check may read a stale render: ${why}`);
+                const diskAfter = (() => { try { return fs.readFileSync(outPath, 'utf-8'); } catch { return null; } })();
+                /**
+                 * What LANDED on disk, not what we asked to be written.
+                 *
+                 * `identical` compares the repair's text to the file, but the
+                 * writer normalises what it saves — it rewrites the stylesheet
+                 * import and settles the trailing bytes — so a repair can
+                 * differ from the file and still leave it unchanged. When that
+                 * happens there is nothing for the dev server to recompile, and
+                 * waiting for it burned the full 25s timeout and then blamed
+                 * Storybook. Measured in one 20-prompt run: 18 times, seven and
+                 * a half minutes, every one of them reported as a dev-server
+                 * problem.
+                 */
+                if (diskBefore !== null && diskAfter !== null && diskBefore === diskAfter) {
+                  logger.log('🔧 Repair changed nothing on disk after the writer normalised it — nothing to re-verify');
+                } else {
+                  const recompile = await waitForRecompile(verifyUrl, relModule, before);
+                  if (!recompile.live) {
+                    // Say WHICH failure this is. They read identically in a
+                    // render and were logged identically, which sent one
+                    // investigation after the dev server when the poll simply
+                    // had no baseline to compare against.
+                    const why = {
+                      no_baseline: `the module could not be read from ${verifyUrl}/${relModule} before the write, so no comparison was possible`,
+                      unreachable: `the module never returned 200 from ${verifyUrl}/${relModule}${recompile.status ? ` (last status ${recompile.status})` : ''}`,
+                      timeout: `the served module was byte-identical for ${Math.round(recompile.waitedMs / 1000)}s (${recompile.beforeBytes} bytes before, ${recompile.afterBytes} after) although the bytes on disk did change`,
+                      changed: '',
+                    }[recompile.reason];
+                    logger.warn(`⚠️ The repair check may read a stale render: ${why}`);
+                  }
                 }
               }
               return verifyStory({


### PR DESCRIPTION

The repair loop compared its own text to the file to decide whether anything
had changed, then waited up to 25s for the dev server to serve new module
text. But the writer normalises what it saves — it rewrites the stylesheet
import and settles the trailing bytes — so a repair can differ from the file
and still leave the file identical. There is then nothing to recompile, the
wait runs to its timeout, and the log blames Storybook.

Measured in one 20-prompt Carbon run: 18 occurrences, seven and a half minutes
spent waiting, every one of them reported as a dev-server problem. A separate
test confirmed the dev server re-transforms an edited story in about a second,
including a file created after startup, so the dev server was never the
suspect it was made out to be.

The check is now what landed on disk, before and after the write. When those
bytes match, the wait is skipped and says so. When they differ and the served
module still does not change, that remains a real warning and now says the
disk did change.

The bench also records the KIND of each finding and one example message per
kind. A results file saying "warning/code: 28" cannot tell anyone what to fix
next, and reading it back meant opening a server log beside the results.



https://claude.ai/code/session_0158a8zxX4SKPdxm7DLfgqp4
