### PR TITLE
feat(generator): show the prop a library says carries CSS

### DIFF
--- a/__tests__/prop-extractor.test.ts
+++ b/__tests__/prop-extractor.test.ts
@@ -61,3 +61,52 @@ describe('rankProps', () => {
     expect(props.map(x => x.name)).toEqual(before);
   });
 });
+
+describe('rankProps and the prop a library says carries CSS', () => {
+  const p = (name: string, doc?: string, required = false) => ({ name, doc, required } as any);
+
+  it('lifts the prop whose own doc says it takes CSS, so its sentence survives the catalog', () => {
+    // MUI's Stack has no required props, no handlers and no state props, so
+    // every prop tied at the bottom tier and sorted alphabetically. `sx` came
+    // eighth and the catalog attaches docs to the first six, so the one
+    // sentence that says where CSS goes was dropped. Measured: 28 of 29
+    // first-round validation errors in a twenty-prompt MUI run were
+    // `alignItems` and `justifyContent` written as top-level props.
+    const stack = [
+      p('children', 'The content of the component.'),
+      p('direction', 'Defines the `flex-direction` style property.'),
+      p('divider', 'Add an element between each child.'),
+      p('spacing', 'Defines the space between immediate children.'),
+      p('sx', 'The system prop, which allows defining system overrides as well as additional CSS styles.'),
+      p('useFlexGap', 'If `true`, the CSS flexbox `gap` is used instead of applying `margin` to children.'),
+    ];
+    const order = rankProps(stack).map(x => x.name);
+    expect(order.indexOf('sx')).toBeLessThan(order.indexOf('children'));
+    // A prop that merely mentions CSS in passing is not an escape hatch.
+    expect(order.indexOf('useFlexGap')).toBeGreaterThan(order.indexOf('sx'));
+  });
+
+  it('does not mistake a class-name prop for a CSS carrier', () => {
+    // Carbon's className says "Additional CSS class names." A composition's
+    // CSS does not go there, and the exclusion reads the same sentence rather
+    // than the prop's name — no design system owes us the name `sx`.
+    // `appearance` sorts before `className` alphabetically and sits in the
+    // bottom tier, so className staying behind it proves className was not
+    // lifted; a lift would put it first.
+    const carbon = [p('className', 'Additional CSS class names.'), p('appearance', 'How it looks.')];
+    expect(rankProps(carbon).map(x => x.name)).toEqual(['appearance', 'className']);
+    // Where a library really does declare one, it is lifted past the same prop.
+    const withCarrier = [p('sx', 'Allows additional CSS styles.'), p('appearance', 'How it looks.')];
+    expect(rankProps(withCarrier).map(x => x.name)).toEqual(['sx', 'appearance']);
+  });
+
+  it('keeps required props, handlers and state above it', () => {
+    const mixed = [
+      p('sx', 'Allows additional CSS styles.'),
+      p('onChange', 'Called when it changes.'),
+      p('value', 'The current value.'),
+      p('label', 'The label.', true),
+    ];
+    expect(rankProps(mixed).map(x => x.name)).toEqual(['label', 'onChange', 'value', 'sx']);
+  });
+});

--- a/story-generator/knowledge/propExtractor.ts
+++ b/story-generator/knowledge/propExtractor.ts
@@ -1736,6 +1736,16 @@ export function formatPropForCatalog(p: PropFact): string {
   return entry;
 }
 
+/**
+ * A doc sentence that describes a prop as carrying CSS itself.
+ *
+ * "Additional CSS class names" — Carbon's `className` — is deliberately NOT a
+ * match: a class-name prop takes classes, and pointing a composition's CSS at
+ * it would be the wrong destination. The exclusion is checked against the same
+ * sentence rather than against the prop's name.
+ */
+const CSS_CARRIER_DOC = /\b(additional|arbitrary|custom|extra|inline)\b[^.]{0,40}\bCSS\s+(styles?|properties|rules)\b|\bstyle overrides\b/i;
+
 export function rankProps(props: PropFact[]): PropFact[] {
   const tier = (p: PropFact): number => {
     if (p.required) return 0;
@@ -1743,6 +1753,26 @@ export function rankProps(props: PropFact[]): PropFact[] {
     if (/^(value|defaultValue|checked|active|selected|opened|open|disabled|loading|error)$/i.test(p.name)) return 2;
     if (/(section|icon|adornment|prefix|suffix|slot|label|placeholder)/i.test(p.name)) return 3;
     if (/^(variant|size|color|radius|shadow|position|orientation)$/i.test(p.name)) return 4;
+    /**
+     * The prop the library itself describes as taking arbitrary CSS.
+     *
+     * Judged by what the library WROTE about the prop, never by what the prop
+     * is called: `sx`, `css` and `style` are three libraries' names for the
+     * same idea and a custom design system owes none of them. MUI's Stack
+     * declares `sx` with "allows defining system overrides as well as
+     * additional CSS styles" — that sentence is the fact a composition needs,
+     * and it was being dropped: with no required props, no handlers and no
+     * state props, every prop on that component tied at the bottom tier and
+     * sorted alphabetically, so `sx` came eighth and the catalog attaches docs
+     * to the first six. Measured on a twenty-prompt MUI run: 28 of 29
+     * first-round validation errors were `alignItems` and `justifyContent`
+     * written as top-level props — CSS with nowhere visible to go.
+     *
+     * The pattern deliberately does not match a prop that merely mentions CSS
+     * in passing: MUI's `useFlexGap` says "the CSS flexbox `gap` is used" and
+     * is a boolean, not an escape hatch.
+     */
+    if (p.doc && CSS_CARRIER_DOC.test(p.doc) && !/\bCSS\s+class/i.test(p.doc)) return 4;
     return 5;
   };
   return [...props].sort((a, b) => tier(a) - tier(b) || a.name.localeCompare(b.name));


### PR DESCRIPTION

The first twenty-prompt run on Material produced 29 first-round validation
errors and 28 of them were the same thing: alignItems and justifyContent
written as top-level props on Stack, which Material moved into sx. The catalog
already listed sx and the prompt already said an undeclared prop is rejected,
so the model knew the prop existed and did not know it was the destination.

The library says so itself. Material's Stack declares sx with "allows defining
system overrides as well as additional CSS styles", and that sentence was
being dropped: with no required props, no handlers and no state props on that
component, every prop tied at the bottom rank and sorted alphabetically, sx
came eighth, and the catalog attaches docs to the first six.

A prop whose own doc describes it as carrying CSS now ranks with variant and
size, so its sentence survives into the catalog. Judged by what the library
wrote, never by what the prop is called — sx, css and style are three
libraries' names for one idea and a custom design system owes us none of them.
Carbon's className says "Additional CSS class names" and is excluded by the
same sentence, because a composition's CSS does not belong in a class-name
prop. Across the two fixtures: 181 props identified on Material, none on
Carbon, which genuinely has no such prop.



https://claude.ai/code/session_0158a8zxX4SKPdxm7DLfgqp4
