### PR TITLE
feat(generator): read the inputs Angular declares for itself

### DIFF
--- a/story-generator/knowledge/angularInputs.ts
+++ b/story-generator/knowledge/angularInputs.ts
@@ -1,0 +1,195 @@
+/**
+ * An Angular component's inputs, read from the declaration Angular itself
+ * emits.
+ *
+ * Measured by the resolution bench across fourteen design systems: Angular
+ * Material discovered 309 components and knew the props of NONE of them. Every
+ * other environment sat between 78% and 100%. The catalog therefore offered
+ * the model 309 names and nothing else, which is the condition under which a
+ * composition invents attributes — the opposite of adhering to the system.
+ *
+ * The facts were never missing. Angular's compiler writes them into the type
+ * of a static member on the class:
+ *
+ *   static ɵcmp: i0.ɵɵComponentDeclaration<
+ *     MatButton,
+ *     "button[matButton], a[matButton], …",   // selector
+ *     ["matButton", "matAnchor"],             // exportAs
+ *     { "appearance": { "alias": "matButton"; "required": false; } },  // inputs
+ *     {},                                     // outputs
+ *     …>;
+ *
+ * So the inputs, their template names, and whether each is required are
+ * declared in the library's own output. This reads them, and takes each
+ * input's TYPE and JSDoc from the class member of the same name.
+ *
+ * This is a FRAMEWORK reader, not a library one: `ɵɵComponentDeclaration` and
+ * `ɵɵDirectiveDeclaration` are Angular's, so any Angular design system —
+ * Material, a vendor's, or one written in-house — is read the same way. There
+ * is no component name, package name or design system anywhere in it.
+ */
+
+import ts from 'typescript';
+
+export interface AngularInput {
+  /** The name written in a template — the alias when the library declares one. */
+  name: string;
+  /** The class property behind it, when the alias differs. */
+  property?: string;
+  required: boolean;
+  /** Declared type of the class member, when it has one. */
+  type?: string;
+  /** First line of the member's JSDoc. */
+  doc?: string;
+  /** True for an @Output: the template binding is an event. */
+  output?: boolean;
+}
+
+export interface AngularComponentFacts {
+  name: string;
+  /** The CSS selector Angular matches — how the component is actually written. */
+  selector?: string;
+  inputs: AngularInput[];
+}
+
+/** Angular's own declaration types, in the order their type arguments appear. */
+const DECLARATION_TYPES = new Set(['ɵɵComponentDeclaration', 'ɵɵDirectiveDeclaration']);
+const INPUTS_ARG = 3;
+const OUTPUTS_ARG = 4;
+
+function typeName(node: ts.TypeNode): string | null {
+  if (!ts.isTypeReferenceNode(node)) return null;
+  const n = node.typeName;
+  return ts.isQualifiedName(n) ? n.right.text : n.text;
+}
+
+/** The string a literal type node carries, or null. */
+function literalText(node: ts.TypeNode | undefined): string | null {
+  if (!node || !ts.isLiteralTypeNode(node)) return null;
+  return ts.isStringLiteral(node.literal) ? node.literal.text : null;
+}
+
+function isTrue(node: ts.TypeNode | undefined): boolean {
+  return !!node && ts.isLiteralTypeNode(node) && node.literal.kind === ts.SyntaxKind.TrueKeyword;
+}
+
+/** First line of the JSDoc immediately above a node. */
+function docOf(node: ts.Node, source: ts.SourceFile): string | undefined {
+  const ranges = ts.getLeadingCommentRanges(source.text, node.getFullStart()) || [];
+  for (const r of ranges.reverse()) {
+    const raw = source.text.slice(r.pos, r.end);
+    if (!raw.startsWith('/**')) continue;
+    const body = raw.replace(/^\/\*\*|\*\/$/g, '')
+      .split('\n')
+      .map(l => l.replace(/^\s*\*\s?/, '').trim())
+      .filter(l => l && !l.startsWith('@'))
+      .join(' ')
+      .trim();
+    if (body) return body.split(/(?<=\.)\s/)[0].trim();
+  }
+  return undefined;
+}
+
+/**
+ * The declared members of one type argument, as {name, aliasedTo, required}.
+ *
+ * Angular writes the map keyed by the CLASS PROPERTY with the template name in
+ * `alias`, so the name a composition writes is the alias when there is one.
+ */
+function membersOf(arg: ts.TypeNode | undefined): Array<{ property: string; alias?: string; required: boolean }> {
+  if (!arg || !ts.isTypeLiteralNode(arg)) return [];
+  const out: Array<{ property: string; alias?: string; required: boolean }> = [];
+  for (const member of arg.members) {
+    if (!ts.isPropertySignature(member) || !member.name) continue;
+    const property = ts.isStringLiteral(member.name) || ts.isIdentifier(member.name)
+      ? (member.name as ts.StringLiteral | ts.Identifier).text
+      : null;
+    if (!property) continue;
+    let alias: string | undefined;
+    let required = false;
+    if (member.type && ts.isTypeLiteralNode(member.type)) {
+      for (const f of member.type.members) {
+        if (!ts.isPropertySignature(f) || !f.name || !ts.isIdentifier(f.name)) continue;
+        if (f.name.text === 'alias') alias = literalText(f.type) ?? undefined;
+        if (f.name.text === 'required') required = isTrue(f.type);
+      }
+    }
+    out.push({ property, ...(alias && alias !== property ? { alias } : {}), required });
+  }
+  return out;
+}
+
+/** The class member of a given name, for its type and its documentation. */
+function memberNamed(cls: ts.ClassDeclaration, name: string): ts.ClassElement | undefined {
+  return cls.members.find(m => {
+    if (!m.name) return false;
+    const n = ts.isIdentifier(m.name) || ts.isStringLiteral(m.name)
+      ? (m.name as ts.Identifier | ts.StringLiteral).text : null;
+    return n === name
+      && (ts.isPropertyDeclaration(m) || ts.isGetAccessorDeclaration(m) || ts.isSetAccessorDeclaration(m));
+  });
+}
+
+function memberType(member: ts.ClassElement | undefined, source: ts.SourceFile): string | undefined {
+  if (!member) return undefined;
+  if (ts.isPropertyDeclaration(member) && member.type) return member.type.getText(source);
+  if (ts.isGetAccessorDeclaration(member) && member.type) return member.type.getText(source);
+  if (ts.isSetAccessorDeclaration(member) && member.parameters[0]?.type) {
+    return member.parameters[0].type.getText(source);
+  }
+  return undefined;
+}
+
+/**
+ * Read every Angular component and directive declared in one source file.
+ *
+ * Returns an empty array for a file that declares none, which is every file in
+ * a React, Vue, Svelte or Lit project — so this is safe to run everywhere and
+ * costs one AST walk.
+ */
+export function readAngularDeclarations(source: ts.SourceFile): AngularComponentFacts[] {
+  const out: AngularComponentFacts[] = [];
+
+  const visit = (node: ts.Node): void => {
+    if (ts.isClassDeclaration(node) && node.name) {
+      for (const member of node.members) {
+        if (!ts.isPropertyDeclaration(member) || !member.type || !member.name) continue;
+        const memberName = ts.isIdentifier(member.name) ? member.name.text : null;
+        if (memberName !== 'ɵcmp' && memberName !== 'ɵdir') continue;
+        const declared = typeName(member.type);
+        if (!declared || !DECLARATION_TYPES.has(declared)) continue;
+        const args = (member.type as ts.TypeReferenceNode).typeArguments || [];
+        const selector = literalText(args[1]) ?? undefined;
+        const inputs: AngularInput[] = [];
+        for (const m of membersOf(args[INPUTS_ARG])) {
+          const classMember = memberNamed(node, m.property);
+          inputs.push({
+            name: m.alias ?? m.property,
+            ...(m.alias ? { property: m.property } : {}),
+            required: m.required,
+            ...(memberType(classMember, source) ? { type: memberType(classMember, source) } : {}),
+            ...(classMember && docOf(classMember, source) ? { doc: docOf(classMember, source) } : {}),
+          });
+        }
+        for (const m of membersOf(args[OUTPUTS_ARG])) {
+          const classMember = memberNamed(node, m.property);
+          inputs.push({
+            name: m.alias ?? m.property,
+            ...(m.alias ? { property: m.property } : {}),
+            required: false,
+            output: true,
+            ...(classMember && docOf(classMember, source) ? { doc: docOf(classMember, source) } : {}),
+          });
+        }
+        out.push({
+          name: node.name.text,
+          ...(selector ? { selector: selector.replace(/\s+/g, ' ').trim() } : {}),
+          inputs,
+        });
+      }
+    }
+    ts.forEachChild(node, visit);
+  };
+  visit(source);
+  return out;
+}

