### PR TITLE
feat(generator): move a CSS prop into the component's own style prop

### DIFF
--- a/__tests__/css-prop-move.test.ts
+++ b/__tests__/css-prop-move.test.ts
@@ -1,0 +1,92 @@
+/**
+ * MUI removed `alignItems` and `justifyContent` from Stack's own props in v6;
+ * they belong in `sx`. A twenty-prompt MUI run produced 28 of its 29
+ * first-round validation errors as exactly those two attributes, in half the
+ * prompts — ten stories paying a full self-heal round trip for one mechanical
+ * edit the checker had already worked out.
+ *
+ * The tests that matter here are the refusals. Moving a prop into a style
+ * object changes what the story means if the prop was never a style, so
+ * anything this cannot place must stay exactly where it is and stay a
+ * violation.
+ */
+import { describe, it, expect } from 'vitest';
+import { moveCssPropsIntoCarrier } from '../story-generator/knowledge/cssPropMove.js';
+import type { PropViolation } from '../story-generator/knowledge/propConformance.js';
+
+const violation = (over: Partial<PropViolation>): PropViolation => ({
+  kind: 'unknown_prop', component: 'Stack', prop: 'alignItems', line: 1,
+  styleCarrier: 'sx', message: 'x', ...over,
+});
+
+describe('moveCssPropsIntoCarrier', () => {
+  it('moves the prop into the carrier the component declares', () => {
+    const code = `const A = () => <Stack direction="row" alignItems="center">x</Stack>;\n`;
+    const out = moveCssPropsIntoCarrier(code, [violation({})]);
+    expect(out.code).toContain(`<Stack direction="row" sx={{ alignItems: "center" }}>`);
+    expect(out.code).not.toContain('alignItems="center"');
+    expect(out.moved).toEqual([{ line: 1, component: 'Stack', prop: 'alignItems', carrier: 'sx' }]);
+    expect(out.remaining).toEqual([]);
+  });
+
+  it('merges into an sx the story already wrote, and takes several props at once', () => {
+    const code = `const A = () => <Stack alignItems="center" justifyContent="space-between" sx={{ mt: 2 }}>x</Stack>;\n`;
+    const out = moveCssPropsIntoCarrier(code, [
+      violation({}), violation({ prop: 'justifyContent' }),
+    ]);
+    expect(out.code).toContain('sx={{ alignItems: "center", justifyContent: "space-between", mt: 2 }}');
+    expect(out.moved).toHaveLength(2);
+  });
+
+  it('keeps a non-literal value, which is still a value the carrier can hold', () => {
+    const code = `const A = ({ align }) => <Stack alignItems={align}>x</Stack>;\n`;
+    const out = moveCssPropsIntoCarrier(code, [violation({})]);
+    expect(out.code).toContain('sx={{ alignItems: align }}');
+  });
+
+  it('refuses a prop that is not a style, and says it is still a violation', () => {
+    // `variant` is a CSS property and also every design system's most common
+    // semantic prop. Moving it would change what the story means.
+    const code = `const A = () => <Chip variant="filled">x</Chip>;\n`;
+    const v = violation({ component: 'Chip', prop: 'variant' });
+    const out = moveCssPropsIntoCarrier(code, [v]);
+    expect(out.code).toBe(code);
+    expect(out.moved).toEqual([]);
+    expect(out.remaining).toEqual([v]);
+  });
+
+  it('refuses when the component declares no style carrier at all', () => {
+    const code = `const A = () => <Stack alignItems="center">x</Stack>;\n`;
+    const v = violation({ styleCarrier: undefined });
+    const out = moveCssPropsIntoCarrier(code, [v]);
+    expect(out.code).toBe(code);
+    expect(out.remaining).toEqual([v]);
+  });
+
+  it('refuses when the carrier is not an object literal, leaving the prop in place', () => {
+    // The attribute must never be removed unless its value has somewhere to
+    // go: an earlier draft deleted it and then declined to place it.
+    const code = `const A = ({ styles }) => <Stack alignItems="center" sx={styles}>x</Stack>;\n`;
+    const v = violation({});
+    const out = moveCssPropsIntoCarrier(code, [v]);
+    expect(out.code).toBe(code);
+    expect(out.moved).toEqual([]);
+    expect(out.remaining).toEqual([v]);
+  });
+
+  it('refuses a bare flag, which has no value to carry', () => {
+    const code = `const A = () => <Stack alignItems>x</Stack>;\n`;
+    const v = violation({});
+    const out = moveCssPropsIntoCarrier(code, [v]);
+    expect(out.code).toBe(code);
+    expect(out.remaining).toEqual([v]);
+  });
+
+  it('leaves every other violation untouched and reports it', () => {
+    const code = `const A = () => <Stack elevation={2}>x</Stack>;\n`;
+    const v = violation({ prop: 'elevation' });
+    const out = moveCssPropsIntoCarrier(code, [v]);
+    expect(out.code).toBe(code);
+    expect(out.remaining).toEqual([v]);
+  });
+});

