### PR TITLE
fix(generator): derive container behaviour once, for both things that need it

### DIFF
--- a/__tests__/layout-behaviour.test.ts
+++ b/__tests__/layout-behaviour.test.ts
@@ -18,7 +18,7 @@ import { describe, it, expect, beforeAll, afterAll } from 'vitest';
 import fs from 'fs';
 import os from 'os';
 import path from 'path';
-import { readLayoutBehaviour, formatLayoutBehaviour } from '../story-generator/knowledge/stylingFacts.js';
+import { readLayoutBehaviour, formatLayoutBehaviour, layoutComponentsFrom } from '../story-generator/knowledge/stylingFacts.js';
 
 let dir: string;
 let sheet: string;
@@ -117,5 +117,32 @@ describe('readLayoutBehaviour', () => {
     // with the prop the component itself declares.
     expect(text).toContain('COPY THIS for any row of controls inside <Stack>');
     expect(text).toContain(`<Stack orientation="horizontal" style={{ justifySelf: 'start' }}>`);
+  });
+});
+
+describe('layoutComponentsFrom', () => {
+  it('takes a prop\'s declared values from the catalog OR the extracted facts', () => {
+    // The regression this exists to stop: two callers built this list
+    // separately, one from a field that was populated and one from a field
+    // that was not, so the same project derived Stack in the prompt and only
+    // Grid in the pipeline — and the deterministic pass silently had nothing
+    // to place for a whole run.
+    const fromCatalog = layoutComponentsFrom(
+      [{ name: 'Stack', propTypes: [{ name: 'orientation', type: "'horizontal' | 'vertical'" }] }],
+    );
+    expect(fromCatalog[0].props?.[0]).toMatchObject({ name: 'orientation' });
+    expect(fromCatalog[0].propTypes).toContain("'horizontal' | 'vertical'");
+
+    const fromFacts = layoutComponentsFrom(
+      [{ name: 'Stack' }],
+      { components: { Stack: { props: [{ name: 'orientation', options: ['horizontal', 'vertical'] }] } } },
+    );
+    expect(fromFacts[0].propValues).toEqual(['horizontal', 'vertical']);
+
+    // Either source alone is enough to derive the horizontal row.
+    for (const catalog of [fromCatalog, fromFacts]) {
+      const out = readLayoutBehaviour([sheet], catalog);
+      expect(out.behaviours.map(b => b.className)).toContain('cds--stack-horizontal');
+    }
   });
 });

--- a/mcp-server/routes/generationCore.ts
+++ b/mcp-server/routes/generationCore.ts
@@ -107,7 +107,7 @@ import { saysMoreThanName } from '../../story-generator/knowledge/descriptionQua
 const GEOMETRY_PROP = /^(sm|md|lg|xl|xxl|max|xs|span|offset|start|end|gap|columns|narrow|condensed|fullWidth|orientation)$/;
 const LAYOUT_PROSE = /\b(column|columns|grid|breakpoint|gutter|span|spacing|width|row|layout)\b/i;
 import { enrichWithSourceFacts, withLocalPropFacts } from '../../story-generator/knowledge/sourceFacts.js';
-import { readStylingFacts, formatStylingGuidance, readDesignTokens, readLayoutBehaviour, formatLayoutBehaviour } from '../../story-generator/knowledge/stylingFacts.js';
+import { readStylingFacts, formatStylingGuidance, readDesignTokens, readLayoutBehaviour, formatLayoutBehaviour, layoutComponentsFrom } from '../../story-generator/knowledge/stylingFacts.js';
 import { fixStretchedControlRows } from '../../story-generator/knowledge/stretchFix.js';
 import type { LayoutBehaviour } from '../../story-generator/knowledge/stylingFacts.js';
 import type { StylingFacts } from '../../story-generator/knowledge/stylingFacts.js';
@@ -806,12 +806,11 @@ async function runStoryGenerationPipeline(
      * from its own stylesheet. Used twice: stated in the prompt, and applied
      * as a deterministic edit after generation (knowledge/stretchFix.ts).
      */
-    layoutBehaviours = readLayoutBehaviour(stylingFacts.stylesheetFiles, (components as any[]).map((c: any) => ({
-      name: c.name,
-      propValues: (c.propTypes || []).flatMap((p: any) => p.options || []),
-      propTypes: (c.propTypes || []).map((p: any) => p.type || ''),
-      props: (c.propTypes || []).map((p: any) => ({ name: p.name, values: p.options, type: p.type })),
-    }))).behaviours;
+    const derivedLayout = readLayoutBehaviour(
+      stylingFacts.stylesheetFiles, layoutComponentsFrom(components as any[], knownProps),
+    );
+    layoutBehaviours = derivedLayout.behaviours;
+    logger.log(`📦 Container behaviour: ${layoutBehaviours.filter(b => b.stretchesChildren).map(b => b.component).join(', ') || 'none'} stretch their children — ${derivedLayout.source}`);
     logger.log(spacingVocab.hasScale
       ? `📏 Spacing vocabulary: ${spacingVocab.source}${Object.keys(spacingVocab.aliasesOf).length ? `; ${Object.keys(spacingVocab.aliasesOf).length} primitive colour(s) with a semantic alias` : ''}`
       : `📏 Spacing vocabulary: ${spacingVocab.source} — the prompt falls back to inline spacing examples and says so`);
@@ -1067,6 +1066,7 @@ async function runStoryGenerationPipeline(
       spacing: spacingVocab,
       styling: stylingFacts,
       icons: iconVocab,
+      layout: layoutBehaviours,
     }
   );
 