--- a/story-generator/knowledge/propExtractor.ts
+++ b/story-generator/knowledge/propExtractor.ts
@@ -26,6 +26,10 @@
  */
 
 import ts from 'typescript';
+import { readAngularDeclarations } from './angularInputs.js';
+
+/** Angular's compiler-emitted declaration types; see knowledge/angularInputs.ts. */
+const ANGULAR_DECLARATION = /ɵɵ(Component|Directive)Declaration/;
 import fs from 'fs';
 import path from 'path';
 import { contentFingerprint, knowledgeCacheFile, pruneStaleKnowledge } from './cacheKey.js';
@@ -375,7 +379,17 @@ function collectFromFile(
     // `Prop`, not `Props`: a type named `AvatarPropTypes` contains no "Props"
     // substring, so the file declaring it was skipped entirely and the
     // component that pointed at it resolved to nothing.
-    if (!text.includes('Prop') && !text.includes('Variant')) {
+    /**
+     * Angular says neither word.
+     *
+     * Its declarations are named `ɵɵComponentDeclaration` and the inputs live
+     * in that type's arguments, so a file declaring a whole component library
+     * can contain no "Prop" and no "Variant" anywhere. Measured: this filter
+     * skipped 98 of Angular Material's 102 declaration files, which is why
+     * that library reported props for 10 of 309 components after its inputs
+     * became readable — the reader was never reached.
+     */
+    if (!text.includes('Prop') && !text.includes('Variant') && !ANGULAR_DECLARATION.test(text)) {
       // A theme file often mentions neither word, yet holds exactly the
       // aliases other files' props point into (`type ThemeSize = 'xs' | …`).
       // Skipping it whole silently emptied the registry, and cross-file
@@ -747,6 +761,34 @@ function collectFromFile(
         : { name: componentName, props: [], variants: values };
     }
   });
+
+  /**
+   * Angular declares its inputs where nothing above looks.
+   *
+   * The resolution bench measured Angular Material at 0 of 309 components with
+   * known props, against 78-100% everywhere else — the catalog offered the
+   * model 309 bare names, which is the condition under which a composition
+   * invents attributes. The facts were never missing: Angular's compiler
+   * writes each input, its template name and whether it is required into the
+   * type of a static member on the class. This reads that, and takes each
+   * input's type and prose from the class member behind it.
+   *
+   * It costs one AST walk on every file and yields nothing for React, Vue,
+   * Svelte or Lit, which declare no such member.
+   */
+  for (const component of readAngularDeclarations(source)) {
+    if (!component.inputs.length) continue;
+    const props: PropFact[] = component.inputs.map(input => ({
+      name: input.output ? `(${input.name})` : input.name,
+      required: input.required,
+      ...(input.type ? { type: input.type } : {}),
+      ...(input.doc ? { doc: input.doc } : {}),
+    }));
+    const prior = out[component.name];
+    out[component.name] = prior
+      ? { ...prior, props: mergeProps(prior.props, props) }
+      : { name: component.name, props };
+  }
 }
 
 /**


### PR DESCRIPTION

The resolution bench across fourteen design systems put every environment
between 78% and 100% for "do we know this component's props" — except Angular
Material, at 0 of 309. The catalog offered the model 309 bare names, which is
the condition under which a composition invents attributes instead of adhering
to the system.

The facts were never missing. Angular's compiler writes each input, its
template name and whether it is required into the type of a static member on
the class:

    static ɵcmp: ɵɵComponentDeclaration<MatButton, "button[matButton], …",
      ["matButton"], { "appearance": { "alias": "matButton"; … } }, {}, …>

That is now read, with each input's type and prose taken from the class member
behind it. Two things had to change: the reader itself, and the pre-filter that
skipped any declaration file without the substring "Prop" — Angular says
neither "Prop" nor "Variant" anywhere, so 98 of its 102 declaration files were
never opened.

Angular Material now knows the props of 78 components rather than 0, with 95%
of those props carrying the library's own description, and component
descriptions up from 8% to 55%. The remaining denominator is mostly modules,
harnesses and type exports that discovery admits as components.

This is a framework reader, not a library one: ɵɵComponentDeclaration is
Angular's, so any Angular design system is read the same way, and no component,
package or design system is named anywhere in it. Every other environment
measured byte-identical before and after.



https://claude.ai/code/session_0158a8zxX4SKPdxm7DLfgqp4
