### PR TITLE
feat(generator): say when a prop list is complete

### DIFF
--- a/__tests__/catalog-complete-props.test.ts
+++ b/__tests__/catalog-complete-props.test.ts
@@ -1,0 +1,68 @@
+/**
+ * Saying a prop list is COMPLETE, and only when it is.
+ *
+ * A list of props reads as a sample. A model weighing a sample against a
+ * strong memory of a library's earlier major version picks the memory:
+ * measured on Material, 30 first-round validation errors across 11 prompts,
+ * 19 of them `alignItems` on Stack — a prop that library moved into `sx` and
+ * that the catalog had correctly stopped listing. Three separate prompt rules
+ * failed to move that number, and none of them said the list was exhaustive,
+ * because until the compiler resolved the prop sets nothing knew that it was.
+ *
+ * The risk in stating it is stating it wrongly, so these tests are mostly
+ * about when the claim must NOT appear: a truncated list is not a complete
+ * one, and a component whose type admits any prop is not closed.
+ */
+import { describe, it, expect } from 'vitest';
+import { ReactAdapter } from '../story-generator/framework-adapters/react-adapter.js';
+
+const adapter = new ReactAdapter();
+const entryFor = (component: Record<string, unknown>, withDocs = false): string =>
+  (adapter as unknown as {
+    formatComponentEntry(c: unknown, cfg: unknown, o: { withDocs: boolean }): string;
+  }).formatComponentEntry(component, { importPath: '@acme/ui' }, { withDocs });
+
+const props = (n: number) => Array.from({ length: n }, (_, i) => `p${i}?`);
+
+describe('a complete prop list says so', () => {
+  it('claims completeness when the compiler resolved a definite set and nothing was withheld', () => {
+    const entry = entryFor({
+      name: 'Stack',
+      props: ['children?', 'direction?', 'spacing?', 'sx?', 'useFlexGap?'],
+      __propsClosed: true,
+    });
+    expect(entry).toContain('COMPLETE list');
+    expect(entry).toContain('any other prop is rejected');
+    // The reason the model needs it, named.
+    expect(entry).toContain('earlier version of this library');
+  });
+
+  it('never claims it for a truncated list', () => {
+    // The catalog shows a bounded number of ranked props. Fourteen props means
+    // two are withheld, and a list with something withheld is not complete —
+    // claiming otherwise would be a lie the model cannot check.
+    const entry = entryFor({ name: 'DataTable', props: props(14), __propsClosed: true });
+    expect(entry).toContain('more');
+    expect(entry).not.toContain('COMPLETE list');
+  });
+
+  it('never claims it when the compiler could not resolve a definite set', () => {
+    // No `__propsClosed`: the type carried an index signature, resolved to
+    // any, or was never resolved at all. Silence is correct there.
+    const entry = entryFor({ name: 'Box', props: ['children?', 'as?'] });
+    expect(entry).not.toContain('COMPLETE list');
+  });
+
+  it('claims it in the documented entry shape too', () => {
+    // The request's own components render with prop docs on separate lines;
+    // the clause has to survive that formatting, not just the compact one.
+    const entry = entryFor({
+      name: 'Button',
+      props: ['children?', 'variant?'],
+      __propDocs: { variant: 'Which visual treatment to use.' },
+      __propsClosed: true,
+    }, true);
+    expect(entry).toContain('COMPLETE list');
+    expect(entry).toContain('Which visual treatment to use.');
+  });
+});

--- a/mcp-server/routes/generationCore.ts
+++ b/mcp-server/routes/generationCore.ts
@@ -719,6 +719,12 @@ async function runStoryGenerationPipeline(
             if (!p.deprecated && p.doc && p.doc.trim()) propDocs[p.name] = p.doc.trim().split('\n')[0];
           }
           if (Object.keys(propDocs).length) component.__propDocs = propDocs;