--- a/mcp-server/routes/generationCore.ts
+++ b/mcp-server/routes/generationCore.ts
@@ -109,6 +109,7 @@ const LAYOUT_PROSE = /\b(column|columns|grid|breakpoint|gutter|span|spacing|widt
 import { enrichWithSourceFacts, withLocalPropFacts } from '../../story-generator/knowledge/sourceFacts.js';
 import { readStylingFacts, formatStylingGuidance, readDesignTokens, readLayoutBehaviour, formatLayoutBehaviour, layoutComponentsFrom } from '../../story-generator/knowledge/stylingFacts.js';
 import { fixStretchedControlRows } from '../../story-generator/knowledge/stretchFix.js';
+import { moveCssPropsIntoCarrier } from '../../story-generator/knowledge/cssPropMove.js';
 import type { LayoutBehaviour } from '../../story-generator/knowledge/stylingFacts.js';
 import type { StylingFacts } from '../../story-generator/knowledge/stylingFacts.js';
 import {
@@ -1554,7 +1555,22 @@ async function runStoryGenerationPipeline(
         storiesDir: path.resolve(process.cwd(), config.generatedStoriesPath || './src/stories/generated'),
       });
       logger.log(`🧷 Prop check: ${summarisePropConformance(propReport)}`);
-      conformanceErrors.push(...formatPropConformanceErrors(propReport));
+      /**
+       * A CSS-named prop the component does not declare goes into the style
+       * prop it does declare, rather than back to the model.
+       *
+       * Measured on a twenty-prompt MUI run: 28 of 29 first-round validation
+       * errors were <Stack alignItems> and <Stack justifyContent>, in half the
+       * prompts. MUI moved both into `sx` in v6. The checker had already
+       * worked out both halves — undeclared, and which carrier exists — so
+       * every one of those retries was paying a model to perform a move.
+       */
+      const carried = moveCssPropsIntoCarrier(aiText, propReport.violations);
+      if (carried.moved.length) {
+        aiText = carried.code;
+        logger.log(`🧷 Moved ${carried.moved.length} CSS prop(s) into the component's own style prop: ${carried.moved.map(m => `<${m.component} ${m.prop}> → ${m.carrier}`).join(', ')}`);
+      }
+      conformanceErrors.push(...formatPropConformanceErrors({ ...propReport, violations: carried.remaining }));
     }
     // Every var(--x) must be a token the project declares. Skipped, and said
     // so, when the project declares none — absent and zero look different.

