### PR TITLE
fix(generator): report the stretch pass even when it changes nothing

### DIFF
--- a/bench/firstAttempt.mjs
+++ b/bench/firstAttempt.mjs
@@ -187,7 +187,17 @@ async function main() {
   const project = projectArg
     ? (path.isAbsolute(projectArg) ? projectArg : path.resolve(PROJECTS_ROOT, projectArg))
     : null;
-  const timeoutMs = Number(arg('timeout', '600')) * 1000;
+  /**
+   * The per-prompt cap.
+   *
+   * It was 600s, and each of the two 20-prompt Carbon runs lost a different
+   * complex prompt to it. Not counting those as passes is right; losing them
+   * is still a measurement that taught nothing, and a complex prompt that
+   * spends three gate attempts legitimately runs past ten minutes. 900s clears
+   * the longest completed run seen (590s) with room, and a run that hits even
+   * this is reported as incomplete exactly as before.
+   */
+  const timeoutMs = Number(arg('timeout', '900')) * 1000;
   const keep = flag('keep');
 
   const only = arg('only', '');

--- a/mcp-server/routes/generationCore.ts
+++ b/mcp-server/routes/generationCore.ts
@@ -442,6 +442,8 @@ async function runStoryGenerationPipeline(
   let stylingFacts: StylingFacts | null = null;
   let spacingVocab: SpacingVocabulary | null = null;
   let layoutBehaviours: LayoutBehaviour[] = [];
+  /** The stretch pass reports once per generation, not once per finalize. */
+  let stretchFixReported = false;
   let iconVocab: IconVocabulary | null = null;
 
   const {
@@ -1854,13 +1856,32 @@ async function runStoryGenerationPipeline(
      * the first output, a healed regeneration and a repair candidate all pass
      * through, so no route can miss it.
      */
-    if (layoutBehaviours.length) {
-      const held = fixStretchedControlRows(fixed, layoutBehaviours, finalFileName);
-      if (held.edits.length) {
-        fixed = held.code;
-        logger.log(`↔️ Stretch fix: ${held.source} — ${held.edits.map(e => `L${e.line} <${e.row}> of ${e.count} <${e.control}>`).join(', ')}`);
-      } else if (held.skipped.length) {
-        logger.log(`↔️ Stretch fix: left ${held.skipped.length} row(s) alone — ${held.skipped.map(sk => `L${sk.line} ${sk.reason}`).join('; ')}`);
+    {
+      const held = layoutBehaviours.length
+        ? fixStretchedControlRows(fixed, layoutBehaviours, finalFileName)
+        : null;
+      if (held?.edits.length) fixed = held.code;
+      /**
+       * Reported on every path, including the one where nothing happened.
+       *
+       * The first version logged only when it changed something, so a pass
+       * that ran and found nothing was indistinguishable from a pass that
+       * never ran — which is the exact conflation this codebase keeps paying
+       * for, introduced here by the commit that fixed it elsewhere. It cost a
+       * run to notice. Logged once per generation, not once per finalize,
+       * because the finalizer also runs for every repair candidate.
+       */
+      if (!stretchFixReported) {
+        stretchFixReported = true;
+        if (!held) {
+          logger.log('↔️ Stretch fix: no container behaviour was derived for this design system — the pass did not run');
+        } else if (held.edits.length) {
+          logger.log(`↔️ Stretch fix: ${held.source} — ${held.edits.map(e => `L${e.line} <${e.row}> of ${e.count} <${e.control}>`).join(', ')}`);
+        } else if (held.skipped.length) {
+          logger.log(`↔️ Stretch fix: left ${held.skipped.length} row(s) alone — ${held.skipped.map(sk => `L${sk.line} ${sk.reason}`).join('; ')}`);
+        } else {
+          logger.log(`↔️ Stretch fix: ran, ${held.source}`);
+        }
       }
     }
     fixed = applyTitleAndId(fixed, cleanTitle, storyIdSlug, config.storyPrefix);


### PR DESCRIPTION

The pass logged only when it edited something, so a run where it found no
qualifying row was indistinguishable from a run where it never had the data to
run at all. That is the conflation this codebase keeps paying for, introduced
by the commit that fixed it elsewhere, and it cost a twenty-prompt run to
notice: the log was silent and the only way to tell which had happened was to
replay the pass over recorded stories by hand.

It now reports on every path — did not run, ran and edited, ran and left rows
alone, ran and found nothing — once per generation rather than once per
finalize, since the finalizer also runs for every repair candidate.

The bench's per-prompt cap goes from 600s to 900s. Each of the two twenty-
prompt Carbon runs lost a different complex prompt to it, and a complex prompt
that legitimately spends three gate attempts runs past ten minutes. A run that
hits the higher cap is still reported as incomplete.



https://claude.ai/code/session_0158a8zxX4SKPdxm7DLfgqp4
