### PR TITLE
feat(generator): hold an action row to its content without asking a model

### DIFF
--- a/__tests__/stretch-fix.test.ts
+++ b/__tests__/stretch-fix.test.ts
@@ -1,0 +1,107 @@
+/**
+ * The deterministic half of the stretch defect.
+ *
+ * Four rounds of prompt guidance did not stop a story putting two buttons at
+ * opposite ends of a void, while the repair pass fixed it almost every time.
+ * There is exactly one correct edit — one attribute on one element — so it is
+ * made here instead of asked for.
+ *
+ * The tests that matter most are the ones asserting it does NOT fire. A row
+ * inside the same container that holds a heading and a badge is a header meant
+ * to span the full width, and hugging it would be a regression introduced by
+ * a transform nobody asked for.
+ */
+import { describe, it, expect } from 'vitest';
+import { fixStretchedControlRows } from '../story-generator/knowledge/stretchFix.js';
+import type { LayoutBehaviour } from '../story-generator/knowledge/stylingFacts.js';
+
+/** What readLayoutBehaviour derives from @carbon/styles for Stack. */
+const carbon: LayoutBehaviour[] = [
+  {
+    component: 'Stack', className: 'cds--stack-vertical', display: 'grid', autoFlow: 'row',
+    variant: { prop: 'orientation', value: 'vertical' }, stretchesChildren: true,
+  },
+  {
+    component: 'Stack', className: 'cds--stack-horizontal', display: 'inline-grid', autoFlow: 'column',
+    variant: { prop: 'orientation', value: 'horizontal' }, stretchesChildren: false,
+  },
+];
+
+const wrap = (inner: string) => `export const Default = {\n  render: () => (\n    <Stack gap={5}>\n${inner}\n    </Stack>\n  ),\n};\n`;
+
+describe('fixStretchedControlRows', () => {
+  it('holds a pair of buttons to their content, naming what it did', () => {
+    const code = wrap('      <Stack orientation="horizontal" gap={3}>\n        <Button>Save changes</Button>\n        <Button kind="secondary">Cancel</Button>\n      </Stack>');
+    const out = fixStretchedControlRows(code, carbon);
+    expect(out.ran).toBe(true);
+    expect(out.edits).toHaveLength(1);
+    expect(out.edits[0]).toMatchObject({ container: 'Stack', row: 'Stack', control: 'Button', count: 2, property: 'justifySelf' });
+    expect(out.code).toContain(`<Stack orientation="horizontal" gap={3} style={{ justifySelf: 'start' }}>`);
+    // Nothing else moved.
+    expect(out.code).toContain('<Button kind="secondary">Cancel</Button>');
+  });
+
+  it('merges into a style the story already wrote', () => {
+    const code = wrap("      <Stack orientation=\"horizontal\" style={{ marginTop: 8 }}>\n        <Button>A</Button>\n        <Button>B</Button>\n      </Stack>");
+    const out = fixStretchedControlRows(code, carbon);
+    expect(out.edits).toHaveLength(1);
+    expect(out.code).toContain("style={{ justifySelf: 'start', marginTop: 8 }}");
+  });
+
+  it('leaves a header row of different components alone', () => {
+    // A heading beside a badge is meant to span the width. This is the
+    // regression the narrow rule exists to avoid, not an edge case.
+    const code = wrap('      <Stack orientation="horizontal">\n        <Heading>Team plan</Heading>\n        <Tag type="blue">Popular</Tag>\n      </Stack>');
+    const out = fixStretchedControlRows(code, carbon);
+    expect(out.edits).toEqual([]);
+    expect(out.code).toBe(code);
+  });
+
+  it('leaves a row that has already decided its width, and says why', () => {
+    for (const [attr, why] of [
+      ['style={{ justifySelf: \'stretch\' }}', 'justifySelf'],
+      ['style={{ width: \'100%\' }}', 'width'],
+      ['className="actions"', 'class'],
+      ['style={styles.row}', 'not an object literal'],
+    ] as Array<[string, string]>) {
+      const code = wrap(`      <Stack orientation="horizontal" ${attr}>\n        <Button>A</Button>\n        <Button>B</Button>\n      </Stack>`);
+      const out = fixStretchedControlRows(code, carbon);
+      expect(out.edits).toEqual([]);
+      expect(out.skipped).toHaveLength(1);
+      expect(out.skipped[0].reason).toContain(why);
+      expect(out.code).toBe(code);
+    }
+  });
+
+  it('does not touch a lone control, or a row outside a stretching container', () => {
+    const lone = wrap('      <Stack orientation="horizontal">\n        <Button>Only one</Button>\n      </Stack>');
+    expect(fixStretchedControlRows(lone, carbon).edits).toEqual([]);
+
+    // The same row, but its parent is the horizontal (non-stretching) form.
+    const outside = `export const D = { render: () => (\n  <Stack orientation="horizontal">\n    <Stack orientation="horizontal">\n      <Button>A</Button>\n      <Button>B</Button>\n    </Stack>\n  </Stack>\n) };\n`;
+    expect(fixStretchedControlRows(outside, carbon).edits).toEqual([]);
+  });
+
+  it('does not run at all when the stylesheet derived no stretching container', () => {
+    // A design system with hashed class names (CSS modules) derives nothing.
+    // That must be visible as "could not run", never as "nothing to fix".
+    const code = wrap('      <Stack orientation="horizontal">\n        <Button>A</Button>\n        <Button>B</Button>\n      </Stack>');
+    const none = fixStretchedControlRows(code, []);
+    expect(none.ran).toBe(false);
+    expect(none.source).toContain('the pass did not run');
+    expect(none.code).toBe(code);
+
+    // Derived a stretching container but no row variant: also cannot place one.
+    const noRow = fixStretchedControlRows(code, [carbon[0]]);
+    expect(noRow.ran).toBe(false);
+    expect(noRow.source).toContain('no row variant');
+  });
+
+  it('leaves the file parseable and fixes every occurrence', () => {
+    const code = `export const D = {\n  render: () => (\n    <Stack gap={5}>\n      <Stack orientation="horizontal"><Button>A</Button><Button>B</Button></Stack>\n      <TextInput id="a" labelText="Email" />\n      <Stack orientation="horizontal"><Link href="#">One</Link><Link href="#">Two</Link></Stack>\n    </Stack>\n  ),\n};\n`;
+    const out = fixStretchedControlRows(code, carbon);
+    expect(out.edits.map(e => e.control)).toEqual(['Button', 'Link']);
+    expect(out.code.match(/justifySelf: 'start'/g)).toHaveLength(2);
+    expect(out.code).toContain('<TextInput id="a" labelText="Email" />');
+  });
+});