--- a/story-generator/knowledge/cssPropMove.ts
+++ b/story-generator/knowledge/cssPropMove.ts
@@ -1,0 +1,162 @@
+/**
+ * A CSS-named prop the component does not declare, moved into the style prop
+ * it does declare — deterministically, instead of asking the model again.
+ *
+ * Measured on a twenty-prompt MUI run: 28 of 29 first-round validation errors
+ * were `<Stack alignItems>` and `<Stack justifyContent>`, across half the
+ * prompts. MUI removed both from Stack's own props in v6; they belong in `sx`.
+ * The check was right, the catalog listed the real props, and the model wrote
+ * the v5 idiom anyway — ten of twenty stories paid a full self-heal round trip
+ * for it.
+ *
+ * There is exactly one correct edit and it is mechanical: the attribute's
+ * value moves into the component's own style carrier under the same name. The
+ * conformance checker already knows both halves — that the prop is undeclared,
+ * and which of `sx`/`css`/`style` the component does declare — so this only
+ * has to perform the move.
+ *
+ * IT IS DELIBERATELY CONSERVATIVE. A prop is moved only when its name is a CSS
+ * property from the list below and its value is a literal. `variant` and
+ * `color` are CSS properties AND common component props, so a component that
+ * does not declare them is not asking for a style — those never move. Anything
+ * this refuses stays a violation and reaches the model exactly as before.
+ */
+
+import ts from 'typescript';
+import type { PropViolation } from './propConformance.js';
+
+/**
+ * CSS properties that a component might plausibly have exposed as a prop.
+ *
+ * Curated rather than derived: Node ships no CSS property list, and reaching
+ * for a browser to get one would make a static repair depend on a render. The
+ * cost of the list being short is a prop that stays a violation, which is the
+ * behaviour without this file at all — so it errs that way on purpose.
+ * `color`, `variant`, `size`, `width`, `height`, `display` and `overflow` are
+ * excluded even though they are CSS: every design system uses at least one of
+ * them as a semantic prop, and moving one into a style object would change
+ * what the story means.
+ */
+const MOVEABLE = new Set([
+  'alignItems', 'alignContent', 'alignSelf', 'justifyContent', 'justifyItems', 'justifySelf',
+  'flexDirection', 'flexWrap', 'flexGrow', 'flexShrink', 'flexBasis', 'placeItems', 'placeContent',
+  'gridTemplateColumns', 'gridTemplateRows', 'gridColumn', 'gridRow', 'gridAutoFlow',
+  'marginTop', 'marginBottom', 'marginLeft', 'marginRight', 'marginInline', 'marginBlock',
+  'paddingTop', 'paddingBottom', 'paddingLeft', 'paddingRight', 'paddingInline', 'paddingBlock',
+  'maxWidth', 'minWidth', 'maxHeight', 'minHeight', 'textAlign', 'whiteSpace', 'wordBreak',
+  'borderRadius', 'boxShadow', 'position', 'top', 'bottom', 'left', 'right', 'zIndex',
+  'backgroundColor', 'textTransform', 'letterSpacing', 'lineHeight', 'fontWeight', 'fontSize',
+  'objectFit', 'aspectRatio', 'cursor', 'opacity',
+]);
+
+export interface CssPropMove {
+  line: number;
+  component: string;
+  prop: string;
+  carrier: string;
+}
+
+export interface CssPropMoveResult {
+  code: string;
+  moved: CssPropMove[];
+  /** Violations that were NOT moved, to be reported exactly as before. */
+  remaining: PropViolation[];
+}
+
+/** The attribute's value as it should appear inside a style object. */
+function valueText(attr: ts.JsxAttribute, src: ts.SourceFile): string | null {
+  const init = attr.initializer;
+  if (!init) return null;                                   // bare flag: not a style
+  if (ts.isStringLiteral(init)) return JSON.stringify(init.text);
+  if (ts.isJsxExpression(init) && init.expression) {
+    const text = init.expression.getText(src);
+    // A spread or an object would nest wrongly; anything else (a literal, a
+    // template, an identifier, a ternary) is a value the carrier can hold.
+    return ts.isObjectLiteralExpression(init.expression) ? null : text;
+  }
+  return null;
+}
+
+/**
+ * Move every moveable violation into its component's style carrier.
+ *
+ * Returns the rewritten code and the violations that remain — never a claim
+ * that a violation was handled when it was not.
+ */
+export function moveCssPropsIntoCarrier(
+  code: string, violations: PropViolation[], fileName = 'story.tsx',
+): CssPropMoveResult {
+  const candidates = violations.filter(v =>
+    v.kind === 'unknown_prop' && v.prop && v.styleCarrier && MOVEABLE.has(v.prop));
+  if (!candidates.length) return { code, moved: [], remaining: violations };
+
+  const src = ts.createSourceFile(fileName, code, ts.ScriptTarget.Latest, true, ts.ScriptKind.TSX);
+  const moved: CssPropMove[] = [];
+  const handled = new Set<PropViolation>();
+  /** Edits applied back to front so earlier offsets stay valid. */
+  const edits: Array<{ start: number; end: number; text: string }> = [];
+
+  const byLine = new Map<string, PropViolation>();
+  for (const v of candidates) byLine.set(`${v.line}:${v.component}:${v.prop}`, v);
+
+  const visit = (node: ts.Node): void => {
+    if (ts.isJsxOpeningElement(node) || ts.isJsxSelfClosingElement(node)) {
+      const tag = node.tagName.getText(src);
+      const line = src.getLineAndCharacterOfPosition(node.getStart(src)).line + 1;
+      const attrs = node.attributes.properties.filter(ts.isJsxAttribute);
+
+      /* Decide everything for this element BEFORE editing anything: an
+         attribute must never be removed unless its value has somewhere to go. */
+      const takeable: Array<{ attr: ts.JsxAttribute; name: string; value: string; v: PropViolation; line: number }> = [];
+      let carrier: string | undefined;
+      for (const attr of attrs) {
+        const name = attr.name.getText(src);
+        const attrLine = src.getLineAndCharacterOfPosition(attr.getStart(src)).line + 1;
+        const v = byLine.get(`${attrLine}:${tag}:${name}`) || byLine.get(`${line}:${tag}:${name}`);
+        if (!v) continue;
+        const value = valueText(attr, src);
+        if (value === null) continue;
+        carrier = v.styleCarrier!;
+        takeable.push({ attr, name, value, v, line: attrLine });
+      }
+
+      if (takeable.length && carrier) {
+        const existing = attrs.find(a => a.name.getText(src) === carrier);
+        const readable = !existing || (existing.initializer !== undefined
+          && ts.isJsxExpression(existing.initializer)
+          && existing.initializer.expression !== undefined
+          && ts.isObjectLiteralExpression(existing.initializer.expression));
+        if (readable) {
+          const gathered = takeable.map(t => `${t.name}: ${t.value}`);
+          for (const t of takeable) {
+            let from = t.attr.getStart(src);
+            while (from > 0 && /\s/.test(code[from - 1])) from--;
+            edits.push({ start: from, end: t.attr.getEnd(), text: '' });
+            moved.push({ line: t.line, component: tag, prop: t.name, carrier: carrier! });
+            handled.add(t.v);
+          }
+          if (existing) {
+            const obj = (existing.initializer as ts.JsxExpression).expression as ts.ObjectLiteralExpression;
+            const at = obj.properties.length ? obj.properties[0].getStart(src) : obj.getStart(src) + 1;
+            edits.push({ start: at, end: at, text: `${gathered.join(', ')}${obj.properties.length ? ', ' : ''}` });
+          } else {
+            const props = node.attributes.properties;
+            const anchor = props.length ? props[props.length - 1].getEnd() : node.tagName.getEnd();
+            edits.push({ start: anchor, end: anchor, text: ` ${carrier}={{ ${gathered.join(', ')} }}` });
+          }
+        }
+        // An unreadable carrier (a variable, a spread) means the props stay
+        // where they are and stay violations — reported, not silently dropped.
+      }
+    }
+    ts.forEachChild(node, visit);
+  };
+
+  visit(src);
+
+  let out = code;
+  for (const e of edits.sort((a, b) => b.start - a.start)) {
+    out = out.slice(0, e.start) + e.text + out.slice(e.end);
+  }
+  return { code: out, moved, remaining: violations.filter(v => !handled.has(v)) };
+}

