### PR TITLE
feat(generator): read what Angular says each export is

### DIFF
--- a/__tests__/angular-inputs.test.ts
+++ b/__tests__/angular-inputs.test.ts
@@ -1,0 +1,77 @@
+/**
+ * What Angular declares about itself, read from the declarations its own
+ * compiler emits.
+ *
+ * The resolution bench measured Angular Material at 0 of 309 components with
+ * known props, against 78-100% everywhere else, and the 309 was itself wrong:
+ * it counted NgModules, injection tokens and test harnesses as components. A
+ * catalog in that state offers a model `<MatButtonModule>` and
+ * `<MAT_BUTTON_CONFIG>` — things no template can write — while saying nothing
+ * about the components beside them.
+ *
+ * Every judgement here is made on a shape Angular or the CDK defines:
+ * `ɵcmp`/`ɵdir` for a component, `ɵmod` for a module, `InjectionToken` for a
+ * token, `static hostSelector` for a harness, `typeof X` for an alias. None of
+ * them looks at a name.
+ */
+import { describe, it, expect } from 'vitest';
+import ts from 'typescript';
+import { readAngularDeclarations } from '../story-generator/knowledge/angularInputs.js';
+
+const parse = (code: string) =>
+  readAngularDeclarations(ts.createSourceFile('t.d.ts', code, ts.ScriptTarget.Latest, true, ts.ScriptKind.TS));
+
+describe('readAngularDeclarations', () => {
+  it('reads an input, its template name and whether it is required', () => {
+    const out = parse(`
+import * as i0 from '@angular/core';
+declare class MatButton {
+    /** Appearance of the button. */
+    get appearance(): MatButtonAppearance | null;
+    set appearance(value: MatButtonAppearance | '');
+    static ɵcmp: i0.ɵɵComponentDeclaration<MatButton, "button[matButton]", ["matButton"], { "appearance": { "alias": "matButton"; "required": true; }; }, {}, never, never, true, never>;
+}
+`);
+    expect(out).toHaveLength(1);
+    const input = out[0].inputs[0];
+    // The name a template writes is the ALIAS, not the class property.
+    expect(input.name).toBe('matButton');
+    expect(input.property).toBe('appearance');
+    expect(input.required).toBe(true);
+    expect(input.doc).toBe('Appearance of the button.');
+    expect(out[0].selector).toBe('button[matButton]');
+  });
+
+  it('marks an NgModule, an injection token and a test harness as not writable', () => {
+    const out = parse(`
+import * as i0 from '@angular/core';
+declare class MatButtonModule {
+    static ɵmod: i0.ɵɵNgModuleDeclaration<MatButtonModule, never, never, never>;
+}
+declare const MAT_BUTTON_CONFIG: InjectionToken<unknown>;
+declare class MatButtonHarness extends ContentContainerComponentHarness {
+    static hostSelector: string;
+}
+`);
+    expect(out.find(c => c.name === 'MatButtonModule')?.isModule).toBe(true);
+    expect(out.find(c => c.name === 'MAT_BUTTON_CONFIG')?.notWritable).toBe(true);
+    // The harness is two hops from ComponentHarness, so its base class says
+    // nothing here; `static hostSelector` is the CDK's own contract and does.
+    expect(out.find(c => c.name === 'MatButtonHarness')?.notWritable).toBe(true);
+  });
+
+  it('reports an alias so it can take the props of what it aliases', () => {
+    // `export declare const MatAnchor: typeof MatButton` is a real component
+    // under a second name; reading only classes left every one with no props.
+    const out = parse(`
+declare class MatButton {}
+declare const MatAnchor: typeof MatButton;
+`);
+    expect(out.find(c => c.name === 'MatAnchor')?.aliasOf).toBe('MatButton');
+  });
+
+  it('yields nothing for a file that declares no Angular component', () => {
+    // The same walk runs over every file in every project, React included.
+    expect(parse('export interface ButtonProps { size?: string }')).toEqual([]);
+  });
+});

