### PR TITLE
feat(generator): resolve props with TypeScript when declarations cannot be followed

### DIFF
--- a/__tests__/checker-props.test.ts
+++ b/__tests__/checker-props.test.ts
@@ -1,0 +1,116 @@
+/**
+ * Props resolved by the compiler, for the shape reading declarations cannot
+ * follow: `interface ButtonProps extends HTMLChakraProps<"button", Base> {}`.
+ *
+ * The tests that matter are about the SUBTRACTION. Asking the compiler about a
+ * styling-props library returns everything — 1,139 props for one Button, of
+ * which 1,123 are the CSS surface every component in that library shares — so
+ * a catalog entry built from the raw answer teaches nothing. What is kept is
+ * what the component adds. That has to work without knowing which library is
+ * being read, and it has to do NOTHING on a library whose components share no
+ * base.
+ */
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import { resolvePropsWithChecker } from '../story-generator/knowledge/checkerProps.js';
+
+/** A package whose components share a styling base, written to disk. */
+function styledLibrary(dir: string): void {
+  const pkg = path.join(dir, 'node_modules', 'styled-lib');
+  fs.mkdirSync(pkg, { recursive: true });
+  fs.writeFileSync(path.join(pkg, 'package.json'), JSON.stringify({
+    name: 'styled-lib', version: '1.0.0', types: 'index.d.ts', main: 'index.js',
+    peerDependencies: { react: '*' },
+  }));
+  fs.writeFileSync(path.join(pkg, 'index.js'), 'module.exports = {};');
+  // Every component takes the same 60-prop style surface; each adds its own.
+  const style = Array.from({ length: 60 }, (_, i) => `  s${i}?: string;`).join('\n');
+  fs.writeFileSync(path.join(pkg, 'index.d.ts'), `
+import * as React from 'react';
+interface StyleBase {
+${style}
+}
+export interface ButtonProps extends StyleBase {
+  /** Which visual treatment to use. */
+  variant?: 'solid' | 'outline';
+  loading?: boolean;
+}
+export interface BadgeProps extends StyleBase { tone?: 'info' | 'warn'; }
+export interface CardProps extends StyleBase { elevated?: boolean; }
+export interface StackProps extends StyleBase { gap?: number; }
+export declare const Button: React.FC<ButtonProps>;
+export declare const Badge: React.FC<BadgeProps>;
+export declare const Card: React.FC<CardProps>;
+export declare const Stack: React.FC<StackProps>;
+`);
+}
+
+/** A package whose components share nothing — the base must come out empty. */
+function plainLibrary(dir: string): void {
+  const pkg = path.join(dir, 'node_modules', 'plain-lib');
+  fs.mkdirSync(pkg, { recursive: true });
+  fs.writeFileSync(path.join(pkg, 'package.json'), JSON.stringify({
+    name: 'plain-lib', version: '1.0.0', types: 'index.d.ts', main: 'index.js',
+    peerDependencies: { react: '*' },
+  }));
+  fs.writeFileSync(path.join(pkg, 'index.js'), 'module.exports = {};');
+  fs.writeFileSync(path.join(pkg, 'index.d.ts'), `
+import * as React from 'react';
+export declare const Alpha: React.FC<{ alpha?: string; shared?: boolean }>;
+export declare const Beta: React.FC<{ beta?: number; shared?: boolean }>;
+export declare const Gamma: React.FC<{ gamma?: 'a' | 'b' }>;
+`);
+}
+
+let dir: string;
+
+beforeAll(() => {
+  dir = fs.mkdtempSync(path.join(os.tmpdir(), 'checkerprops-'));
+  // React's own types have to be resolvable for a JSX probe to mean anything.
+  fs.symlinkSync(
+    path.resolve(process.cwd(), 'node_modules', '@types'),
+    path.join(fs.mkdirSync(path.join(dir, 'node_modules'), { recursive: true }) ?? path.join(dir, 'node_modules'), '@types'),
+    'dir',
+  );
+  styledLibrary(dir);
+  plainLibrary(dir);
+});
+
+afterAll(() => fs.rmSync(dir, { recursive: true, force: true }));
+
+describe('resolvePropsWithChecker', () => {
+  it('keeps what a component adds and drops the base its library shares', () => {
+    const out = resolvePropsWithChecker({ projectRoot: dir, importPath: 'styled-lib' });
+    expect(out.ran).toBe(true);
+    // The 60 shared style props are recognised as the library's base.
+    expect(out.baseProps.length).toBeGreaterThanOrEqual(60);
+    const button = out.components.find(c => c.name === 'Button');
+    expect(button).toBeDefined();
+    expect(button!.total).toBeGreaterThan(60);
+    expect(button!.own.map(p => p.name).sort()).toEqual(['loading', 'variant']);
+    // The library's own words and its declared value set both survive.
+    const variant = button!.own.find(p => p.name === 'variant')!;
+    expect(variant.options).toEqual(['solid', 'outline']);
+    expect(variant.doc).toBe('Which visual treatment to use.');
+    expect(out.components.find(c => c.name === 'Badge')!.own.map(p => p.name)).toEqual(['tone']);
+  });
+
+  it('subtracts nothing from a library whose components share no base', () => {
+    // Self-calibrating: with no shared surface, no prop reaches the threshold,
+    // so a library like Carbon or Material keeps everything it declares.
+    const out = resolvePropsWithChecker({ projectRoot: dir, importPath: 'plain-lib' });
+    expect(out.ran).toBe(true);
+    expect(out.baseProps).toEqual([]);
+    const alpha = out.components.find(c => c.name === 'Alpha')!;
+    expect(alpha.own.map(p => p.name).sort()).toEqual(['alpha', 'shared']);
+  });
+
+  it('says it could not run rather than reporting nothing found', () => {
+    const out = resolvePropsWithChecker({ projectRoot: dir, importPath: 'no-such-package-anywhere' });
+    expect(out.ran).toBe(false);
+    expect(out.reason).toBeTruthy();
+    expect(out.components).toEqual([]);
+  });
+});