--- a/story-generator/knowledge/propConformance.ts
+++ b/story-generator/knowledge/propConformance.ts
@@ -47,6 +47,17 @@ export interface PropViolation {
   line: number;
   /** The declared prop this one most resembles, when anything does. */
   suggestion?: string;
+  /**
+   * A style-carrying prop this component DOES declare (`sx`, `css`, `style`).
+   *
+   * Present so a caller can move a CSS-named prop into it deterministically.
+   * MUI removed `alignItems` and `justifyContent` from Stack's own props in
+   * v6 — they belong in `sx` — and a twenty-prompt MUI run produced 28 of its
+   * 29 first-round validation errors as exactly those two attributes, in half
+   * the prompts. Naming the carrier here is what lets that be a move rather
+   * than a retry.
+   */
+  styleCarrier?: string;
   /** A message that names the fix, not just the fault. */
   message: string;
 }
@@ -442,8 +453,9 @@ export function checkPropConformance(code: string, opts: PropConformanceOptions)
     const own = [...resolved.names].filter(n => !intrinsic.generic.has(n));
     const suggestion = nearestProp(name, own, resolved.names);
     if (!viaCast) {
+      const styleCarrier = ['sx', 'css', 'style'].find(c => resolved.names.has(c));
       report.violations.push({
-        kind: 'unknown_prop', component: tag, prop: name, line: lineOf(node), suggestion,
+        kind: 'unknown_prop', component: tag, prop: name, line: lineOf(node), suggestion, styleCarrier,
         message: `<${tag} ${name}> is not a prop this component declares`
           + (suggestion ? ` — did you mean \`${suggestion}\`?` : '.')
           + ` ${describe(tag, resolved.names, suggestion)}.`,


### PR DESCRIPTION

The first twenty-prompt run on MUI: 28 of 29 first-round validation errors
were <Stack alignItems> and <Stack justifyContent>, in half the prompts. MUI
removed both from Stack's own props in v6 and they belong in sx. The check was
right and the catalog listed the real props; the model wrote the v5 idiom
anyway, and ten of twenty stories paid a full self-heal round trip for one
mechanical edit.

The conformance checker already knew both halves — that the prop is undeclared
and which of sx/css/style the component does declare — so the violation now
carries the carrier's name and the move is performed instead of reported.

Conservative by construction. A prop moves only when its name is on a curated
list of CSS properties and its value has somewhere to go. color, variant,
size, width, height, display and overflow are excluded although they are CSS:
every design system uses at least one as a semantic prop, and moving one would
change what the story means. A carrier that is not a readable object literal,
a bare flag, or a prop off the list stays exactly where it is and stays a
violation — the attribute is never removed unless its value has a destination.



https://claude.ai/code/session_0158a8zxX4SKPdxm7DLfgqp4