@@ -1880,7 +1880,7 @@ async function runStoryGenerationPipeline(
         } else if (held.skipped.length) {
           logger.log(`↔️ Stretch fix: left ${held.skipped.length} row(s) alone — ${held.skipped.map(sk => `L${sk.line} ${sk.reason}`).join('; ')}`);
         } else {
-          logger.log(`↔️ Stretch fix: ran, ${held.source}`);
+          logger.log(`↔️ Stretch fix: ${held.ran ? 'ran, ' : ''}${held.source}`);
         }
       }
     }
@@ -2977,6 +2977,16 @@ async function buildClaudePromptWithContext(
     styling?: StylingFacts | null;
     /** The derived icon/placeholder vocabulary. */
     icons?: IconVocabulary | null;
+    /**
+     * Container behaviour derived from the project's stylesheet.
+     *
+     * Passed in rather than derived here. Both this prompt section and the
+     * deterministic stretch pass need it, they each built the catalog for it
+     * separately, and they drifted: one found Carbon's Stack and the other
+     * found only Grid, so the pass had no row to place and did nothing for a
+     * whole run without saying so.
+     */
+    layout?: LayoutBehaviour[];
   }
 ): Promise<string> {
   // What the previous code already uses must stay fully described, or an
@@ -3121,22 +3131,16 @@ async function buildClaudePromptWithContext(
      * directly in a Stack comes out full width. That is a fact in a file we
      * already read, not a convention to be assumed.
      */
-    const layout = readLayoutBehaviour(styling.stylesheetFiles, (components || []).map((c: any) => ({
-      name: c.name,
-      propValues: (c.propTypes || []).flatMap((p: any) => p.options || []),
-      propTypes: (c.propTypes || []).map((p: any) => p.type || ''),
-      // With the prop that declares a variant value, the derived advice can be
-      // written back as JSX the model can copy verbatim.
-      props: (c.propTypes || []).map((p: any) => ({ name: p.name, values: p.options, type: p.type })),
-    })));
-    const layoutSection = formatLayoutBehaviour(layout);
+    const layout = options.layout
+      ? { behaviours: options.layout, source: `${options.layout.length} rule(s) derived for this project` }
+      : readLayoutBehaviour(styling.stylesheetFiles, layoutComponentsFrom((components || []) as any[]));
+    const layoutSection = formatLayoutBehaviour(layout as any);
     if (layoutSection) {
-      logger.log(`📦 Container behaviour: ${layout.behaviours.filter(b => b.stretchesChildren).length} stretching container(s) — ${layout.source}`);
       prompt = injectBeforeUserRequest(prompt, layoutSection);
     } else {
       // Zero matched and nothing read must not read alike: a hashed-class
       // design system (CSS modules) legitimately matches nothing.
-      logger.log(`📦 No container behaviour derived: ${layout.source}`);
+      logger.log(`📦 No container behaviour stated in the prompt: ${layout.source}`);
     }
   } catch (error) {
     logger.log(`⚠️ Could not read styling facts: ${error}`);

--- a/story-generator/knowledge/stylingFacts.ts
+++ b/story-generator/knowledge/stylingFacts.ts
@@ -705,6 +705,35 @@ function classSegments(className: string): string[] {
 }
 
 /**
+ * The catalog as `readLayoutBehaviour` needs it, from BOTH places a prop's
+ * declared values can live.
+ *
+ * This exists because the two callers built it separately and drifted. The
+ * prompt path read `component.propTypes` and found Carbon's Stack; the
+ * generation pipeline read the same field at a point where it holds nothing
+ * and found only Grid, so the deterministic stretch pass had no row variant to
+ * place and silently did nothing for a whole twenty-prompt run. The prop facts
+ * from the extractor are the other half, and one function now supplies both.
+ */
+export function layoutComponentsFrom(
+  components: Array<{ name: string; propTypes?: Array<{ name?: string; type?: string; options?: string[] }> }>,
+  facts?: { components?: Record<string, { props?: Array<{ name: string; type?: string; options?: string[] }> }> } | null,
+): LayoutComponent[] {
+  return components.map(c => {
+    const declared = [
+      ...(c.propTypes || []).map(p => ({ name: p.name || '', values: p.options, type: p.type })),
+      ...((facts?.components?.[c.name]?.props) || []).map(p => ({ name: p.name, values: p.options, type: p.type })),
+    ].filter(p => p.name);
+    return {
+      name: c.name,
+      props: declared,
+      propValues: declared.flatMap(p => p.values || []),
+      propTypes: declared.map(p => p.type || ''),
+    };
+  });
+}
+
+/**
  * Layout rules the stylesheet states for the catalog's own components.
  *
  * The component-to-class link is a HYPOTHESIS checked against the file, never


### PR DESCRIPTION

The prompt section and the deterministic stretch pass both need to know which
containers stretch their children. They built the catalog for it separately,
from different fields, and drifted: the prompt path read component.propTypes
and found Carbon's Stack, while the pipeline read the same field at a point
where it holds nothing and found only Grid. Grid carries no variant class, so
the pass had no row form to recognise and did nothing at all for a full
twenty-prompt run — reporting nothing, because at the time it only logged when
it changed something.

The derivation now happens once and is passed to the prompt builder, and the
catalog it reads is built by one shared function that takes a prop's declared
values from the component list OR from the extracted prop facts, whichever
holds them.

Also corrects that log line, which said "ran" for a pass that had returned
ran: false.



https://claude.ai/code/session_0158a8zxX4SKPdxm7DLfgqp4
