### PR TITLE
fix(generator): let a repair finish instead of paying for a regeneration

### DIFF
--- a/mcp-server/routes/generationCore.ts
+++ b/mcp-server/routes/generationCore.ts
@@ -2316,6 +2316,16 @@ async function runStoryGenerationPipeline(
             code: fixedFileContents,
             report: verification,
             context: repairContext,
+            /**
+             * Two, because the alternative to a second repair is a full
+             * regeneration and the prices are not close. Measured on one
+             * Carbon story that spent three gate attempts: each regeneration
+             * cost 80-103s of model time, each repair 11-16s. The loop already
+             * stops the moment a repair fails to reduce blockers, so a second
+             * attempt costs nothing when the first one did not help, and
+             * finishes the job — without regenerating — when it did.
+             */
+            maxAttempts: 2,
             signal: verifyBudget.signal,
             deadline: verifyDeadline,
             staticallyValid: (candidate) => {
@@ -2459,6 +2469,12 @@ async function runStoryGenerationPipeline(
                     : '🔧 Repair changed only comments or formatting — the served module cannot differ, so nothing to wait for');
                 } else {
                   const recompile = await waitForRecompile(verifyUrl, relModule, before);
+                  if (recompile.live) {
+                    // The latency distribution is the reason the timeout is
+                    // what it is; keep measuring it so a future change to
+                    // either number is made on evidence.
+                    logger.log(`🔁 Dev server served the repaired module after ${(recompile.waitedMs / 1000).toFixed(1)}s`);
+                  }
                   if (!recompile.live) {
                     // Say WHICH failure this is. They read identically in a
                     // render and were logged identically, which sent one

--- a/story-generator/verify/renderHarness.ts
+++ b/story-generator/verify/renderHarness.ts
@@ -548,6 +548,16 @@ export function describeFetchError(err: unknown): string {
  * path, so the honest signal is the module TEXT changing — which needs no
  * guess about what the change should look like, only that one happened.
  *
+ * THE TIMEOUT IS 45s BECAUSE 25s WAS INSIDE THE DISTRIBUTION. Measured on the
+ * Carbon fixture, invalidation after a write took 1s, 1s, 2s, 4s, 5s, 9s and
+ * 15s on the same project within an hour — the same edit shape each time, the
+ * spread coming from how busy the machine was. A 25s cap therefore expired on
+ * ordinary slow cases, not on broken ones, and each expiry cost far more than
+ * the wait: the repair was then judged against the previous render, looked
+ * like no improvement, was discarded, and the gate spent 80-100s regenerating
+ * a story whose repair had in fact been correct. Seven expiries in one
+ * twenty-prompt run. Waiting is nearly free; regenerating is not.
+ *
  * Returns the outcome, never a bare boolean, because the ways this can fail
  * are not one thing and were reported as one. `no_baseline` means the module
  * could not be read BEFORE the write, so there is nothing to compare and the
@@ -574,7 +584,7 @@ export async function waitForRecompile(
   modulePath: string,
   /** Module text captured BEFORE the write. */
   previousText: string | null,
-  timeoutMs = 25000,
+  timeoutMs = 45000,
   intervalMs = 500,
 ): Promise<RecompileResult> {
   const started = Date.now();


### PR DESCRIPTION

Timed one Carbon story that spent three gate attempts and 385s. The model
calls were 80s, 103s and 81s for the three generations, against 11s and 16s
for the two repairs. Two thirds of the wall clock was regenerating a story
whose repair had been on the right track.

Two changes, both from that timeline.

The wait for the dev server to serve the repaired module was capped at 25s,
and the cap was inside the normal distribution rather than outside it:
measured on the same fixture within an hour, invalidation took 1s, 1s, 2s, 4s,
5s, 9s and 15s, the spread following how busy the machine was. Seven waits
expired in one twenty-prompt run, and each expiry was expensive — the repair
was then judged against the previous render, looked like no improvement, was
discarded, and the gate regenerated. The cap is now 45s and the observed
latency is logged, so the next change to either number is made on evidence.

The repair loop was allowed one attempt before the gate regenerated. It is
allowed two. The loop already returns the moment a repair fails to reduce
blockers, so the second attempt costs nothing when the first did not help, and
saves a 90s regeneration when it did.

Neither change touches what the model produces or decides.



https://claude.ai/code/session_0158a8zxX4SKPdxm7DLfgqp4