--- a/mcp-server/routes/generationCore.ts
+++ b/mcp-server/routes/generationCore.ts
@@ -108,6 +108,8 @@ const GEOMETRY_PROP = /^(sm|md|lg|xl|xxl|max|xs|span|offset|start|end|gap|column
 const LAYOUT_PROSE = /\b(column|columns|grid|breakpoint|gutter|span|spacing|width|row|layout)\b/i;
 import { enrichWithSourceFacts, withLocalPropFacts } from '../../story-generator/knowledge/sourceFacts.js';
 import { readStylingFacts, formatStylingGuidance, readDesignTokens, readLayoutBehaviour, formatLayoutBehaviour } from '../../story-generator/knowledge/stylingFacts.js';
+import { fixStretchedControlRows } from '../../story-generator/knowledge/stretchFix.js';
+import type { LayoutBehaviour } from '../../story-generator/knowledge/stylingFacts.js';
 import type { StylingFacts } from '../../story-generator/knowledge/stylingFacts.js';
 import {
   deriveSpacingVocabulary, checkInlineSpacing, checkTokenTiers, checkRawColors, formatSpacingErrors, formatTierErrors, formatColorErrors, repairSpacingNote,
@@ -439,6 +441,7 @@ async function runStoryGenerationPipeline(
    */
   let stylingFacts: StylingFacts | null = null;
   let spacingVocab: SpacingVocabulary | null = null;
+  let layoutBehaviours: LayoutBehaviour[] = [];
   let iconVocab: IconVocabulary | null = null;
 
   const {
@@ -796,6 +799,17 @@ async function runStoryGenerationPipeline(
     spacingVocab = deriveSpacingVocabulary({
       components: components as any[], facts: knownProps, styling: stylingFacts, layoutRules: config.layoutRules,
     });
+    /**
+     * Which of this design system's containers stretch their children, read
+     * from its own stylesheet. Used twice: stated in the prompt, and applied
+     * as a deterministic edit after generation (knowledge/stretchFix.ts).
+     */
+    layoutBehaviours = readLayoutBehaviour(stylingFacts.stylesheetFiles, (components as any[]).map((c: any) => ({
+      name: c.name,
+      propValues: (c.propTypes || []).flatMap((p: any) => p.options || []),
+      propTypes: (c.propTypes || []).map((p: any) => p.type || ''),
+      props: (c.propTypes || []).map((p: any) => ({ name: p.name, values: p.options, type: p.type })),
+    }))).behaviours;
     logger.log(spacingVocab.hasScale
       ? `📏 Spacing vocabulary: ${spacingVocab.source}${Object.keys(spacingVocab.aliasesOf).length ? `; ${Object.keys(spacingVocab.aliasesOf).length} primitive colour(s) with a semantic alias` : ''}`
       : `📏 Spacing vocabulary: ${spacingVocab.source} — the prompt falls back to inline spacing examples and says so`);
@@ -1833,6 +1847,22 @@ async function runStoryGenerationPipeline(
       if (r.lost.length) logger.warn(`📌 ${r.lost.length} pinned prop(s) no longer have an element: ${r.lost.map(describePin).join(', ')}`);
     }
     fixed = frameworkAdapter.postProcess(fixed);
+    /**
+     * A row of identical controls inside a container the stylesheet says
+     * stretches its children is the one defect four rounds of prompt guidance
+     * could not prevent, and it has exactly one correct edit. Made here, where
+     * the first output, a healed regeneration and a repair candidate all pass
+     * through, so no route can miss it.
+     */
+    if (layoutBehaviours.length) {
+      const held = fixStretchedControlRows(fixed, layoutBehaviours, finalFileName);
+      if (held.edits.length) {
+        fixed = held.code;
+        logger.log(`↔️ Stretch fix: ${held.source} — ${held.edits.map(e => `L${e.line} <${e.row}> of ${e.count} <${e.control}>`).join(', ')}`);
+      } else if (held.skipped.length) {
+        logger.log(`↔️ Stretch fix: left ${held.skipped.length} row(s) alone — ${held.skipped.map(sk => `L${sk.line} ${sk.reason}`).join('; ')}`);
+      }
+    }
     fixed = applyTitleAndId(fixed, cleanTitle, storyIdSlug, config.storyPrefix);
     fixed = alignStorybookTypesImport(fixed, config.storybookFramework);
 

--- a/story-generator/knowledge/stretchFix.ts
+++ b/story-generator/knowledge/stretchFix.ts
@@ -1,0 +1,269 @@
+/**
+ * The one edit that stops an action row spreading, applied without a model.
+ *
+ * The defect, measured on Carbon across four benches: a story puts two buttons
+ * in the design system's own row primitive, and they come out at opposite ends
+ * of a 300px void. The chain is short and every link is correct on its own.
+ * `.cds--stack-vertical` declares `display: grid` and sets no `justify-items`,
+ * so every direct child stretches. The row of buttons IS a direct child, so it
+ * is stretched to the full width, and its own auto columns then absorb the
+ * free space and push the first and last button apart.
+ *
+ * Four rounds of prompt guidance did not prevent it: a rule about action rows,
+ * the container behaviour derived from the stylesheet, the layout probe's own
+ * remedy, and finally a copyable JSX pattern. Across those runs the model added
+ * the fix reliably AFTER the probe reported the defect and almost never before,
+ * and the same prompt on the same build moved between one and three gate
+ * attempts. That is the signature of a change that should not involve a model:
+ * there is exactly one correct edit, to one attribute of one element, and the
+ * project already treats those as AST work rather than generation.
+ *
+ * WHAT IT WILL NOT TOUCH. The rule is deliberately narrow, because the same
+ * shape with different contents is a layout that SHOULD span the full width —
+ * a card header with a title on the left and a badge on the right is a row
+ * inside the same stretching container, and hugging it would be a regression.
+ * So a row qualifies only when its own direct children are two or more
+ * elements of the SAME component. Every measured failure is that: two Buttons.
+ * A title beside a Tag is two different components and is left alone.
+ */
+
+import ts from 'typescript';
+import type { LayoutBehaviour } from './stylingFacts.js';
+
+export interface StretchFixEdit {
+  line: number;
+  /** The stretching container whose child was hugging nothing. */
+  container: string;
+  /** The row element that was stretched. */
+  row: string;
+  /** The component repeated inside it. */
+  control: string;
+  count: number;
+  /** The property written. */
+  property: string;
+}
+
+export interface StretchFixSkip {
+  line: number;
+  row: string;
+  reason: string;
+}
+
+export interface StretchFixResult {
+  code: string;
+  edits: StretchFixEdit[];
+  skipped: StretchFixSkip[];
+  /**
+   * False when no stretching container is known for this design system, so
+   * the pass could not run at all. A design system with hashed class names
+   * derives nothing and lands here — which must not read like a pass.
+   */
+  ran: boolean;
+  /** One line for the log, always. */
+  source: string;
+}
+
+/** Properties that mean the author has already decided this element's width. */
+const ALREADY_DECIDED = /^(justifySelf|alignSelf|width|maxWidth|minWidth|inlineSize|maxInlineSize|justifyContent|placeSelf|gridColumn|flex)$/;
+
+interface RowVariant {
+  /** Values of a prop that select the inline-flowing form, e.g. horizontal. */
+  values: Map<string, string>;
+  /** The prop those values belong to. */
+  prop?: string;
+}
+
+/**
+ * Which components stretch their children, and which of their variants are
+ * rows — both read from the behaviours derived from the project's stylesheet,
+ * never from a name.
+ */
+function index(behaviours: LayoutBehaviour[]) {
+  const stretching = new Map<string, LayoutBehaviour>();
+  const rows = new Map<string, RowVariant>();
+  for (const b of behaviours) {
+    if (b.stretchesChildren) {
+      // The default form of the component is the one with no variant class;
+      // prefer it, so `<Stack>` with no orientation is recognised.
+      if (!stretching.has(b.component) || !b.variant) stretching.set(b.component, b);
+      continue;
+    }
+    const flowsAcross = /column/.test(b.autoFlow || '') || /^row$/.test(b.flexDirection || '');
+    if (!flowsAcross || !b.variant) continue;
+    const entry: RowVariant = rows.get(b.component) || { values: new Map<string, string>() };
+    entry.values.set(b.variant.value, b.variant.prop);
+    entry.prop = b.variant.prop;
+    rows.set(b.component, entry);
+  }
+  return { stretching, rows };
+}
+
+const tagName = (
+  el: ts.JsxOpeningElement | ts.JsxSelfClosingElement, src: ts.SourceFile,
+): string => el.tagName.getText(src);
+
+function attributesOf(el: ts.JsxOpeningElement | ts.JsxSelfClosingElement): ts.JsxAttribute[] {
+  return el.attributes.properties.filter((a): a is ts.JsxAttribute => ts.isJsxAttribute(a));
+}
+
+function attribute(
+  el: ts.JsxOpeningElement | ts.JsxSelfClosingElement, name: string, src: ts.SourceFile,
+): ts.JsxAttribute | undefined {
+  return attributesOf(el).find(a => a.name.getText(src) === name);
+}
+
+/** The literal string an attribute is set to, when it is one. */
+function literalValue(attr: ts.JsxAttribute | undefined, src: ts.SourceFile): string | null {
+  if (!attr || !attr.initializer) return null;
+  if (ts.isStringLiteral(attr.initializer)) return attr.initializer.text;
+  if (ts.isJsxExpression(attr.initializer) && attr.initializer.expression
+      && ts.isStringLiteralLike(attr.initializer.expression)) {
+    return attr.initializer.expression.text;
+  }
+  void src;
+  return null;
+}
+
+/** JSX element children, ignoring whitespace text and expression containers. */
+function elementChildren(node: ts.JsxElement): Array<ts.JsxElement | ts.JsxSelfClosingElement> {
+  const out: Array<ts.JsxElement | ts.JsxSelfClosingElement> = [];
+  for (const child of node.children) {
+    if (ts.isJsxElement(child) || ts.isJsxSelfClosingElement(child)) out.push(child);
+  }
+  return out;
+}
+
+function openingOf(node: ts.JsxElement | ts.JsxSelfClosingElement): ts.JsxOpeningElement | ts.JsxSelfClosingElement {
+  return ts.isJsxElement(node) ? node.openingElement : node;
+}
+
+/**
+ * Does this element already say how wide it should be?
+ *
+ * Checked in the style object and in the attributes, because a design system
+ * may own either. When the style is not an object literal we cannot read it,
+ * and an unreadable style counts as decided — guessing past it is how a
+ * transform breaks a layout someone wrote on purpose.
+ */
+function widthIsDecided(
+  el: ts.JsxOpeningElement | ts.JsxSelfClosingElement, src: ts.SourceFile,
+): string | null {
+  for (const attr of attributesOf(el)) {
+    const name = attr.name.getText(src);
+    if (ALREADY_DECIDED.test(name)) return `the element already sets ${name}`;
+    if (name === 'className' || name === 'class') return 'the element carries a class of its own';
+    if (name !== 'style') continue;
+    const init = attr.initializer;
+    if (!init || !ts.isJsxExpression(init) || !init.expression) return 'its style could not be read';
+    if (!ts.isObjectLiteralExpression(init.expression)) return 'its style is not an object literal';
+    for (const prop of init.expression.properties) {
+      if (!ts.isPropertyAssignment(prop) && !ts.isShorthandPropertyAssignment(prop)) {
+        return 'its style object is spread from elsewhere';
+      }
+      const key = prop.name?.getText(src).replace(/['"]/g, '') ?? '';
+      if (ALREADY_DECIDED.test(key)) return `its style already sets ${key}`;
+    }
+  }
+  return null;
+}
+
+/** Is this element a row that flows across, per the derived behaviours? */
+function rowVariantOf(
+  el: ts.JsxOpeningElement | ts.JsxSelfClosingElement, src: ts.SourceFile, rows: Map<string, RowVariant>,
+): boolean {
+  const entry = rows.get(tagName(el, src));
+  if (!entry) return false;
+  for (const [value, prop] of entry.values) {
+    if (literalValue(attribute(el, prop, src), src) === value) return true;
+  }
+  return false;
+}
+
+/**
+ * Add `justifySelf: 'start'` (or `alignSelf` under a flex parent) to every row
+ * of identical controls sitting directly inside a container the stylesheet
+ * says stretches its children.
+ */
+export function fixStretchedControlRows(
+  code: string,
+  behaviours: LayoutBehaviour[],
+  fileName = 'story.tsx',
+): StretchFixResult {
+  const { stretching, rows } = index(behaviours);
+  if (!stretching.size || !rows.size) {
+    return {
+      code, edits: [], skipped: [], ran: false,
+      source: stretching.size
+        ? `${stretching.size} stretching container(s) derived but no row variant among them — nothing to place`
+        : 'no stretching container derived from this project\'s stylesheet — the pass did not run',
+    };
+  }
+
+  const src = ts.createSourceFile(fileName, code, ts.ScriptTarget.Latest, true, ts.ScriptKind.TSX);
+  const edits: StretchFixEdit[] = [];
+  const skipped: StretchFixSkip[] = [];
+  /** Insertions, applied back to front so earlier offsets stay valid. */
+  const splices: Array<{ at: number; text: string }> = [];
+
+  const lineOf = (node: ts.Node) => src.getLineAndCharacterOfPosition(node.getStart(src)).line + 1;
+
+  const visit = (node: ts.Node): void => {
+    if (ts.isJsxElement(node)) {
+      const open = node.openingElement;
+      const name = tagName(open, src);
+      const container = stretching.get(name);
+      // The row form of the same component is not the stretching form.
+      if (container && !rowVariantOf(open, src, rows)) {
+        for (const child of elementChildren(node)) {
+          const childOpen = openingOf(child);
+          if (!rowVariantOf(childOpen, src, rows)) continue;
+          const inner = ts.isJsxElement(child) ? elementChildren(child) : [];
+          const controlNames = new Set(inner.map(c => tagName(openingOf(c), src)));
+          if (inner.length < 2 || controlNames.size !== 1) {
+            // Not an action row: one control, or a mix of components, which is
+            // usually a header that is meant to span the full width.
+            continue;
+          }
+          const decided = widthIsDecided(childOpen, src);
+          if (decided) {
+            skipped.push({ line: lineOf(childOpen), row: tagName(childOpen, src), reason: decided });
+            continue;
+          }
+          const property = /grid$/.test(container.display) ? 'justifySelf' : 'alignSelf';
+          const styleAttr = attribute(childOpen, 'style', src);
+          if (styleAttr && styleAttr.initializer && ts.isJsxExpression(styleAttr.initializer)
+              && styleAttr.initializer.expression
+              && ts.isObjectLiteralExpression(styleAttr.initializer.expression)) {
+            const obj = styleAttr.initializer.expression;
+            const at = obj.properties.length ? obj.properties[0].getStart(src) : obj.getStart(src) + 1;
+            splices.push({ at, text: `${property}: 'start'${obj.properties.length ? ', ' : ''}` });
+          } else {
+            const props = childOpen.attributes.properties;
+            const anchor = props.length ? props[props.length - 1].getEnd() : childOpen.tagName.getEnd();
+            splices.push({ at: anchor, text: ` style={{ ${property}: 'start' }}` });
+          }
+          edits.push({
+            line: lineOf(childOpen),
+            container: name,
+            row: tagName(childOpen, src),
+            control: [...controlNames][0],
+            count: inner.length,
+            property,
+          });
+        }
+      }
+    }
+    ts.forEachChild(node, visit);
+  };
+  visit(src);
+
+  let out = code;
+  for (const s of splices.sort((a, b) => b.at - a.at)) {
+    out = out.slice(0, s.at) + s.text + out.slice(s.at);
+  }
+
+  const source = edits.length
+    ? `${edits.length} control row(s) held to their content inside ${[...new Set(edits.map(e => e.container))].join(', ')}`
+    : `no control row needed it (${stretching.size} stretching container(s), ${skipped.length} row(s) already decided)`;
+  return { code: out, edits, skipped, ran: true, source };
+}


### PR DESCRIPTION

Four rounds of prompt guidance did not stop a story putting two buttons at
opposite ends of a 300px void: a rule about action rows, the container
behaviour derived from the stylesheet, the layout probe's own remedy, and a
copyable JSX pattern. Across those runs the model added the fix reliably after
the probe reported the defect and almost never before, and the same prompt on
the same build moved between one and three gate attempts.

That is the signature of a change that should not involve a model. There is
exactly one correct edit, to one attribute of one element, and this project
already treats those as AST work.

A row of controls directly inside a container the stylesheet says stretches
its children now gets justifySelf: 'start' (alignSelf under a flex parent),
merged into a style the story already wrote. Both halves are derived: which
containers stretch, and which of their variants is a row.

The narrowness is the point. A row qualifies only when its own children are
two or more elements of the SAME component, which is what every measured
failure is — two Buttons, two Links. A heading beside a badge is a header
meant to span the full width, and hugging it would be a regression this
transform introduced on its own. Anything that already sets a width, a
self-alignment, a class, or a style we cannot read is left alone and said so
in the log. A design system whose classes are hashed derives no container, and
the pass reports that it did not run rather than that it found nothing.

It runs inside the finalizer, so the first output, a healed regeneration and a
repair candidate all pass through it.



https://claude.ai/code/session_0158a8zxX4SKPdxm7DLfgqp4
