### PR TITLE
fix(generator): say the catalog describes the version installed here

### DIFF
--- a/__tests__/loader-failure.test.ts
+++ b/__tests__/loader-failure.test.ts
@@ -115,6 +115,10 @@ describe('the prompt bounds scope instead of encouraging it', () => {
     expect(text).toContain('REJECTED before the story is saved');
     expect(text).toContain('never `ariaLabel`');
     expect(text).toContain("prop's VALUE");
+    // The measured MUI failure: the model writing a prop from the library's
+    // previous major version, which the catalog does not list.
+    expect(text).toContain('The catalog describes the version installed HERE');
+    expect(text).toContain('When your memory and the catalog disagree, the catalog is right');
 
     // One prompt used to carry two image rules: the derived IMAGE RULES said a
     // placeholder is never a remote URL, and the reminder block said every image

--- a/story-generator/promptGenerator.ts
+++ b/story-generator/promptGenerator.ts
@@ -345,6 +345,12 @@ export async function buildFrameworkAwarePrompt(
     // props; what it never said is that anything else is rejected, so the
     // model had no reason not to guess. A retry costs a full model call.
     '- Use only the props this catalog lists for a component. A prop the component does not declare is REJECTED before the story is saved and the whole generation is retried — so do not invent one, do not guess a camelCase spelling of an HTML attribute (`aria-label` is written exactly that way, never `ariaLabel`), and do not carry a prop over from a different library. If the prop you want is not listed, use one that is, or leave it out.',
+    // Measured on a twenty-prompt Material run: 19 of 23 first-round validation
+    // errors were one attribute, <Stack alignItems>, which that library moved
+    // out of the component's own props in a major version. The catalog listed
+    // the real props and the model wrote the remembered ones — a version prior,
+    // not a knowledge gap, and every widely-used library has the same trap.
+    '- The catalog describes the version installed HERE. A prop you remember from a library\'s earlier major version is still rejected: libraries move props into a style prop, rename them, or drop them between versions. When your memory and the catalog disagree, the catalog is right — it was read from this project\'s own node_modules a moment ago.',
     '- The same applies to a prop\'s VALUE: when the catalog shows a prop\'s accepted values, use one of them exactly. A value outside that set is rejected the same way.',
     '- Build what was asked for, and what that plainly requires — nothing else. A request for a navigation bar is a navigation bar, not a page built around one. Do not add regions, panels or features the request did not ask for (a search field, a filter bar, a notification centre, an activity feed, a toast system). When a request is broad ("a dashboard"), build the parts it names or plainly implies and make those excellent, rather than adding others to look thorough.',
     // Verification blocks on this and the prompt never mentioned it, so the


### PR DESCRIPTION

Twenty prompts on Material produced 23 first-round validation errors and 19
were one attribute: <Stack alignItems>, which that library moved out of the
component's own props in a major version. The catalog listed the real props,
the prompt already said an undeclared prop is rejected, and the model wrote
the remembered ones anyway. That is a version prior, not a knowledge gap, and
no amount of listing the right props contradicts it.

So the prompt now says the thing that does: the catalog was read from this
project's node_modules a moment ago, a prop remembered from an earlier major
version is still rejected, and where memory and the catalog disagree the
catalog is right.

General by construction — every widely-used library has the same trap, and
nothing here names one.



https://claude.ai/code/session_0158a8zxX4SKPdxm7DLfgqp4