+          /**
+           * Carried to the catalog so the entry can say the list is complete.
+           * Only meaningful when the compiler resolved a definite set — see
+           * propsAreClosed in propExtractor.ts.
+           */
+          if (facts.propsAreClosed) component.__propsClosed = true;
           component.props = rankProps(facts.props.filter(p => !p.deprecated)).map(p => {
             /**
              * Say REQUIRED, rather than implying it by the absence of `?`.

--- a/story-generator/framework-adapters/base-adapter.ts
+++ b/story-generator/framework-adapters/base-adapter.ts
@@ -291,9 +291,29 @@ export abstract class BaseFrameworkAdapter implements FrameworkAdapter {
         : hiddenHasBehaviour
           ? `, …${hidden.length} more`
           : `, …${hidden.length} more (styling and layout only — every state prop and handler this component has is listed above)`;
+      /**
+       * Say when the list is COMPLETE, and only then.
+       *
+       * A list of props reads as a sample, and a model weighing a sample
+       * against a strong memory of a library's earlier major version picks the
+       * memory. Measured on Material: 30 first-round validation errors across
+       * 11 prompts, 19 of them one prop — `alignItems` on Stack — that the
+       * library moved into `sx` and the catalog had correctly stopped listing.
+       * Three separate prompt rules failed to move that number; none of them
+       * said the list was exhaustive, because nothing knew that it was.
+       *
+       * The compiler knows: it resolves a definite prop set for a component
+       * whose type has no index signature. Claimed only when nothing was
+       * withheld from the entry — a truncated list is not a complete one — and
+       * only for the components the request is about, where the docs are
+       * rendered and the extra clause is affordable.
+       */
+      const complete = hidden.length === 0 && (component as any).__propsClosed
+        ? ' — this is the COMPLETE list; any other prop is rejected before the story is saved, including one you remember from an earlier version of this library'
+        : '';
       entry += docs
-        ? `\n  Props:\n    ${shown.join('\n    ')}${tail ? `\n    ${tail.replace(/^, /, '')}` : ''}`
-        : `\n  Props: ${shown.join(', ')}${tail}`;
+        ? `\n  Props${complete}:\n    ${shown.join('\n    ')}${tail ? `\n    ${tail.replace(/^, /, '')}` : ''}`
+        : `\n  Props${complete}: ${shown.join(', ')}${tail}`;
     }
 
     // A description that only restates the name — discovery's `Chip component

--- a/story-generator/knowledge/propExtractor.ts
+++ b/story-generator/knowledge/propExtractor.ts
@@ -135,6 +135,17 @@ export interface ComponentFacts {
    * cannot know from a bare name that `<CLIENT_VERSION />` is impossible.
    */
   notAComponent?: boolean;
+  /**
+   * The compiler resolved a DEFINITE prop set for this component: no index
+   * signature, nothing unresolved. Anything outside it is rejected.
+   *
+   * Recorded so the catalog can say so. Listing props without saying the list
+   * is complete reads as a sample, and a model weighing a sample against a
+   * strong memory of an earlier major version picks the memory: measured on
+   * Material, 30 first-round validation errors across 11 prompts, nearly all
+   * of them one prop that library moved out of the component.
+   */
+  propsAreClosed?: boolean;
 }
 
 export interface ExtractedProps {
@@ -1654,13 +1665,15 @@ async function readOnePackage(
         let added = 0;
         for (const component of checked.components) {
           if (!component.own.length) continue;
+          const closed = component.verdict === 'closed' ? { propsAreClosed: true } : {};
           const prior = components[component.name];
           if (prior && prior.props.length) {
             const before = prior.props.length;
             prior.props = mergeProps(prior.props, component.own);
+            Object.assign(prior, closed);
             if (prior.props.length > before) filled++;
           } else {
-            components[component.name] = { name: component.name, props: component.own };
+            components[component.name] = { name: component.name, props: component.own, ...closed };
             added++;
           }
         }


### PR DESCRIPTION

A catalog entry lists a component's props and has never said whether that is
all of them. It reads as a sample, and a model weighing a sample against a
strong memory of a library's earlier major version picks the memory. Measured
on Material: 30 first-round validation errors across 11 prompts, 19 of them
`alignItems` on Stack — a prop that library moved into `sx` and that the
catalog had correctly stopped listing.

Three prompt rules were tried against that number and none of them moved it:
that undeclared props are rejected, where the library says CSS belongs, and
that the catalog describes the version installed here. None of them said the
list was exhaustive, because until the compiler resolved the prop sets nothing
knew that it was.

It does now. Where type resolution returned a definite set — no index
signature, nothing unresolved — the entry says the list is complete and that
anything else is rejected, naming the version-memory trap explicitly.

Claimed narrowly, because the risk is claiming it wrongly: never for a
truncated list, since a list with props withheld is not a complete one, and
never for a component whose type admits any prop. Both refusals are tested.

Whether this moves Material's number is the next measurement; the three
attempts before it did not.



https://claude.ai/code/session_0158a8zxX4SKPdxm7DLfgqp4