--- a/story-generator/knowledge/checkerProps.ts
+++ b/story-generator/knowledge/checkerProps.ts
@@ -1,0 +1,261 @@
+/**
+ * A component's props as TypeScript itself resolves them.
+ *
+ * Reading declarations syntactically gets most libraries most of the way, and
+ * then stops dead at one shape:
+ *
+ *   export interface ButtonProps extends HTMLChakraProps<"button", ButtonBaseProps> {}
+ *
+ * An empty interface extending a generic instantiated in another file. Nothing
+ * short of type resolution can follow it, and the resolution bench measured
+ * what that costs: 90 of 754 components known on one library, 49 of 63 on
+ * another, 28 of 33 on a third. A catalog that lists a component and nothing
+ * about it is the condition under which a composition invents attributes.
+ *
+ * So this asks the compiler. It writes one throwaway module that imports the
+ * library and probes each export as a JSX element, then reads the contextual
+ * type of the attributes — the same question tsc answers when it type-checks a
+ * story, and the same machinery the post-generation prop check already uses.
+ *
+ * WHY IT SUBTRACTS. Asking the compiler about a styling-props library returns
+ * everything: Chakra's Button resolves to 1,139 props, of which 1,123 are the
+ * CSS surface every component in that library shares. A catalog entry listing
+ * them teaches nothing and crowds out the entry that matters. What a
+ * composition needs is what THIS component adds — size, variant, loading,
+ * loadingText — so a prop carried by nearly every component here is treated as
+ * the library's shared base and left out.
+ *
+ * That subtraction is self-calibrating and needs no knowledge of any library:
+ * where components share a styling base, the base is found and removed; where
+ * they share nothing — Carbon, Material — no prop reaches the threshold and
+ * nothing is removed. Nothing in this file names a design system.
+ */
+
+import ts from 'typescript';
+import path from 'path';
+import type { PropFact } from './propExtractor.js';
+
+export interface ResolvedComponent {
+  name: string;
+  /** What this component adds beyond the library's shared base. */
+  own: PropFact[];
+  /** Everything the compiler resolved, including the shared base. */
+  total: number;
+  /**
+   * `closed` — the compiler resolved a definite set, so anything outside it is
+   * rejected. `open` — an index signature admits any prop. `unknown` — the
+   * type resolved to any, or to nothing at all, which is what a type-only or
+   * namespace export looks like.
+   */
+  verdict: 'closed' | 'open' | 'unknown';
+}
+
+export interface CheckerPropsResult {
+  components: ResolvedComponent[];
+  /** Props shared by nearly every component, treated as the library's base. */
+  baseProps: string[];
+  /** False when no program could be built; distinct from "resolved nothing". */
+  ran: boolean;
+  reason?: string;
+  ms: number;
+}
+
+/** Present on every JSX element; listing it teaches nothing. */
+const UNIVERSAL = new Set(['key', 'ref', 'children']);
+
+/**
+ * A prop on at least this share of the library's substantial components is its
+ * shared base rather than any one component's API. 0.9 rather than a round 1.0
+ * because a styling base is not applied with perfect uniformity — a handful of
+ * components legitimately omit a few of its props.
+ */
+const BASE_SHARE = 0.9;
+
+/**
+ * A component whose resolved set is this large is a real component rather than
+ * a namespace or a type export, and only those vote on what the base is. With
+ * namespace exports in the denominator the threshold is never reached and the
+ * base comes out empty, which is the bug this constant exists to avoid.
+ */
+const SUBSTANTIAL = 50;
+
+function compilerOptionsFor(dir: string): ts.CompilerOptions {
+  const defaults: ts.CompilerOptions = {
+    jsx: ts.JsxEmit.ReactJSX,
+    moduleResolution: ts.ModuleResolutionKind.Bundler,
+    module: ts.ModuleKind.ESNext,
+    target: ts.ScriptTarget.ES2022,
+    strict: true,
+    esModuleInterop: true,
+  };
+  let options: ts.CompilerOptions = defaults;
+  const cfgPath = ts.findConfigFile(dir, ts.sys.fileExists);
+  if (cfgPath) {
+    const cfg = ts.readConfigFile(cfgPath, ts.sys.readFile);
+    if (cfg.config) {
+      const parsed = ts.parseJsonConfigFileContent(cfg.config, ts.sys, path.dirname(cfgPath));
+      options = { ...parsed.options };
+      options.jsx ??= defaults.jsx;
+      options.moduleResolution ??= defaults.moduleResolution;
+      options.module ??= defaults.module;
+      options.target ??= defaults.target;
+    }
+  }
+  for (const key of ['rootDir', 'outDir', 'outFile', 'composite', 'declaration', 'declarationDir',
+    'declarationMap', 'emitDeclarationOnly', 'incremental', 'tsBuildInfoFile', 'sourceMap',
+    'inlineSourceMap', 'plugins'] as const) {
+    delete (options as Record<string, unknown>)[key];
+  }
+  return { ...options, noEmit: true, skipLibCheck: true, allowJs: true, noUnusedLocals: false, noUnusedParameters: false };
+}
+
+function programOver(code: string, virtualFile: string, options: ts.CompilerOptions): ts.Program {
+  const host = ts.createCompilerHost(options, true);
+  const getSourceFile = host.getSourceFile;
+  const fileExists = host.fileExists;
+  const readFile = host.readFile;
+  host.getSourceFile = (name, lang, onError, shouldCreate) =>
+    name === virtualFile
+      ? ts.createSourceFile(name, code, lang, true, ts.ScriptKind.TSX)
+      : getSourceFile.call(host, name, lang, onError, shouldCreate);
+  host.fileExists = name => name === virtualFile || fileExists.call(host, name);
+  host.readFile = name => (name === virtualFile ? code : readFile.call(host, name));
+  return ts.createProgram([virtualFile], options, host);
+}
+
+/** The module's own exported names, as the compiler resolves them. */
+function exportedNames(code: string, virtual: string, options: ts.CompilerOptions): string[] {
+  const program = programOver(code, virtual, options);
+  const checker = program.getTypeChecker();
+  const source = program.getSourceFile(virtual);
+  if (!source) return [];
+  let moduleSymbol: ts.Symbol | undefined;
+  const visit = (node: ts.Node): void => {
+    if (ts.isImportDeclaration(node) && node.moduleSpecifier) {
+      moduleSymbol = checker.getSymbolAtLocation(node.moduleSpecifier) ?? moduleSymbol;
+    }
+    ts.forEachChild(node, visit);
+  };
+  visit(source);
+  if (!moduleSymbol) return [];
+  return checker.getExportsOfModule(moduleSymbol).map(s => s.name);
+}
+
+/** First sentence of a symbol's documentation, when it has one. */
+function docOf(symbol: ts.Symbol, checker: ts.TypeChecker): string | undefined {
+  const parts = symbol.getDocumentationComment(checker);
+  const text = ts.displayPartsToString(parts).trim();
+  if (!text) return undefined;
+  return text.split(/\n/)[0].split(/(?<=\.)\s/)[0].trim();
+}
+
+/** The string literals of a union type, when every member is one. */
+function literalValues(type: ts.Type): string[] | undefined {
+  const parts = type.isUnion() ? type.types : [type];
+  const out: string[] = [];
+  for (const p of parts) {
+    if (p.isStringLiteral()) out.push(p.value);
+    else if (p.flags & (ts.TypeFlags.Undefined | ts.TypeFlags.Null)) continue;
+    else return undefined;
+  }
+  return out.length > 1 && out.length <= 24 ? out : undefined;
+}
+
+/**
+ * Resolve the props of a package's components with the compiler.
+ *
+ * React only: the probe is a JSX element, which is the question tsc can answer
+ * about a React component and cannot answer about a Vue, Angular or Lit one.
+ * Those frameworks declare their inputs outright and are read directly.
+ */
+export function resolvePropsWithChecker(opts: {
+  projectRoot: string;
+  importPath: string;
+  /** Where a story would live; the tsconfig above it governs resolution. */
+  storiesDir?: string;
+  /** Cap on how many exports are probed, so an enormous package stays bounded. */
+  limit?: number;
+}): CheckerPropsResult {
+  const started = Date.now();
+  const dir = opts.storiesDir && opts.storiesDir.length ? opts.storiesDir : opts.projectRoot;
+  const virtual = path.join(dir, '__story_ui_prop_probe__.tsx');
+  const options = compilerOptionsFor(dir);
+  const spec = opts.importPath.replace(/'/g, "\\'");
+
+  let names: string[];
+  try {
+    names = exportedNames(`import * as L from '${spec}';\nexport const __lib = L;\n`, virtual, options);
+  } catch (error) {
+    return { components: [], baseProps: [], ran: false, ms: Date.now() - started, reason: `module could not be resolved: ${error instanceof Error ? error.message : String(error)}` };
+  }
+  const probes = names.filter(n => /^[A-Z]/.test(n)).slice(0, opts.limit ?? 1200);
+  if (!probes.length) {
+    return { components: [], baseProps: [], ran: false, ms: Date.now() - started, reason: `no capitalised exports resolved from ${opts.importPath}` };
+  }
+
+  const code = `import * as L from '${spec}';\n`
+    + probes.map((n, i) => `export const __p${i} = <L.${n} />;`).join('\n') + '\n';
+  const program = programOver(code, virtual, options);
+  const checker = program.getTypeChecker();
+  const source = program.getSourceFile(virtual);
+  if (!source) {
+    return { components: [], baseProps: [], ran: false, ms: Date.now() - started, reason: 'probe module did not compile' };
+  }
+
+  /** Everything resolved per component, before the base is subtracted. */
+  const resolved = new Map<string, { symbols: Map<string, ts.Symbol>; open: boolean }>();
+  const visit = (node: ts.Node): void => {
+    if (ts.isJsxSelfClosingElement(node)) {
+      const tag = node.tagName.getText(source).replace(/^L\./, '');
+      const type = checker.getContextualType(node.attributes);
+      const symbols = new Map<string, ts.Symbol>();
+      let open = false;
+      if (type && !(type.flags & (ts.TypeFlags.Any | ts.TypeFlags.Unknown))) {
+        for (const part of type.isUnion() ? type.types : [type]) {
+          if (checker.getIndexInfosOfType(part).length) open = true;
+          for (const s of checker.getPropertiesOfType(part)) if (!symbols.has(s.name)) symbols.set(s.name, s);
+        }
+      }
+      resolved.set(tag, { symbols, open });
+    }
+    ts.forEachChild(node, visit);
+  };
+  visit(source);
+
+  // What nearly every substantial component here shares is the library's base.
+  const substantial = [...resolved.values()].filter(r => r.symbols.size > SUBSTANTIAL);
+  const frequency = new Map<string, number>();
+  for (const r of substantial) for (const name of r.symbols.keys()) frequency.set(name, (frequency.get(name) ?? 0) + 1);
+  const baseProps = substantial.length >= 3
+    ? [...frequency.entries()].filter(([, n]) => n >= substantial.length * BASE_SHARE).map(([n]) => n)
+    : [];
+  const base = new Set(baseProps);
+
+  const components: ResolvedComponent[] = [];
+  for (const [name, r] of resolved) {
+    const ownNames = [...r.symbols.keys()].filter(n => !base.has(n) && !UNIVERSAL.has(n));
+    const own: PropFact[] = ownNames.map(propName => {
+      const symbol = r.symbols.get(propName)!;
+      const declaration = symbol.valueDeclaration ?? symbol.declarations?.[0];
+      const type = declaration ? checker.getTypeOfSymbolAtLocation(symbol, declaration) : undefined;
+      const values = type ? literalValues(type) : undefined;
+      const text = type ? checker.typeToString(type) : undefined;
+      const doc = docOf(symbol, checker);
+      return {
+        name: propName,
+        required: !(symbol.flags & ts.SymbolFlags.Optional),
+        ...(text && text.length <= 120 ? { type: text } : {}),
+        ...(values ? { options: values } : {}),
+        ...(doc ? { doc } : {}),
+      };
+    });
+    components.push({
+      name,
+      own,
+      total: r.symbols.size,
+      verdict: r.symbols.size <= 1 ? 'unknown' : r.open ? 'open' : 'closed',
+    });
+  }
+
+  return { components, baseProps, ran: true, ms: Date.now() - started };
+}

--- a/story-generator/knowledge/propExtractor.ts
+++ b/story-generator/knowledge/propExtractor.ts
@@ -28,6 +28,18 @@
 import ts from 'typescript';
 import { readAngularDeclarations } from './angularInputs.js';
 import { readVueDeclarations } from './vueProps.js';
+import { resolvePropsWithChecker } from './checkerProps.js';
+
+/** Does this package declare React — the framework whose components a JSX probe can resolve? */
+function declaresReact(root: string): boolean {
+  try {
+    const pkg = JSON.parse(fs.readFileSync(path.join(root, 'package.json'), 'utf-8'));
+    return ['peerDependencies', 'dependencies', 'devDependencies']
+      .some(field => pkg[field] && Object.keys(pkg[field]).some((d: string) => d === 'react' || d === '@types/react'));
+  } catch {
+    return false;
+  }
+}
 
 /** Angular's compiler-emitted declaration types; see knowledge/angularInputs.ts. */
 const ANGULAR_DECLARATION = /ɵɵ(Component|Directive)Declaration/;
@@ -1395,7 +1407,8 @@ function collectPropTypes(source: ts.SourceFile, out: Record<string, ComponentFa
  *    exported component rather than a `<Name>Props` convention; a path given
  *    as the package no longer reads node_modules.
  */
-const EXTRACTOR_SCHEMA = 7 // 7: optionsOpen from the member's own type text; 6: OverridableStringUnion literals; caches written before it hid MUI's variant/color/size;
+const EXTRACTOR_SCHEMA = 8 // 8: props resolved by the TypeScript checker for React packages;
+  // // 7: optionsOpen from the member's own type text; 6: OverridableStringUnion literals; caches written before it hid MUI's variant/color/size;
 
 /**
  * Keyed on version AND a content fingerprint (`knowledge/cacheKey`).
@@ -1583,6 +1596,53 @@ async function readOnePackage(
   }
   if (crossFilled > 0) {
     logger.log(`🧠 Resolved option values across files for ${crossFilled} prop(s) in ${pkgName}`);
+  }
+
+  /**
+   * Ask the compiler about what reading declarations could not resolve.
+   *
+   * `interface ButtonProps extends HTMLChakraProps<"button", ButtonBaseProps> {}`
+   * declares nothing locally and cannot be followed syntactically. Measured by
+   * the resolution bench, that shape cost one library 664 of its 754
+   * components. Type resolution answers it, and only ADDS: a prop already read
+   * from a declaration keeps its own reading, which carries the library's
+   * prose.
+   *
+   * Gated on the library declaring React, because the probe is a JSX element —
+   * a question tsc can answer about a React component and not about a Vue,
+   * Angular or Lit one, which declare their inputs outright and are read
+   * directly. The gate is the package's own manifest, not its name.
+   */
+  if (declaresReact(root)) {
+    try {
+      const checked = resolvePropsWithChecker({ projectRoot, importPath: pkgName, storiesDir: projectRoot });
+      if (!checked.ran) {
+        logger.log(`🧠 Type resolution for ${pkgName}: did not run — ${checked.reason}`);
+      } else {
+        let filled = 0;
+        let added = 0;
+        for (const component of checked.components) {
+          if (!component.own.length) continue;
+          const prior = components[component.name];
+          if (prior && prior.props.length) {
+            const before = prior.props.length;
+            prior.props = mergeProps(prior.props, component.own);
+            if (prior.props.length > before) filled++;
+          } else {
+            components[component.name] = { name: component.name, props: component.own };
+            added++;
+          }
+        }
+        logger.log(
+          `🧠 Type resolution for ${pkgName}: ${checked.components.length} export(s) probed in ${(checked.ms / 1000).toFixed(1)}s — ` +
+          `${added} component(s) that had no props now have them, ${filled} extended` +
+          `${checked.baseProps.length ? `; ${checked.baseProps.length} prop(s) shared by nearly every component treated as this library's base` : '; no shared base found, so nothing was subtracted'}`,
+        );
+      }
+    } catch (error) {
+      // Never fail an extraction because type resolution could not run.
+      logger.log(`🧠 Type resolution for ${pkgName} failed, declarations stand alone: ${error instanceof Error ? error.message : String(error)}`);
+    }
   }
 
   const entry = typesEntryFile(root);


### PR DESCRIPTION

Reading declarations syntactically gets most libraries most of the way and then
stops dead at one shape:

    export interface ButtonProps extends HTMLChakraProps<"button", ButtonBaseProps> {}

An empty interface extending a generic instantiated in another file. The
resolution bench measured what that costs: 90 of 754 components known on one
library, 28 of 33 on another, 209 of 235 on a third.

So the compiler is asked. One throwaway module imports the library, probes each
export as a JSX element, and reads the contextual type of the attributes — the
same question tsc answers when it type-checks a story, and the same machinery
the post-generation prop check already uses. Gated on the package declaring
React in its own manifest, because a JSX probe is a question about a React
component; Vue, Angular and Lit declare their inputs outright and are read
directly.

It has to subtract. Asking the compiler about a styling-props library returns
everything — one Button resolves to 1,139 props, of which 1,123 are the CSS
surface every component there shares — and a catalog listing them teaches
nothing while crowding out the entry that matters. A prop carried by nearly
every substantial component in the package is treated as that library's base
and left out, so Button comes back as size, variant, loading, loadingText.

The subtraction is self-calibrating and knows no library: where a shared base
exists it is found and removed; where components share nothing, no prop reaches
the threshold and nothing is removed. Both directions are covered by tests
against synthetic packages.

Measured, props known, before → after:
  chakra    12% → 62%     mui       90% → 99%
  fluent    89% → 97%     astryx    94% → 100%
  radix     85% → 94%     mantine   97% → 98%
  atlaskit  78% → 79%     carbon    98% → 98%
Non-React environments unchanged. Cost is 5-7s per package, cached with the
rest of the extraction under a bumped schema.



https://claude.ai/code/session_0158a8zxX4SKPdxm7DLfgqp4
