### PR TITLE
fix(generator): say that controls on one line share a vertical centre

### DIFF
--- a/__tests__/spacing-vocabulary.test.ts
+++ b/__tests__/spacing-vocabulary.test.ts
@@ -76,6 +76,11 @@ describe('deriveSpacingVocabulary', () => {
     expect(rules).toContain('SIZE TO ITS CONTENT');
     expect(rules).toContain('space-between/space-around/space-evenly');
     expect(rules).toContain('Spare width belongs OUTSIDE the group');
+    // The only defect that shipped as a blocker on all three design systems
+    // measured: a row whose controls do not share a vertical centre. The probe
+    // said it; the prompt did not.
+    expect(rules).toContain('SHARE A VERTICAL CENTRE');
+    expect(rules).toContain('align-items: center');
   });
 
   it('reads the spacing scale from tokens whose name says spacing AND whose value is a length, sorted by size', () => {

--- a/story-generator/knowledge/spacingFacts.ts
+++ b/story-generator/knowledge/spacingFacts.ts
@@ -567,6 +567,22 @@ export function formatSpacingRules(
   // the spare width, leaving a 300px void between two buttons. Rule 3 named
   // the right container and never ruled out the wrong one, so this states the
   // prohibition in the same words the layout probe uses when it catches it.
+  /**
+   * The single most common defect in a story that ships carrying an issue.
+   *
+   * Measured across three design systems: the same prompt — a settings page
+   * with a sticky save bar — was the ONLY story to ship with a blocker on
+   * Carbon, on Sail Shelf and on Material, and in all three the blocker was
+   * the same, a row whose controls do not share a vertical centre. The layout
+   * probe says exactly this when it catches one; the prompt never said it. It
+   * appeared only inside a fallback code example that a design system with its
+   * own row primitive never sees — which is every library where this failed.
+   */
+  lines.push('   Controls on one line SHARE A VERTICAL CENTRE. A row of mixed heights — a button beside');
+  lines.push('   an input, a heading beside an action — sags unless the row centres them: use the row');
+  lines.push('   primitive\'s own alignment prop, or align-items: center on the container. If one control');
+  lines.push('   has a label above it and the others do not, they no longer share a centre; give them the');
+  lines.push('   same treatment or align the row to its bottom edge instead.');
   lines.push('   The row must SIZE TO ITS CONTENT. Never let a container distribute its spare width');
   lines.push('   between the buttons — no space-between/space-around/space-evenly on a row of two or');
   lines.push('   three controls, and no grid whose auto tracks stretch to fill the container. Both put');


### PR DESCRIPTION

Every story that shipped carrying a blocker tonight was the same prompt — a
settings page with a sticky save bar — and on Carbon, on Sail Shelf and on
Material the blocker was the same defect: a row whose controls do not share a
vertical centre, so the row sags. One prompt, three unrelated design systems,
one cause.

The layout probe says exactly this when it catches one. The prompt never did.
The rule existed only inside a fallback code example shown to design systems
that have no row primitive of their own — which is not one of the three where
this failed, because all of them have one.

It is now stated where the spacing rules are read, in the probe's own words,
including the case that produces it most often: one control carrying a label
above it while its neighbours do not.

Whether it moves the number is the next measurement. It is the second attempt
at this defect family — the first ruled out the container that spreads a row —
and they are different failures, one horizontal and one vertical.



https://claude.ai/code/session_0158a8zxX4SKPdxm7DLfgqp4