--- a/bench/resolution.mjs
+++ b/bench/resolution.mjs
@@ -555,10 +555,24 @@ async function measure(env) {
    */
   const knownByBase = new Set(
     Object.entries(extractedFacts?.components || {})
-      .filter(([, f]) => (f.sharedBaseOnly || f.namespaceMembers?.length) && !(f.props || []).length)
+      .filter(([, f]) => (f.sharedBaseOnly || f.declaresNoProps || f.namespaceMembers?.length) && !(f.props || []).length)
       .map(([name]) => name),
   );
-  const withProps = components.filter(c => (c.props || []).length > 0 || knownByBase.has(c.name)).length;
+  /**
+   * Exports the compiler proved are not components — an NgModule, an injection
+   * token, a version constant. They were counted as components we knew nothing
+   * about, which is two errors at once: the percentage looked worse than the
+   * knowledge, and the catalog was offering the model something it cannot
+   * write. Excluded from the denominator and reported, never silently dropped.
+   */
+  const notComponents = new Set(
+    Object.entries(extractedFacts?.components || {})
+      .filter(([, f]) => f.notAComponent)
+      .map(([name]) => name),
+  );
+  const judged = components.filter(c => !notComponents.has(c.name));
+  const excluded = components.length - judged.length;
+  const withProps = judged.filter(c => (c.props || []).length > 0 || knownByBase.has(c.name)).length;
   /**
    * WHICH components we know nothing about, not just how many.
    *
@@ -566,7 +580,7 @@ async function measure(env) {
    * are not components — namespace objects, type exports, modules — and the two
    * call for opposite fixes. Named here so the next reader can tell them apart.
    */
-  const noProps = components.filter(c => (c.props || []).length === 0 && !knownByBase.has(c.name)).map(c => c.name);
+  const noProps = judged.filter(c => (c.props || []).length === 0 && !knownByBase.has(c.name)).map(c => c.name);
   /**
    * A description counts only if it says something the component's NAME does
    * not — the same predicate the pipeline uses to decide whether to REPLACE a
@@ -595,6 +609,8 @@ async function measure(env) {
     runtimeOnlyExport,
     knowProps: withProps,
     noProps,
+    judgedComponents: judged.length,
+    excludedNotComponents: excluded,
     totalProps, docedProps, deprecatedProps, defaultedProps,
     knowDescription: withDesc,
     knowExamples: withExamples,
@@ -616,7 +632,8 @@ function report(r) {
       : `  named export present       : n/a — no bare package specifiers in this catalog`)
     : `  named export present       : ${checked - r.missingExport.length}/${checked}  ${pct(checked - r.missingExport.length, checked)}` +
       (r.uncheckedExport.length ? `  (${r.uncheckedExport.length} NOT CHECKED — no readable package entry)` : ''));
-  console.log(`  props known                : ${r.knowProps}/${r.components}  ${pct(r.knowProps, r.components)}`);
+  console.log(`  props known                : ${r.knowProps}/${r.judgedComponents ?? r.components}  ${pct(r.knowProps, r.judgedComponents ?? r.components)}`
+    + (r.excludedNotComponents ? `  (${r.excludedNotComponents} export(s) excluded: the compiler proved they cannot be written as an element)` : ''));
   if (r.noProps?.length) {
     console.log(`    no props known for ${r.noProps.length}: ${r.noProps.slice(0, 14).join(', ')}${r.noProps.length > 14 ? ' …' : ''}`);
   }

--- a/story-generator/knowledge/angularInputs.ts
+++ b/story-generator/knowledge/angularInputs.ts
@@ -47,6 +47,24 @@ export interface AngularInput {
 
 export interface AngularComponentFacts {
   name: string;
+  /**
+   * This class is an NgModule, not something a template can write.
+   *
+   * Angular ships one per component group and discovery admits them all —
+   * MatButtonModule beside MatButton. A catalog that offers a module as a
+   * component invites `<MatButtonModule>`, which renders nothing. Recognised
+   * by the declaration Angular's own compiler emits for it, never by its name.
+   */
+  isModule?: boolean;
+  /**
+   * Not writable in a template for a reason Angular's own types state: an
+   * injection token, or a test harness. Discovery admits both beside the
+   * components, and a catalog offering `<MAT_BUTTON_CONFIG>` teaches the model
+   * something impossible.
+   */
+  notWritable?: boolean;
+  /** This export is another component under a second name: `typeof MatButton`. */
+  aliasOf?: string;
   /** The CSS selector Angular matches — how the component is actually written. */
   selector?: string;
   inputs: AngularInput[];
@@ -109,9 +127,19 @@ function membersOf(arg: ts.TypeNode | undefined): Array<{ property: string; alia
     let required = false;
     if (member.type && ts.isTypeLiteralNode(member.type)) {
       for (const f of member.type.members) {
-        if (!ts.isPropertySignature(f) || !f.name || !ts.isIdentifier(f.name)) continue;
-        if (f.name.text === 'alias') alias = literalText(f.type) ?? undefined;
-        if (f.name.text === 'required') required = isTrue(f.type);
+        if (!ts.isPropertySignature(f) || !f.name) continue;
+        /**
+         * The keys are STRING LITERALS, not identifiers.
+         *
+         * Angular emits `{ "alias": "matButton"; "required": false; }`, and
+         * accepting only identifiers meant neither was ever read: every input
+         * was catalogued under its class property while a template has to
+         * write the alias. `appearance` where the answer is `matButton`.
+         */
+        const key = ts.isIdentifier(f.name) || ts.isStringLiteral(f.name)
+          ? (f.name as ts.Identifier | ts.StringLiteral).text : null;
+        if (key === 'alias') alias = literalText(f.type) ?? undefined;
+        if (key === 'required') required = isTrue(f.type);
       }
     }
     out.push({ property, ...(alias && alias !== property ? { alias } : {}), required });
@@ -151,7 +179,51 @@ export function readAngularDeclarations(source: ts.SourceFile): AngularComponent
   const out: AngularComponentFacts[] = [];
 
   const visit = (node: ts.Node): void => {
+    /**
+     * `declare const X: InjectionToken<…>` and `declare const Y: typeof Z`.
+     *
+     * The first cannot be an element at all; the second IS one, under a second
+     * name — Angular Material exports MatAnchor as `typeof MatButton`, and
+     * reading only classes left every such alias with no props at all.
+     */
+    if (ts.isVariableStatement(node)) {
+      for (const decl of node.declarationList.declarations) {
+        if (!ts.isIdentifier(decl.name) || !decl.type) continue;
+        if (ts.isTypeReferenceNode(decl.type)) {
+          const referenced = ts.isQualifiedName(decl.type.typeName) ? decl.type.typeName.right.text : decl.type.typeName.text;
+          if (referenced === 'InjectionToken') {
+            out.push({ name: decl.name.text, notWritable: true, inputs: [] });
+          }
+        } else if (ts.isTypeQueryNode(decl.type)) {
+          const target = ts.isQualifiedName(decl.type.exprName) ? decl.type.exprName.right.text : decl.type.exprName.text;
+          if (/^[A-Z]/.test(target)) out.push({ name: decl.name.text, aliasOf: target, inputs: [] });
+        }
+      }
+    }
     if (ts.isClassDeclaration(node) && node.name) {
+      const moduleMember = node.members.find(m =>
+        ts.isPropertyDeclaration(m) && m.name && ts.isIdentifier(m.name) && m.name.text === 'ɵmod');
+      if (moduleMember) {
+        out.push({ name: node.name.text, isModule: true, inputs: [] });
+      }
+      /**
+       * A test harness extends the CDK's own base class and is never written
+       * in a template. Judged by what it extends, which Angular declares.
+       */
+      const heritage = node.heritageClauses?.flatMap(h => h.types.map(t => t.expression.getText(source))) ?? [];
+      /**
+       * `static hostSelector` is the CDK's harness contract — the selector a
+       * harness searches for. A component never declares it, and a harness
+       * always does, so the shape identifies one whichever base class it
+       * extends: MatButtonHarness extends ContentContainerComponentHarness,
+       * two hops from ComponentHarness and invisible from this file.
+       */
+      const hasHostSelector = node.members.some(m =>
+        ts.isPropertyDeclaration(m) && m.name && ts.isIdentifier(m.name) && m.name.text === 'hostSelector'
+        && m.modifiers?.some(mod => mod.kind === ts.SyntaxKind.StaticKeyword));
+      if (hasHostSelector || heritage.some(h => /(^|\.)ComponentHarness$/.test(h) || /(^|\.)HarnessPredicate$/.test(h))) {
+        out.push({ name: node.name.text, notWritable: true, inputs: [] });
+      }
       for (const member of node.members) {
         if (!ts.isPropertyDeclaration(member) || !member.type || !member.name) continue;
         const memberName = ts.isIdentifier(member.name) ? member.name.text : null;

--- a/story-generator/knowledge/propExtractor.ts
+++ b/story-generator/knowledge/propExtractor.ts
@@ -45,7 +45,7 @@ function declaresReact(root: string): boolean {
 }
 
 /** Angular's compiler-emitted declaration types; see knowledge/angularInputs.ts. */
-const ANGULAR_DECLARATION = /ɵɵ(Component|Directive)Declaration/;
+const ANGULAR_DECLARATION = /ɵɵ(Component|Directive)Declaration|ComponentHarness/;   // a harness file declares neither a component nor a "Prop", and holds the exports to EXCLUDE
 import fs from 'fs';
 import path from 'path';
 import { contentFingerprint, knowledgeCacheFile, pruneStaleKnowledge } from './cacheKey.js';
@@ -146,6 +146,15 @@ export interface ComponentFacts {
    * of them one prop that library moved out of the component.
    */
   propsAreClosed?: boolean;
+  /**
+   * Resolved, and it declares no props at all.
+   *
+   * Angular's MatIconButton is a real component whose input map is empty. An
+   * empty prop list would otherwise mean "we could not read it", so it was
+   * counted as unknown alongside the injection tokens and test harnesses —
+   * the same absent-versus-zero conflation, one more time.
+   */
+  declaresNoProps?: boolean;
 }
 
 export interface ExtractedProps {
@@ -850,8 +859,32 @@ function collectFromFile(
       : { name: component.name, props };
   }
 
+  const angularAliases: Array<{ name: string; aliasOf: string }> = [];
   for (const component of readAngularDeclarations(source)) {
-    if (!component.inputs.length) continue;
+    if (component.aliasOf) {
+      angularAliases.push({ name: component.name, aliasOf: component.aliasOf });
+      continue;
+    }
+    if (component.notWritable) {
+      const prior = out[component.name];
+      out[component.name] = { ...(prior ?? { name: component.name, props: [] }), notAComponent: true };
+      continue;
+    }
+    if (component.isModule) {
+      // An NgModule is not something a template writes. Marked so the catalog
+      // stops offering it beside the components it declares.
+      const prior = out[component.name];
+      out[component.name] = { ...(prior ?? { name: component.name, props: [] }), notAComponent: true };
+      continue;
+    }
+    if (!component.inputs.length) {
+      // A component with an empty input map declares nothing — a fact, not a gap.
+      const prior = out[component.name];
+      if (!prior || !prior.props.length) {
+        out[component.name] = { ...(prior ?? { name: component.name, props: [] }), declaresNoProps: true };
+      }
+      continue;
+    }
     const props: PropFact[] = component.inputs.map(input => ({
       name: input.output ? `(${input.name})` : input.name,
       required: input.required,
@@ -863,6 +896,19 @@ function collectFromFile(
       ? { ...prior, props: mergeProps(prior.props, props) }
       : { name: component.name, props };
   }
+
+  /**
+   * An alias takes the props of what it aliases. Applied after the pass so the
+   * target has been read, whichever order the declarations appear in.
+   */
+  for (const { name, aliasOf } of angularAliases) {
+    const target = out[aliasOf];
+    if (!target || !target.props.length) continue;
+    const prior = out[name];
+    if (prior && prior.props.length) continue;
+    out[name] = { ...(prior ?? { name, props: [] }), props: target.props, doc: target.doc };
+  }
+
 }
 
 /**
@@ -1338,6 +1384,13 @@ function mergeComponents(
     const prior = into[name];
     into[name] = prior
       ? {
+          // Spread both sides FIRST: this rebuilt the entry from four named
+          // fields, so every fact added since — that an export is a namespace,
+          // an NgModule, a component declaring nothing, or one whose prop set
+          // the compiler closed — was silently dropped whenever a package was
+          // merged. The flags were written and never survived to a reader.
+          ...facts,
+          ...prior,
           name,
           props: mergeProps(prior.props, facts.props),
           variants: prior.variants ?? facts.variants,


### PR DESCRIPTION

The resolution bench measured Angular Material at 0 of 309 components with
known props, and the 309 was itself wrong: it counted NgModules, injection
tokens and test harnesses as components. That catalog offered a model
<MatButtonModule> and <MAT_BUTTON_CONFIG> — things no template can write —
while saying nothing about the components beside them.

Each judgement is made on a shape Angular or the CDK defines. ɵcmp and ɵdir
declare a component and its inputs. ɵmod declares a module. A const typed
InjectionToken is a token. `static hostSelector` is the CDK's harness
contract, which identifies a harness two hops from ComponentHarness where the
base class says nothing. `typeof MatButton` is a component under a second
name, and takes that component's props. No rule looks at a name.

A component whose input map is empty is recorded as declaring no props rather
than counted as unreadable — the same absent-versus-zero conflation, one more
time.

Two bugs found by writing the tests. Angular emits those input maps with
STRING-LITERAL keys, so `alias` and `required` were never read and every input
was catalogued under its class property — `appearance` where a template must
write `matButton`. And mergeComponents rebuilt each entry from four named
fields, so every fact added since — namespace, module, closed prop set,
declares-nothing — was silently dropped whenever packages were merged.

Angular Material: 0% → 84% props known (125 of 149), 160 exports excluded.
Fluent moved 91% → 93% from the merge fix. No other environment changed.



https://claude.ai/code/session_0158a8zxX4SKPdxm7DLfgqp4
