### PR TITLE
fix(generator): the grouped row has to refuse the stretch too

### DIFF
--- a/__tests__/layout-behaviour.test.ts
+++ b/__tests__/layout-behaviour.test.ts
@@ -104,5 +104,10 @@ describe('readLayoutBehaviour', () => {
     expect(text).toContain('.cds--stack-vertical');
     expect(text).toContain('display: grid');
     expect(text).toContain('EVERY direct child stretches');
+    // The second-order case: wrapping the controls in a row does not help,
+    // because the row is a direct child too. Three measured failures were
+    // exactly this, and the first version of this text recommended it.
+    expect(text).toContain('Wrapping them in a row is NOT enough');
+    expect(text).toContain("justifySelf: 'start'");
   });
 });

--- a/story-generator/knowledge/stylingFacts.ts
+++ b/story-generator/knowledge/stylingFacts.ts
@@ -831,10 +831,29 @@ export function formatLayoutBehaviour(result: LayoutBehaviourResult): string {
   for (const b of stretching) {
     if (seen.has(b.component)) continue;
     seen.add(b.component);
+    const axis = /grid$/.test(b.display) ? 'justify-items' : 'align-items';
+    const selfProp = /grid$/.test(b.display) ? 'justifySelf' : 'alignSelf';
     lines.push(
       `- <${b.component}> renders \`display: ${b.display}\`${b.autoFlow ? `, \`grid-auto-flow: ${b.autoFlow}\`` : ''} (.${b.className}) and sets no ` +
-      `${/grid$/.test(b.display) ? 'justify-items' : 'align-items'}, so EVERY direct child stretches to its full width. ` +
-      `A button, tag, badge or chip placed directly inside comes out full width. Put such controls in a row that sizes to its content instead.`,
+      `${axis}, so EVERY direct child stretches to its full width. ` +
+      `A button, tag, badge or chip placed directly inside comes out full width.`,
+    );
+    /**
+     * The second-order case, and the one that actually failed three times.
+     *
+     * Wrapping the controls in a row is the obvious remedy and it is not
+     * enough: the ROW is a direct child too, so it is stretched to the full
+     * width, and its own auto tracks then absorb the free space and push the
+     * first and last control to opposite ends. Measured on Carbon: a login
+     * form and a pricing page both put two buttons in a horizontal Stack
+     * inside a vertical Stack, and the layout probe reported a 300px void
+     * between them, three gate attempts running.
+     */
+    lines.push(
+      `  Wrapping them in a row is NOT enough on its own: the row is a direct child too, so it is ` +
+      `stretched to the full width and its own columns then spread the controls to opposite ends. ` +
+      `Give the row \`${selfProp}: 'start'\` (or put it inside an element that hugs its content) so it ` +
+      `stays as wide as its buttons.`,
     );
   }
   return lines.join('\n');

--- a/story-generator/verify/probes/layout.ts
+++ b/story-generator/verify/probes/layout.ts
@@ -794,7 +794,13 @@ export async function runLayoutProbe(page: any, options: LayoutOptions = {}): Pr
                 message:
                   `${children.length} controls (${names.join(', ')}) are spread across the full width of their row instead of grouped: ${names[worstIdx + 1]} starts ${Math.round(worst)}px after ${names[worstIdx]} ends, although the declared gap is ${gap}px. ` +
                   `The parent is a ${mechanism}. ` +
-                  `Group them: put the controls in a row that sizes to its content (display: flex with the gap, or ${isGrid ? 'inline-grid / grid-auto-columns: max-content' : 'justify-content: flex-start'}) or use the design system's button-group component${isGrid ? '' : ', and keep the spare width outside the group'}.`,
+                  `Group them: put the controls in a row that sizes to its content (display: flex with the gap, or ${isGrid ? 'inline-grid / grid-auto-columns: max-content' : 'justify-content: flex-start'}) or use the design system's button-group component${isGrid ? '' : ', and keep the spare width outside the group'}. ` +
+                  // The remedy above was followed and the defect came back
+                  // three times: the design system's own row primitive is a
+                  // grid, so wrapping the controls in it produced another
+                  // stretched grid that spread them again. The row has to
+                  // refuse the stretch as well as group the controls.
+                  `If that row is itself a child of a stretching flex or grid container — which the design system's own stack primitive usually is — it will be stretched to the full width and spread the controls again, so give the row justify-self: start (or align-self: start in a column flex parent) as well.`,
                 evidence: `voids between neighbours: ${voids.map(v => Math.round(v)).join('px, ')}px against a ${gap}px gap; container ${Math.round(contentWidth)}px wide, controls ${rects.map(r => Math.round(r.width)).join('/')}px`,
                 selector: cssPath(el),
                 ...authorOf(el),


### PR DESCRIPTION

A login form and a pricing page both failed three gate attempts on the same
blocker: two buttons pushed to opposite ends of a 300px void. The story had
already done what every rule asked. It put the controls in the design system's
own row primitive.

That is the whole defect. Carbon's Stack is a grid, so a horizontal Stack
placed inside a vertical Stack is itself a stretched grid item, and its auto
columns then absorb the free width and push the first and last control apart.
Grouping the controls was necessary and not sufficient, and the advice stopped
at grouping — in the prompt, in the derived container facts, and in the layout
probe's own remedy, which recommended a plain flex row while other rules
forbade hand-rolling one.

All three now say the same thing: give the row justify-self: start, or put it
in something that hugs its content, so it stays as wide as its buttons.



https://claude.ai/code/session_0158a8zxX4SKPdxm7DLfgqp4
