### PR TITLE
fix(generator): mark a library-owned class warning as library-owned

### DIFF
--- a/bench/lib/firstAttemptRecord.mjs
+++ b/bench/lib/firstAttemptRecord.mjs
@@ -312,6 +312,15 @@ export function buildRecord({ prompt, events, durationMs, env, transportError = 
        * built from, so record it here where the analysis actually happens.
        */
       findingsByKind: countBy(completion?.verification?.findings ?? [], findingKind),
+      /**
+       * Whether every finding that stood belonged to the design system rather
+       * than the story. Carbon's own <Form> writes a class its stylesheet does
+       * not define, and that warning appeared in 7 of 12 dirty stories in one
+       * run — so part of "not clean" was measuring Carbon, not the generator.
+       * Reported alongside, never instead: the bar itself does not move.
+       */
+      onlyLibraryFindings: (completion?.verification?.findings ?? []).length > 0
+        && (completion?.verification?.findings ?? []).every(f => findingKind(f).startsWith('library-')),
       /** One example message per kind, capped, so a kind can be recognised. */
       findingExamples: Object.fromEntries(
         Object.entries(
@@ -372,8 +381,15 @@ export function summarise(records) {
     const seen = new Set((r.validation.rounds.find(x => x.round === 1)?.errors ?? []).map(e => e.class));
     for (const c of seen) promptsWithClass[c] = (promptsWithClass[c] ?? 0) + 1;
   }
+  /**
+   * Dirty runs whose only surviving findings belong to the design system.
+   * Reported beside the headline, never folded into it: the bar stays where it
+   * is, and the reader can see how much of "not clean" was the library's own
+   * markup rather than the generator's output.
+   */
+  const libraryOnly = records.filter(r => r.firstAttemptClean === false && r.verification?.onlyLibraryFindings).length;
   return {
-    total, clean, dirty, unknown, judged,
+    total, clean, dirty, unknown, judged, libraryOnly,
     percent: judged ? Math.round((clean / judged) * 1000) / 10 : null,
     medianModelCalls: median(records.map(r => r.modelCalls)),
     medianSeconds: median(records.map(r => r.seconds)),
@@ -428,6 +444,9 @@ export function formatSummary(s) {
   const lines = [headline(s)];
   if (s.unknown > 0) {
     lines.push(`${s.unknown} run(s) NOT JUDGED — verification or validation could not report. Not counted as clean and not counted as dirty.`);
+  }
+  if (s.libraryOnly > 0) {
+    lines.push(`of the ${s.dirty} dirty, ${s.libraryOnly} carried ONLY findings owned by the design system (its own markup, never repairable from a composition).`);
   }
   lines.push(`self-healed: ${s.selfHealed} · verification repair ran: ${s.repairRan} (improved ${s.repairImproved}) · gate regenerated: ${s.gateRegenerated}`);
   if (s.validationClasses.length === 0) {

--- a/story-generator/verify/verifyStory.ts
+++ b/story-generator/verify/verifyStory.ts
@@ -518,7 +518,14 @@ export async function verifyStory(options: VerifyStoryOptions): Promise<VerifyRe
     } else {
       for (const u of classes.undefined_) {
         findings.push({
-          id: `undefined-class-${findings.length}`,
+          // `library-` prefix, matching the census findings, so a reader —
+          // and the bench — can tell the design system's own markup from the
+          // story's without parsing the message. Carbon's <Form> writes
+          // `cds--form`, for which @carbon/styles ships no rule; that is a true
+          // fact about Carbon and nothing a composition can act on.
+          id: u.ownedByLibrary && u.owner
+            ? `library-undefined-class-${findings.length}`
+            : `undefined-class-${findings.length}`,
           severity: 'warning',
           class: 'code',
           message: u.ownedByLibrary && u.owner

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -4,5 +4,14 @@ export default defineConfig({
   test: {
     include: ['**/__tests__/**/*.test.ts'],
     environment: 'node',
+    /**
+     * Vitest's 5s default is too tight for the handful of tests that compile
+     * TypeScript or run the whole generation pipeline. They pass in about
+     * eight seconds on an idle machine and time out when the machine is busy —
+     * which is exactly when the pre-commit hook runs them, so a green suite
+     * became a red commit twice over with nothing wrong. A generous ceiling
+     * still fails a genuine hang; it just stops reporting load as a defect.
+     */
+    testTimeout: 30_000,
   },
 });


### PR DESCRIPTION

Carbon's <Form> renders class="cds--form", and @carbon/styles ships no rule
for it — verified in the browser, not assumed: the class check reads 1343
defined classes from four readable stylesheets and that one is not among them.
The finding is true and the composition cannot act on it.

It was already unrepairable and already named the owning component in its
message, but its id looked like any other finding, so anything reading ids
counted the design system's own markup as the story's. It now carries the
same library- prefix the census findings use.

The bench reports, beside the headline, how many dirty runs carried only such
findings. In one twenty-prompt run that was 7 of 12 — a large part of "not
clean" was measuring Carbon rather than the generator. Reported alongside and
never folded in: the bar does not move.

Also raises Vitest's 5s default timeout. Two tests that compile TypeScript or
run the whole pipeline take about eight seconds on an idle machine and time
out when it is busy, which is when the pre-commit hook runs them — a green
suite became a red commit twice with nothing wrong.



https://claude.ai/code/session_0158a8zxX4SKPdxm7DLfgqp4
