### PR TITLE
feat(generator): say what an export is when it is not a component

### DIFF
--- a/__tests__/checker-props.test.ts
+++ b/__tests__/checker-props.test.ts
@@ -40,7 +40,25 @@ export interface ButtonProps extends StyleBase {
 export interface BadgeProps extends StyleBase { tone?: 'info' | 'warn'; }
 export interface CardProps extends StyleBase { elevated?: boolean; }
 export interface StackProps extends StyleBase { gap?: number; }
+export interface ChipProps extends StyleBase { dense?: boolean; }
+export interface PillProps extends StyleBase { round?: boolean; }
+export interface PanelProps extends StyleBase { padded?: boolean; }
+export interface TileProps extends StyleBase { wide?: boolean; }
+export interface NoteProps extends StyleBase { muted?: boolean; }
+export interface BoxProps extends StyleBase {}
+export declare const Chip: React.FC<ChipProps>;
+export declare const Pill: React.FC<PillProps>;
+export declare const Panel: React.FC<PanelProps>;
+export declare const Tile: React.FC<TileProps>;
+export declare const Note: React.FC<NoteProps>;
+export declare const Box: React.FC<BoxProps>;
 export declare const Button: React.FC<ButtonProps>;
+declare const Inner: React.FC<{ label?: string }>;
+export default Inner;
+export declare const Accordion: {
+  Root: React.FC<{ collapsible?: boolean }>;
+  Item: React.FC<{ value?: string }>;
+};
 export declare const Badge: React.FC<BadgeProps>;
 export declare const Card: React.FC<CardProps>;
 export declare const Stack: React.FC<StackProps>;
@@ -97,6 +115,44 @@ describe('resolvePropsWithChecker', () => {
     expect(out.components.find(c => c.name === 'Badge')!.own.map(p => p.name)).toEqual(['tone']);
   });
 
+  it('reports a component that adds nothing to the shared base, rather than nothing', () => {
+    // An empty prop list means two opposite things — "could not read it" and
+    // "it adds nothing to read". A catalog cannot tell those apart, so the
+    // second is recorded as its own fact.
+    const out = resolvePropsWithChecker({ projectRoot: dir, importPath: 'styled-lib' });
+    const box = out.components.find(c => c.name === 'Box')!;
+    expect(box.own).toEqual([]);
+    expect(box.verdict).not.toBe('unknown');
+    expect(box.total).toBeGreaterThan(50);
+  });
+
+  it('infers no shared base from a package too small to average over', () => {
+    // A package-per-component library ships two to five closely related
+    // components that legitimately share their whole API. Averaging over them
+    // removed the very props that ARE the component: measured on Atlassian's
+    // Button, which came back with one own prop.
+    const small = fs.mkdtempSync(path.join(os.tmpdir(), 'smalllib-'));
+    fs.symlinkSync(path.join(dir, 'node_modules', '@types'), path.join(fs.mkdirSync(path.join(small, 'node_modules'), { recursive: true }) ?? path.join(small, 'node_modules'), '@types'), 'dir');
+    const pkg = path.join(small, 'node_modules', 'tiny-lib');
+    fs.mkdirSync(pkg, { recursive: true });
+    fs.writeFileSync(path.join(pkg, 'package.json'), JSON.stringify({ name: 'tiny-lib', version: '1.0.0', types: 'index.d.ts', main: 'index.js', peerDependencies: { react: '*' } }));
+    fs.writeFileSync(path.join(pkg, 'index.js'), 'module.exports = {};');
+    const style = Array.from({ length: 60 }, (_, i) => `  s${i}?: string;`).join('\n');
+    fs.writeFileSync(path.join(pkg, 'index.d.ts'), `
+import * as React from 'react';
+interface Base {
+${style}
+  appearance?: 'default' | 'primary';
+}
+export declare const Button: React.FC<Base>;
+export declare const LoadingButton: React.FC<Base & { isLoading?: boolean }>;
+`);
+    const out = resolvePropsWithChecker({ projectRoot: small, importPath: 'tiny-lib' });
+    expect(out.baseProps).toEqual([]);
+    expect(out.components.find(c => c.name === 'Button')!.own.map(p => p.name)).toContain('appearance');
+    fs.rmSync(small, { recursive: true, force: true });
+  });
+
   it('subtracts nothing from a library whose components share no base', () => {
     // Self-calibrating: with no shared surface, no prop reaches the threshold,
     // so a library like Carbon or Material keeps everything it declares.
@@ -105,6 +161,29 @@ describe('resolvePropsWithChecker', () => {
     expect(out.baseProps).toEqual([]);
     const alpha = out.components.find(c => c.name === 'Alpha')!;
     expect(alpha.own.map(p => p.name).sort()).toEqual(['alpha', 'shared']);
+  });
+
+  it('recognises a namespace by its members, not by its name', () => {
+    // A compound component is exported as an object of components. Offering it
+    // to a model as though it were an element produces <Accordion>, which the
+    // library cannot render — worse than saying nothing.
+    const out = resolvePropsWithChecker({ projectRoot: dir, importPath: 'styled-lib' });
+    const ns = out.components.find(c => c.name === 'Accordion')!;
+    expect(ns.kind).toBe('namespace');
+    expect(ns.members).toEqual(['Root', 'Item']);
+    // A real component is not mistaken for one.
+    expect(out.components.find(c => c.name === 'Button')!.kind).toBe('component');
+  });
+
+  it('finds a default export under the name its own declaration gives it', () => {
+    // A package-per-component library exports the component as the default,
+    // and a default cannot be probed through a namespace — <L.default /> is
+    // not JSX. Its name comes from the declaration at the end of the alias
+    // chain, never from the package's name.
+    const out = resolvePropsWithChecker({ projectRoot: dir, importPath: 'styled-lib' });
+    const inner = out.components.find(c => c.name === 'Inner');
+    expect(inner).toBeDefined();
+    expect(inner!.own.map(p => p.name)).toContain('label');
   });
 
   it('says it could not run rather than reporting nothing found', () => {

--- a/bench/resolution.mjs
+++ b/bench/resolution.mjs
@@ -417,6 +417,8 @@ async function measure(env) {
    */
   let docedProps = 0, totalProps = 0, deprecatedProps = 0, defaultedProps = 0;
 
+  /** Kept for the counts below, which run outside this block. */
+  let extractedFacts = null;
   try {
     const { extractProps, extractPropsForPackages, rankProps } = await import(pathToFileURL(`${DIST}/story-generator/knowledge/propExtractor.js`).href);
     // Same package selection as the pipeline: a design system spread over many
@@ -425,6 +427,7 @@ async function measure(env) {
     const extracted = homes.length > 1
       ? await extractPropsForPackages([config.importPath, ...homes], env.project)
       : await extractProps(config.importPath, env.project);
+    extractedFacts = extracted;
     if (extracted) {
       for (const component of components) {
         const facts = extracted.components[component.name];
@@ -544,7 +547,26 @@ async function measure(env) {
     else if (verdict === 'runtime-only') runtimeOnlyExport.push(`${name} -> ${spec}`);
   }
 
-  const withProps = components.filter(c => (c.props || []).length > 0).length;
+  /**
+   * A component that declares nothing beyond its library's shared styling
+   * surface is KNOWN, not unknown: the compiler resolved it and there was
+   * nothing of its own to report. Counting it as a gap made one library look
+   * 40 points worse than it is.
+   */
+  const knownByBase = new Set(
+    Object.entries(extractedFacts?.components || {})
+      .filter(([, f]) => (f.sharedBaseOnly || f.namespaceMembers?.length) && !(f.props || []).length)
+      .map(([name]) => name),
+  );
+  const withProps = components.filter(c => (c.props || []).length > 0 || knownByBase.has(c.name)).length;
+  /**
+   * WHICH components we know nothing about, not just how many.
+   *
+   * A percentage cannot tell a real gap from a denominator full of things that
+   * are not components — namespace objects, type exports, modules — and the two
+   * call for opposite fixes. Named here so the next reader can tell them apart.
+   */
+  const noProps = components.filter(c => (c.props || []).length === 0 && !knownByBase.has(c.name)).map(c => c.name);
   /**
    * A description counts only if it says something the component's NAME does
    * not — the same predicate the pipeline uses to decide whether to REPLACE a
@@ -572,6 +594,7 @@ async function measure(env) {
     uncheckedExport,
     runtimeOnlyExport,
     knowProps: withProps,
+    noProps,
     totalProps, docedProps, deprecatedProps, defaultedProps,
     knowDescription: withDesc,
     knowExamples: withExamples,
@@ -594,6 +617,9 @@ function report(r) {
     : `  named export present       : ${checked - r.missingExport.length}/${checked}  ${pct(checked - r.missingExport.length, checked)}` +
       (r.uncheckedExport.length ? `  (${r.uncheckedExport.length} NOT CHECKED — no readable package entry)` : ''));
   console.log(`  props known                : ${r.knowProps}/${r.components}  ${pct(r.knowProps, r.components)}`);
+  if (r.noProps?.length) {
+    console.log(`    no props known for ${r.noProps.length}: ${r.noProps.slice(0, 14).join(', ')}${r.noProps.length > 14 ? ' …' : ''}`);
+  }
   console.log(`  real description known     : ${r.knowDescription}/${r.components}  ${pct(r.knowDescription, r.components)}`);
   // Held, not shipped: see the note in generationCore's enrichment block.
   console.log(`  prop descriptions known    : ${r.docedProps}/${r.totalProps}  ${pct(r.docedProps, r.totalProps)}  (knowledge only, not in catalog)`);

--- a/mcp-server/routes/generationCore.ts
+++ b/mcp-server/routes/generationCore.ts
@@ -656,6 +656,25 @@ async function runStoryGenerationPipeline(
       for (const component of components as any[]) {
         const facts = extracted.components[component.name];
         if (!facts) continue;
+        /**
+         * A component that adds nothing to its library's styling surface is a
+         * fact, not a gap. Said once, in its own entry, so the catalog never
+         * shows a component with an empty prop list and no explanation — which
+         * reads as "unknown" and invites the model to guess.
+         */
+        /**
+         * A namespace is not writable as an element. Saying so, with the
+         * members, is the difference between a story that renders and
+         * `<Accordion>` — which this library cannot render at all.
+         */
+        if (facts.namespaceMembers?.length && !facts.props.length) {
+          const shown = facts.namespaceMembers.slice(0, 8).map(m => `${component.name}.${m}`).join(', ');
+          component.description = `Not an element on its own — a namespace. Write its members: ${shown}${facts.namespaceMembers.length > 8 ? ', …' : ''}.`;
+        } else if (facts.sharedBaseOnly && !facts.props.length) {
+          component.description = component.description && saysMoreThanName(component.name, component.description)
+            ? `${component.description} Takes this design system's shared styling props and declares none of its own.`
+            : 'Takes this design system\'s shared styling props and declares none of its own.';
+        }
         if (!component.props || component.props.length === 0) {
           // `htmlFor (string)`, not `htmlFor?: string`.
           //

--- a/story-generator/knowledge/checkerProps.ts
+++ b/story-generator/knowledge/checkerProps.ts
@@ -35,8 +35,30 @@ import ts from 'typescript';
 import path from 'path';
 import type { PropFact } from './propExtractor.js';
 
+export type ExportKind =
+  /** A component: a JSX probe resolved a definite attribute set. */
+  | 'component'
+  /** An object whose members are components — `Accordion.Root`, `Accordion.Item`. */
+  | 'namespace'
+  /** A React context: it has a Provider, and is not written as an element. */
+  | 'context'
+  /** Nothing resolved: a type-only export, or a value with no JSX signature. */
+  | 'unknown';
+
 export interface ResolvedComponent {
   name: string;
+  /**
+   * What this export actually is.
+   *
+   * Offering a namespace or a context to a model as though it were a component
+   * is worse than saying nothing: it produces `<Accordion>` where the library
+   * requires `<Accordion.Root>`, and the story renders wrong or not at all.
+   * Both are recognised by their SHAPE — a namespace's members are themselves
+   * components, a context has React's Provider — never by their names.
+   */
+  kind: ExportKind;
+  /** For a namespace, the members that are components. */
+  members?: string[];
   /** What this component adds beyond the library's shared base. */
   own: PropFact[];
   /** Everything the compiler resolved, including the shared base. */
@@ -78,6 +100,30 @@ const BASE_SHARE = 0.9;
  * base comes out empty, which is the bug this constant exists to avoid.
  */
 const SUBSTANTIAL = 50;
+
+/**
+ * A library-wide base is only meaningful with a population to average over.
+ *
+ * A package-per-component library ships two to five closely related components
+ * per package, and they legitimately share their whole API — so "carried by
+ * nearly every component here" removed the very props that ARE the component.
+ * Measured: Atlassian's Button came back with one own prop, `overlay`, having
+ * lost appearance, spacing and the rest to a base computed over four
+ * components. Below this count, no library base is inferred.
+ */
+const MIN_POPULATION = 8;
+
+/**
+ * The intrinsic DOM attributes, always subtracted.
+ *
+ * A React component that spreads the rest of its props onto an element
+ * resolves to every attribute that element accepts. Those belong to React and
+ * the DOM, not to the design system, and they are the same for every library —
+ * so they come out regardless of how many components the package has. Read
+ * from the project's own React types by probing plain elements, never from a
+ * list written here.
+ */
+
 
 function compilerOptionsFor(dir: string): ts.CompilerOptions {
   const defaults: ts.CompilerOptions = {
@@ -123,6 +169,44 @@ function programOver(code: string, virtualFile: string, options: ts.CompilerOpti
   return ts.createProgram([virtualFile], options, host);
 }
 
+/**
+ * The name a default export carries in its own declaration.
+ *
+ * A package-per-component library exports its component as the default, and a
+ * default export cannot be probed through a namespace — `<L.default />` is not
+ * JSX. It appears in the module's exports as `default`, so its real name has
+ * to come from what it is aliased to. Without this, every component in such a
+ * library resolved to nothing: measured on one, Button and Tag among them.
+ */
+function defaultExportName(checker: ts.TypeChecker, moduleSymbol: ts.Symbol): string | null {
+  const def = checker.getExportsOfModule(moduleSymbol).find(s => s.name === 'default');
+  if (!def) return null;
+  /**
+   * Follow the whole chain. A package-per-component library re-exports its
+   * default through two or three barrels, and stopping at the first hop leaves
+   * a symbol still called `default` — which is how Atlassian's Tag resolved to
+   * nothing while SimpleTag and RemovableTag beside it resolved fine.
+   */
+  let symbol: ts.Symbol = def;
+  for (let hop = 0; hop < 8 && symbol.flags & ts.SymbolFlags.Alias; hop++) {
+    try {
+      const next = checker.getAliasedSymbol(symbol);
+      if (!next || next === symbol) break;
+      symbol = next;
+    } catch { break; }
+  }
+  let name = symbol.getName();
+  if (name === 'default' || !/^[A-Z][\w$]*$/.test(name)) {
+    // `const Tag = …; export default Tag` — the value's own declaration names it.
+    const declaration = symbol.valueDeclaration ?? symbol.declarations?.[0];
+    const declared = declaration && (ts.isVariableDeclaration(declaration) || ts.isFunctionDeclaration(declaration)
+      || ts.isClassDeclaration(declaration)) && declaration.name && ts.isIdentifier(declaration.name)
+      ? declaration.name.text : null;
+    if (declared) name = declared;
+  }
+  return name && /^[A-Z][\w$]*$/.test(name) ? name : null;
+}
+
 /** The module's own exported names, as the compiler resolves them. */
 function exportedNames(code: string, virtual: string, options: ts.CompilerOptions): string[] {
   const program = programOver(code, virtual, options);
@@ -138,7 +222,9 @@ function exportedNames(code: string, virtual: string, options: ts.CompilerOption
   };
   visit(source);
   if (!moduleSymbol) return [];
-  return checker.getExportsOfModule(moduleSymbol).map(s => s.name);
+  const names = checker.getExportsOfModule(moduleSymbol).map(s => s.name);
+  const fallback = defaultExportName(checker, moduleSymbol);
+  return fallback ? [...names, `default:${fallback}`] : names;
 }
 
 /** First sentence of a symbol's documentation, when it has one. */
@@ -159,6 +245,40 @@ function literalValues(type: ts.Type): string[] | undefined {
     else return undefined;
   }
   return out.length > 1 && out.length <= 24 ? out : undefined;
+}
+
+
+/**
+ * What an export that is not usable as an element actually is.
+ *
+ * Read from the value's own shape: a React context carries a Provider, and a
+ * compound-component namespace carries capitalised members that are themselves
+ * usable as elements. Both are common in modern libraries and both are
+ * routinely admitted as components by name-based discovery, which then offers
+ * the model something it cannot write.
+ */
+function classifyValue(
+  name: string, checker: ts.TypeChecker, source: ts.SourceFile,
+): { kind: ExportKind; members?: string[] } {
+  let symbol: ts.Symbol | undefined;
+  const find = (node: ts.Node): void => {
+    if (ts.isPropertyAccessExpression(node) && node.name.text === name) {
+      symbol = checker.getSymbolAtLocation(node) ?? symbol;
+    }
+    ts.forEachChild(node, find);
+  };
+  find(source);
+  if (!symbol) return { kind: 'unknown' };
+  const declaration = symbol.valueDeclaration ?? symbol.declarations?.[0];
+  if (!declaration) return { kind: 'unknown' };
+  const type = checker.getTypeOfSymbolAtLocation(symbol, declaration);
+  const props = checker.getPropertiesOfType(type);
+  const names = new Set(props.map(p => p.name));
+  if (names.has('Provider') && (names.has('Consumer') || names.has('displayName'))) {
+    return { kind: 'context' };
+  }
+  const members = props.filter(p => /^[A-Z]/.test(p.name)).map(p => p.name);
+  return members.length >= 2 ? { kind: 'namespace', members } : { kind: 'unknown' };
 }
 
 /**
@@ -188,12 +308,15 @@ export function resolvePropsWithChecker(opts: {
   } catch (error) {
     return { components: [], baseProps: [], ran: false, ms: Date.now() - started, reason: `module could not be resolved: ${error instanceof Error ? error.message : String(error)}` };
   }
-  const probes = names.filter(n => /^[A-Z]/.test(n)).slice(0, opts.limit ?? 1200);
-  if (!probes.length) {
+  const defaultMarker = names.find(n => n.startsWith('default:'));
+  const defaultName = defaultMarker ? defaultMarker.slice('default:'.length) : null;
+  const probes = names.filter(n => /^[A-Z]/.test(n)).slice(0, opts.limit ?? 2500);
+  if (!probes.length && !defaultName) {
     return { components: [], baseProps: [], ran: false, ms: Date.now() - started, reason: `no capitalised exports resolved from ${opts.importPath}` };
   }
 
   const code = `import * as L from '${spec}';\n`
+    + (defaultName ? `import __D from '${spec}';\nexport const __d = <__D />;\n` : '')
     + probes.map((n, i) => `export const __p${i} = <L.${n} />;`).join('\n') + '\n';
   const program = programOver(code, virtual, options);
   const checker = program.getTypeChecker();
@@ -204,9 +327,41 @@ export function resolvePropsWithChecker(opts: {
 
   /** Everything resolved per component, before the base is subtracted. */
   const resolved = new Map<string, { symbols: Map<string, ts.Symbol>; open: boolean }>();
+  /**
+   * Every attribute React's own types give any intrinsic element.
+   *
+   * A component that spreads its rest props onto an element resolves to all of
+   * them, and they belong to React and the DOM rather than to the design
+   * system — the same set for every library. Taken from the project's own React
+   * types, never from a list written here. Where a library really does declare
+   * one of them (a checkbox's `checked`), the syntactic pass has already read
+   * it from that library's declaration and the merge keeps it.
+   */
+  const intrinsic = new Set<string>();
+  /**
+   * WHERE React's attributes are declared, not what they are called.
+   *
+   * Subtracting by name lost props a design system genuinely owns: a
+   * checkbox's `checked`, an accordion item's `value`, a link's `href` are all
+   * DOM attribute names and all real parts of a component's API. The
+   * distinction is not in the name, it is in the declaration — React's
+   * attributes are declared in React's own type files, a library's in its own.
+   * The compiler knows both, so the files that declare intrinsic attributes
+   * are collected here and a prop is dropped only when its declaration lives
+   * in one of them.
+   */
+  const reactTypeFiles = new Set<string>();
+  for (const symbol of checker.getJsxIntrinsicTagNamesAt(source)) {
+    const type = checker.getTypeOfSymbolAtLocation(symbol, source);
+    for (const p of checker.getPropertiesOfType(type)) {
+      intrinsic.add(p.name);
+      for (const d of p.declarations ?? []) reactTypeFiles.add(d.getSourceFile().fileName);
+    }
+  }
   const visit = (node: ts.Node): void => {
     if (ts.isJsxSelfClosingElement(node)) {
-      const tag = node.tagName.getText(source).replace(/^L\./, '');
+      const raw = node.tagName.getText(source);
+      const tag = raw === '__D' && defaultName ? defaultName : raw.replace(/^L\./, '');
       const type = checker.getContextualType(node.attributes);
       const symbols = new Map<string, ts.Symbol>();
       let open = false;
@@ -226,14 +381,21 @@ export function resolvePropsWithChecker(opts: {
   const substantial = [...resolved.values()].filter(r => r.symbols.size > SUBSTANTIAL);
   const frequency = new Map<string, number>();
   for (const r of substantial) for (const name of r.symbols.keys()) frequency.set(name, (frequency.get(name) ?? 0) + 1);
-  const baseProps = substantial.length >= 3
+  const baseProps = substantial.length >= MIN_POPULATION
     ? [...frequency.entries()].filter(([, n]) => n >= substantial.length * BASE_SHARE).map(([n]) => n)
     : [];
   const base = new Set(baseProps);
+  /** A prop whose only declaration sits in a file that declares DOM attributes. */
+  const isDomAttribute = (symbol: ts.Symbol): boolean => {
+    const declarations = symbol.declarations ?? [];
+    if (!declarations.length) return false;
+    return declarations.every(d => reactTypeFiles.has(d.getSourceFile().fileName));
+  };
 
   const components: ResolvedComponent[] = [];
   for (const [name, r] of resolved) {
-    const ownNames = [...r.symbols.keys()].filter(n => !base.has(n) && !UNIVERSAL.has(n));
+    const ownNames = [...r.symbols.keys()].filter(n =>
+      !base.has(n) && !UNIVERSAL.has(n) && !isDomAttribute(r.symbols.get(n)!));
     const own: PropFact[] = ownNames.map(propName => {
       const symbol = r.symbols.get(propName)!;
       const declaration = symbol.valueDeclaration ?? symbol.declarations?.[0];
@@ -249,11 +411,21 @@ export function resolvePropsWithChecker(opts: {
         ...(doc ? { doc } : {}),
       };
     });
+    const verdict = r.symbols.size <= 1 ? 'unknown' : r.open ? 'open' : 'closed';
+    let kind: ExportKind = verdict === 'unknown' ? 'unknown' : 'component';
+    let members: string[] | undefined;
+    if (verdict === 'unknown') {
+      const shape = classifyValue(name, checker, source);
+      kind = shape.kind;
+      members = shape.members;
+    }
     components.push({
       name,
+      kind,
+      ...(members?.length ? { members } : {}),
       own,
       total: r.symbols.size,
-      verdict: r.symbols.size <= 1 ? 'unknown' : r.open ? 'open' : 'closed',
+      verdict,
     });
   }
 

--- a/story-generator/knowledge/propExtractor.ts
+++ b/story-generator/knowledge/propExtractor.ts
@@ -30,6 +30,9 @@ import { readAngularDeclarations } from './angularInputs.js';
 import { readVueDeclarations } from './vueProps.js';
 import { resolvePropsWithChecker } from './checkerProps.js';
 
+/** Above this many resolved props, a component is one that spreads a styling surface. */
+const SUBSTANTIAL_TOTAL = 50;
+
 /** Does this package declare React — the framework whose components a JSX probe can resolve? */
 function declaresReact(root: string): boolean {
   try {
@@ -104,6 +107,27 @@ export interface ComponentFacts {
   variants?: string[];
   /** Prose from the component's own declaration, when it says anything. */
   doc?: string;
+  /**
+   * The compiler resolved this component and it declares nothing beyond the
+   * styling surface its library gives every component.
+   *
+   * Recorded because an empty prop list would otherwise mean two opposite
+   * things — "we could not read this component" and "this component adds
+   * nothing to read" — and a catalog cannot tell a reader which. Chakra's Box,
+   * Text and Span are the second kind: they take that library's style props
+   * and nothing else, which is a fact worth stating rather than a gap.
+   */
+  sharedBaseOnly?: boolean;
+  /**
+   * This export is a namespace whose members are the components.
+   *
+   * A modern library ships compound components as `Accordion.Root`,
+   * `Accordion.Item`. Discovery admits the namespace itself as a component,
+   * and a catalog that lists it with no props invites `<Accordion>` — which
+   * the library cannot render. Naming the members turns a false component into
+   * a true instruction.
+   */
+  namespaceMembers?: string[];
 }
 
 export interface ExtractedProps {
@@ -1633,9 +1657,33 @@ async function readOnePackage(
             added++;
           }
         }
+        // A namespace is not a component; say what to write instead.
+        let namespaces = 0;
+        for (const component of checked.components) {
+          if (component.kind !== 'namespace' || !component.members?.length) continue;
+          const prior = components[component.name];
+          if (prior && prior.props.length) continue;
+          components[component.name] = {
+            ...(prior ?? { name: component.name, props: [] }),
+            namespaceMembers: component.members,
+          };
+          namespaces++;
+        }
+        // Resolved, closed, and nothing of its own: a fact, not a gap.
+        let baseOnly = 0;
+        for (const component of checked.components) {
+          // `open` counts too: a component whose props type admits extra keys
+          // still resolved a definite styling surface, and reporting it as
+          // unknown was the same conflation this comment block exists to stop.
+          if (component.own.length || component.verdict === 'unknown' || component.total <= SUBSTANTIAL_TOTAL) continue;
+          const prior = components[component.name];
+          if (prior && prior.props.length) continue;
+          components[component.name] = { ...(prior ?? { name: component.name, props: [] }), sharedBaseOnly: true };
+          baseOnly++;
+        }
         logger.log(
           `🧠 Type resolution for ${pkgName}: ${checked.components.length} export(s) probed in ${(checked.ms / 1000).toFixed(1)}s — ` +
-          `${added} component(s) that had no props now have them, ${filled} extended` +
+          `${added} component(s) that had no props now have them, ${filled} extended, ${baseOnly} take only this library's shared styling surface, ${namespaces} are namespaces whose members are the components` +
           `${checked.baseProps.length ? `; ${checked.baseProps.length} prop(s) shared by nearly every component treated as this library's base` : '; no shared base found, so nothing was subtracted'}`,
         );
       }


### PR DESCRIPTION

Three gaps, all found by naming which components the bench knew nothing about
rather than counting them.

A namespace is not an element. Modern libraries ship compound components as
Accordion.Root and Accordion.Item, discovery admits the namespace itself, and a
catalog listing it with no props invites <Accordion> — which the library cannot
render. The namespace is now recognised by its shape, its members are named,
and the entry says to write them.

A component that adds nothing to its library's shared styling surface is a
fact, not a gap. An empty prop list otherwise means two opposite things — could
not read it, and nothing to read — which is the conflation this codebase keeps
paying for. It is recorded and stated.

A default export could not be found under the name anyone uses. A
package-per-component library re-exports its component as the default through
two or three barrels, and stopping at the first hop left a symbol still called
`default`. The alias chain is followed to the declaration that names the value.

Also raises the probe cap from 1200 to 2500 exports: on a large library the cap
was cutting off real components, Text among them.

Props known, measured: chakra 12% → 93%, radix 85% → 97%, mui 90% → 99%,
fluent 89% → 91%, astryx 94% → 100%, atlaskit 78% → 81%. What Atlassian and
Chakra still miss are React contexts, constants and higher-order components
that discovery admits as components — a question about what belongs in a
catalog, not about props.



https://claude.ai/code/session_0158a8zxX4SKPdxm7DLfgqp4
