### PR TITLE
fix(generator): a component that takes only children is known, not unknown

### DIFF
--- a/story-generator/knowledge/propExtractor.ts
+++ b/story-generator/knowledge/propExtractor.ts
@@ -1757,10 +1757,22 @@ async function readOnePackage(
           // `open` counts too: a component whose props type admits extra keys
           // still resolved a definite styling surface, and reporting it as
           // unknown was the same conflation this comment block exists to stop.
-          if (component.own.length || component.verdict === 'unknown' || component.total <= SUBSTANTIAL_TOTAL) continue;
+          if (component.own.length || component.verdict === 'unknown') continue;
           const prior = components[component.name];
           if (prior && prior.props.length) continue;
-          components[component.name] = { ...(prior ?? { name: component.name, props: [] }), sharedBaseOnly: true };
+          /**
+           * Two ways to declare nothing, and both were counted as unknown.
+           *
+           * A component that spreads a styling surface declares nothing of its
+           * own beyond it. A render-prop component — Chakra ships one per
+           * compound component, `(props: ContextProps) => ReactNode` — declares
+           * nothing beyond `children`. The first was recorded and the second
+           * was not, because the rule required a large resolved set, so 51
+           * components on one library read as "we know nothing" when the truth
+           * was "it takes children".
+           */
+          const marker = component.total > SUBSTANTIAL_TOTAL ? { sharedBaseOnly: true } : { declaresNoProps: true };
+          components[component.name] = { ...(prior ?? { name: component.name, props: [] }), ...marker };
           baseOnly++;
         }
         logger.log(


### PR DESCRIPTION

Two ways to declare nothing, and only one was recorded. A component that
spreads its library's styling surface declares nothing of its own beyond it —
already handled. A render-prop component declares nothing beyond `children`,
and was not, because the rule required a large resolved set before it would
believe the emptiness.

Chakra ships one such component per compound component, typed
`(props: ContextProps) => ReactNode`. Fifty-one of them read as "we know
nothing about this" when the truth was "it takes children" — the same
absent-versus-zero conflation this codebase keeps paying for, in the one place
left that still had it.

Chakra now reports 754 of 754 components known, up from 90 at the start of the
session. Fluent reaches 100% for the same reason. No other environment moved.



https://claude.ai/code/session_0158a8zxX4SKPdxm7DLfgqp4
