### PR TITLE
fix(generator): a container is not a content-hugging control

### DIFF
--- a/__tests__/layout-probe.test.ts
+++ b/__tests__/layout-probe.test.ts
@@ -156,6 +156,33 @@ describe.runIf(tooling)('layout probe — stretched hug-content controls', { ret
     expect(hits[0].message).toContain('align-self: start');
   }, 30_000);
 
+  it('leaves a sticky action bar alone: a container is not a control', async () => {
+    /**
+     * The most expensive false positive in the suite. A sticky save bar has a
+     * background colour by necessity — without one the page scrolls under it —
+     * which made it "decorated", its two buttons give it the text
+     * "CancelSave changes" at 18 characters, and its height is a bar's height.
+     * It was reported as a content-hugging tag rendered 904px wide when full
+     * width is what a save bar is FOR.
+     *
+     * It was the only story shipping with an issue, the only one burning all
+     * three gate attempts, and the entire p90 tail, on three unrelated design
+     * systems. Four prompt rules were written against it and none could work,
+     * because the composition was correct every time.
+     */
+    const bar = `<div style="background:#f4f4f4;height:48px;display:flex;align-items:center;gap:8px;padding:0 8px">${button('Cancel')}${button('Save changes')}</div>`;
+    const r = await probe(columnStack(bar + '<p>copy</p>'));
+    expect(r.problems.filter(p => p.kind === 'stretched_control')).toHaveLength(0);
+  }, 30_000);
+
+  it('still flags a real pill that merely sits beside a control', async () => {
+    // The exclusion is about what an element CONTAINS, not what is near it: a
+    // stretched tag next to a button is still a stretched tag.
+    const r = await probe(columnStack(pill('New') + button('Save') + '<p>copy</p>'));
+    const hits = r.problems.filter(p => p.kind === 'stretched_control');
+    expect(hits.some(h => h.message.includes('208px wide'))).toBe(true);
+  }, 30_000);
+
   it('leaves an element the source sized on purpose alone', async () => {
     // `width: 100%` is a decision. The computed width is the same number as
     // a stretch, so this has to be read from what was written.

--- a/story-generator/verify/probes/layout.ts
+++ b/story-generator/verify/probes/layout.ts
@@ -336,6 +336,30 @@ export async function runLayoutProbe(page: any, options: LayoutOptions = {}): Pr
       if (r.height > 64) return false;
       const descendants = (Array.from(el.querySelectorAll('*')) as Element[]).filter(d => !d.parentElement?.closest('svg'));
       if (descendants.length > 4) return false;
+      /**
+       * An element containing a control is a CONTAINER, not a control.
+       *
+       * `decorated` above admits anything with a background colour, and a
+       * sticky action bar has one by necessity — without it the page scrolls
+       * under the bar. With two buttons inside, its text reads
+       * "CancelSave changes", 18 characters, and its height is a bar's height,
+       * so it passed every test here and was reported as a content-hugging tag
+       * rendered 904px wide. It is full width BY DESIGN.
+       *
+       * That false positive was the single most expensive finding in the
+       * suite: the only story shipping with an issue, the only one burning all
+       * three gate attempts, and the whole p90 tail — on Carbon, Sail Shelf and
+       * Material alike. Four prompt rules were written against it and none
+       * could work, because the composition was correct every time. The last
+       * one carried BOTH remedies the tool had asked for, `justifySelf: start`
+       * and `alignItems: center`, and was still reported.
+       *
+       * A tag, pill or badge contains text and perhaps an icon. It never
+       * contains a button.
+       */
+      if (el.querySelector('button, a[href], [role="button"], [role="tab"], [role="menuitem"], input, select, textarea')) {
+        return false;
+      }
       const t = (el.textContent || '').trim();
       return t.length > 0 && t.length <= 40;
     };


### PR DESCRIPTION

The stretched-control check accepts any element that is "decorated" — has a
background colour, a border, or a background image — with short text and few
descendants. A sticky action bar has a background by necessity, or the page
scrolls under it. With two buttons inside, its text reads "CancelSave changes",
eighteen characters, and its height is a bar's height. So it passed every test
and was reported as a content-hugging tag rendered 904px wide, when full width
is what a save bar is for.

This was the most expensive finding in the suite. One prompt — a settings page
with a sticky save bar — was the only story shipping with an issue, the only
one burning all three gate attempts, and the entire p90 tail, on Carbon, Sail
Shelf and Material alike. Four prompt rules were written against it over the
session and none of them could have worked: the composition was correct every
time. The last one carried BOTH remedies the tool had asked for,
justifySelf: start and alignItems: center, and was reported anyway.

Reading the story rather than the finding's name is what found it. A tag, pill
or badge contains text and perhaps an icon; it never contains a button. An
element containing a control is a container.

Tested both directions: a sticky bar of two buttons is left alone, and a real
pill sitting beside a button is still flagged — the exclusion is about what an
element contains, not what is near it.



https://claude.ai/code/session_0158a8zxX4SKPdxm7DLfgqp4
