### PR TITLE
fix(generator): give the model the row to copy, not a rule to apply

### DIFF
--- a/__tests__/layout-behaviour.test.ts
+++ b/__tests__/layout-behaviour.test.ts
@@ -44,7 +44,8 @@ beforeAll(() => {
 afterAll(() => fs.rmSync(dir, { recursive: true, force: true }));
 
 const carbon = [
-  { name: 'Stack', propTypes: ["'horizontal' | 'vertical'", 'string'] },
+  { name: 'Stack', propTypes: ["'horizontal' | 'vertical'", 'string'],
+    props: [{ name: 'orientation', type: "'horizontal' | 'vertical'" }, { name: 'gap', type: 'string' }] },
   { name: 'Grid', propTypes: ['boolean'] },
   { name: 'Modal', propTypes: ['boolean'] },
   { name: 'Toggletip', propTypes: ['boolean'] },
@@ -109,5 +110,12 @@ describe('readLayoutBehaviour', () => {
     // exactly this, and the first version of this text recommended it.
     expect(text).toContain('Wrapping them in a row is NOT enough');
     expect(text).toContain("justifySelf: 'start'");
+    // The rule alone was measured and was not enough: the model added the
+    // stretch refusal only after the probe reported the defect, on three
+    // prompts, every run. It copies examples more reliably than it applies
+    // conditional prose, so the row it should copy carries the fix, written
+    // with the prop the component itself declares.
+    expect(text).toContain('COPY THIS for any row of controls inside <Stack>');
+    expect(text).toContain(`<Stack orientation="horizontal" style={{ justifySelf: 'start' }}>`);
   });
 });

--- a/mcp-server/routes/generationCore.ts
+++ b/mcp-server/routes/generationCore.ts
@@ -3074,6 +3074,9 @@ async function buildClaudePromptWithContext(
       name: c.name,
       propValues: (c.propTypes || []).flatMap((p: any) => p.options || []),
       propTypes: (c.propTypes || []).map((p: any) => p.type || ''),
+      // With the prop that declares a variant value, the derived advice can be
+      // written back as JSX the model can copy verbatim.
+      props: (c.propTypes || []).map((p: any) => ({ name: p.name, values: p.options, type: p.type })),
     })));
     const layoutSection = formatLayoutBehaviour(layout);
     if (layoutSection) {

--- a/story-generator/knowledge/stylingFacts.ts
+++ b/story-generator/knowledge/stylingFacts.ts
@@ -676,6 +676,8 @@ export interface LayoutBehaviour {
   autoFlow?: string;
   templateColumns?: string;
   flexDirection?: string;
+  /** The prop and value that select this variant, when the class named one. */
+  variant?: { prop: string; value: string };
   /** Children are stretched across the container's inline axis by default. */
   stretchesChildren: boolean;
 }
@@ -715,6 +717,8 @@ function classSegments(className: string): string[] {
  */
 export interface LayoutComponent {
   name: string;
+  /** Declared props with the values they accept, so a variant class can name its prop. */
+  props?: Array<{ name: string; values?: string[]; type?: string }>;
   /** String values this component's own props accept, e.g. vertical/horizontal. */
   propValues?: string[];
   /**
@@ -739,6 +743,8 @@ export function readLayoutBehaviour(
   const files = stylesheetFiles || [];
   const wanted = new Map<string, string>();
   const valuesOf = new Map<string, Set<string>>();
+  /** value -> the prop that declares it, so a variant class can be written back as JSX. */
+  const propOf = new Map<string, Map<string, string>>();
   for (const c of components) {
     const name = typeof c === 'string' ? c : c.name;
     wanted.set(name.toLowerCase(), name);
@@ -746,6 +752,15 @@ export function readLayoutBehaviour(
       ? []
       : [...(c.propValues || []).map(v => v.toLowerCase()), ...(c.propTypes || []).flatMap(literalsOfType)];
     valuesOf.set(name, new Set(declared));
+    const byProp = new Map<string, string>();
+    if (typeof c !== 'string') {
+      for (const prop of c.props || []) {
+        for (const v of [...(prop.values || []).map(x => x.toLowerCase()), ...literalsOfType(prop.type || '')]) {
+          if (!byProp.has(v)) byProp.set(v, prop.name);
+        }
+      }
+    }
+    propOf.set(name, byProp);
   }
   const componentNames = components.map(c => (typeof c === 'string' ? c : c.name));
   const behaviours: LayoutBehaviour[] = [];
@@ -804,9 +819,11 @@ export function readLayoutBehaviour(
       const stretchesChildren = alongBlock
         && (isGrid ? !decls['justify-items'] || decls['justify-items'] === 'stretch'
                    : !decls['align-items'] || decls['align-items'] === 'stretch');
+      const variantProp = trailing.length === 1 ? propOf.get(hit)?.get(trailing[0]) : undefined;
       behaviours.push({
         component: hit,
         className,
+        ...(variantProp ? { variant: { prop: variantProp, value: trailing[0] } } : {}),
         display,
         autoFlow,
         templateColumns: decls['grid-template-columns'],
@@ -855,6 +872,24 @@ export function formatLayoutBehaviour(result: LayoutBehaviourResult): string {
       `Give the row \`${selfProp}: 'start'\` (or put it inside an element that hugs its content) so it ` +
       `stays as wide as its buttons.`,
     );
+    /**
+     * The pattern, not just the rule.
+     *
+     * Measured: with the rule alone, the model composed the action row without
+     * the stretch refusal on the first attempt and added it only after the
+     * layout probe reported the defect — three prompts, every run. It copies
+     * examples far more reliably than it applies conditional prose, so the row
+     * it is meant to copy has to carry the fix already.
+     */
+    const row = result.behaviours.find(r =>
+      r.component === b.component && r.variant && !r.stretchesChildren
+      && (/column/.test(r.autoFlow || '') || /^row$/.test(r.flexDirection || '')));
+    if (row) {
+      lines.push(
+        `  COPY THIS for any row of controls inside <${b.component}>: ` +
+        `<${row.component} ${row.variant!.prop}="${row.variant!.value}" style={{ ${selfProp}: 'start' }}> … </${row.component}>`,
+      );
+    }
   }
   return lines.join('\n');
 }


### PR DESCRIPTION

The stretch guidance shipped and was measured: the container facts reached the
prompt 34 times in a 20-prompt run, and the same three stories still put two
buttons at opposite ends of a void on their first attempt. Reading the kept
output shows what changed and what did not. The repair now fixes it — the
final login form carries style={{ justifySelf: 'start' }} on its action row,
and the gate settles a round earlier — but the first attempt never has it.

The rule was correct and conditional, and prose about what to do if you build
a row is not what a model reaches for while building one. The example is. So
the derived section now ends with the row itself, written with the prop the
component declares:

    COPY THIS for any row of controls inside <Stack>:
    <Stack orientation="horizontal" style={{ justifySelf: 'start' }}> … </Stack>

Both halves are derived. The horizontal variant is found as a sibling rule for
the same component that flows along the inline axis, and the prop name comes
from whichever declared prop admits that class's trailing segment as a value.



https://claude.ai/code/session_0158a8zxX4SKPdxm7DLfgqp4
