### PR TITLE
fix(generator): join a package's default export to the name the project uses

### DIFF
--- a/bench/resolution.mjs
+++ b/bench/resolution.mjs
@@ -430,7 +430,12 @@ async function measure(env) {
     extractedFacts = extracted;
     if (extracted) {
       for (const component of components) {
-        const facts = extracted.components[component.name];
+        // Same join the pipeline makes: a package's default export under the
+        // name the project actually imports it by.
+        const facts = extracted.components[component.name]
+          ?? (component.__componentPath && extracted.defaultExports?.[component.__componentPath]
+            ? extracted.components[extracted.defaultExports[component.__componentPath]]
+            : undefined);
         if (!facts) continue;
         if (!component.props || component.props.length === 0) {
           component.props = rankProps(facts.props).map(p => `${p.name}${p.required ? '' : '?'}`);

--- a/mcp-server/routes/generationCore.ts
+++ b/mcp-server/routes/generationCore.ts
@@ -654,7 +654,21 @@ async function runStoryGenerationPipeline(
       let enriched = 0;
       let describedFromTypes = 0;
       for (const component of components as any[]) {
-        const facts = extracted.components[component.name];
+        /**
+         * A package-per-component library exports its component as the
+         * default, and the value's own declaration often names it something
+         * else: `@atlaskit/tag`'s default is declared `RemovableTag` while the
+         * project imports it as `Tag`. Neither half can resolve that alone —
+         * discovery holds the name in use, the extractor holds the package's
+         * default — so they are joined here, and only when nothing was found
+         * under the name itself.
+         */
+        const facts = extracted.components[component.name]
+          ?? (() => {
+            const home = component.__componentPath;
+            const declared = home && extracted.defaultExports?.[home];
+            return declared ? extracted.components[declared] : undefined;
+          })();
         if (!facts) continue;
         /**
          * A component that adds nothing to its library's styling surface is a

--- a/story-generator/knowledge/checkerProps.ts
+++ b/story-generator/knowledge/checkerProps.ts
@@ -80,6 +80,16 @@ export interface ResolvedComponent {
 
 export interface CheckerPropsResult {
   components: ResolvedComponent[];
+  /**
+   * The name the package's DEFAULT export declares for itself.
+   *
+   * A package-per-component library exports its component as the default, and
+   * the value's own declaration often names it something else — Atlassian's
+   * `@atlaskit/tag` default is declared `RemovableTag`, while everyone imports
+   * it as `Tag`. Reported so a caller holding the name discovery uses can join
+   * the two; neither half can do it alone.
+   */
+  defaultExport?: string;
   /** Props shared by nearly every component, treated as the library's base. */
   baseProps: string[];
   /** False when no program could be built; distinct from "resolved nothing". */
@@ -454,5 +464,5 @@ export function resolvePropsWithChecker(opts: {
     });
   }
 
-  return { components, baseProps, ran: true, ms: Date.now() - started };
+  return { components, baseProps, ran: true, ms: Date.now() - started, ...(defaultName ? { defaultExport: defaultName } : {}) };
 }

--- a/story-generator/knowledge/propExtractor.ts
+++ b/story-generator/knowledge/propExtractor.ts
@@ -165,6 +165,15 @@ export interface ExtractedProps {
   components: Record<string, ComponentFacts>;
   /** Interfaces that declare nothing locally, so callers can be honest about gaps. */
   inheritedOnly: string[];
+  /**
+   * Package name -> the name that package's default export declares.
+   *
+   * The join a package-per-component library needs: discovery knows a
+   * component as `Tag` because that is how the project imports it, while the
+   * library's own declaration calls the same value `RemovableTag`. Recorded
+   * here so an enrichment holding both can put them together.
+   */
+  defaultExports?: Record<string, string>;
   extractedAt: string;
   /**
    * Packages this one re-exports from, when it is a barrel over siblings.
@@ -1636,6 +1645,7 @@ async function readOnePackage(
   const files = filesToRead();
   const components: Record<string, ComponentFacts> = {};
   const inheritedOnly: string[] = [];
+  const defaultExports: Record<string, string> = {};
   const allTypes: Record<string, PropFact[]> = {};
   const links: PropsTypeLink[] = [];
   const registry: TypeTextRegistry = { aliases: new Map(), tuples: new Map() };
@@ -1711,6 +1721,7 @@ async function readOnePackage(
   if (declaresReact(root)) {
     try {
       const checked = resolvePropsWithChecker({ projectRoot, importPath: pkgName, storiesDir: projectRoot });
+      if (checked.defaultExport) defaultExports[pkgName] = checked.defaultExport;
       if (!checked.ran) {
         logger.log(`🧠 Type resolution for ${pkgName}: did not run — ${checked.reason}`);
       } else {
@@ -1798,6 +1809,7 @@ async function readOnePackage(
     version,
     components,
     inheritedOnly,
+    ...(Object.keys(defaultExports).length ? { defaultExports } : {}),
     extractedAt: new Date().toISOString(),
     reexportedFrom,
   };
@@ -1947,6 +1959,7 @@ export async function extractPropsForPackages(
 
   const merged: Record<string, ComponentFacts> = {};
   const inheritedOnly: string[] = [];
+  const defaultExports: Record<string, string> = {};
   let any = false;
 
   for (const pkg of unique) {
@@ -1957,6 +1970,14 @@ export async function extractPropsForPackages(
       const prior = merged[name];
       merged[name] = prior
         ? {
+            // Spread first, for the same reason mergeComponents does: this is
+            // a second copy of that merge, and rebuilding an entry from four
+            // named fields drops every fact added since — namespace, module,
+            // closed prop set, declares-nothing. A package-per-component
+            // library goes through THIS path, so the flags were being lost on
+            // exactly the libraries that need them most.
+            ...facts,
+            ...prior,
             name,
             props: mergeProps(prior.props, facts.props),
             variants: prior.variants ?? facts.variants,
@@ -1965,6 +1986,7 @@ export async function extractPropsForPackages(
         : facts;
     }
     for (const n of one.inheritedOnly) if (!inheritedOnly.includes(n)) inheritedOnly.push(n);
+    Object.assign(defaultExports, one.defaultExports ?? {});
   }
 
   if (!any) return null;
@@ -1973,6 +1995,7 @@ export async function extractPropsForPackages(
     importPath: unique.join(','),
     components: merged,
     inheritedOnly,
+    ...(Object.keys(defaultExports).length ? { defaultExports } : {}),
     extractedAt: new Date().toISOString(),
   };
 }


### PR DESCRIPTION

A package-per-component library exports its component as the default, and the
value's own declaration often names it something else: @atlaskit/tag's default
is declared RemovableTag while every project imports it as Tag. Neither half
of the system could resolve that alone — discovery holds the name in use, the
extractor holds what the package's default declares — so the component
appeared in the catalog with no props at all.

The extractor now records, per package, the name its default export declares,
and the enrichment joins the two when nothing was found under the name itself.
Both the pipeline and the resolution bench make the same join, so the bench
still measures what the model is actually given.

Also fixes a second copy of the merge bug: extractPropsForPackages rebuilt
each entry from four named fields, dropping every fact added since — namespace,
module, closed prop set, declares-nothing. That path is the one a
package-per-component library takes, so the flags were being lost on precisely
the libraries that need them.

Atlassian: 81% → 84% props known, with Tag and TeamsAvatar resolved. The
remaining ten are higher-order components and utilities that are callable and
therefore indistinguishable from components by signature, plus constants from
a package that is not a component library. That is the floor for this
approach, and it is two attempts, so I am stopping there.



https://claude.ai/code/session_0158a8zxX4SKPdxm7DLfgqp4
