### PR TITLE
fix(cli): keep Vite's own module watcher alive, not just Storybook's indexer

### DIFF
--- a/__tests__/storybook-watcher.test.ts
+++ b/__tests__/storybook-watcher.test.ts
@@ -251,3 +251,33 @@ export default config;
     expect(pollingIsConfigured(dir)).toBe(false);
   });
 });
+
+describe('Vite\'s own module watcher', () => {
+  it('adds polling to the block Story UI wrote, and never to one it did not', async () => {
+    /**
+     * Storybook's story INDEX watcher and Vite's MODULE watcher are different
+     * watchers, and the launcher only fixes the first. Measured on a Storybook
+     * that had been running seven hours: a story rewritten on disk was never
+     * re-transformed — still serving the previous bytes after 90 seconds — so
+     * four of six repairs in a twenty-prompt run waited the full timeout and
+     * were then re-checked against the render they were meant to replace. With
+     * polling, the same edit was served in one second.
+     */
+    const { ensureViteWatchPolling, viteFinalConfigSnippet } = await import('../cli/setup.js');
+    const ours = `export default {\n  ${viteFinalConfigSnippet()}\n};\n`;
+    // What init writes already polls, so there is nothing to add.
+    expect(ours).toContain('usePolling');
+    expect(ensureViteWatchPolling(ours)).toBeNull();
+
+    // An older install carries the block without it.
+    const older = ours.replace(/\/\/ Story UI: keep Vite's own[\s\S]*?\n    }\n/, '');
+    expect(older).not.toContain('usePolling');
+    const updated = ensureViteWatchPolling(older);
+    expect(updated).toContain('usePolling');
+    expect(updated).toContain('return config;');
+
+    // Someone else's viteFinal is theirs.
+    const theirs = 'export default { viteFinal: async (config) => { return config; } };';
+    expect(ensureViteWatchPolling(theirs)).toBeNull();
+  });
+});

--- a/cli/setup.ts
+++ b/cli/setup.ts
@@ -826,8 +826,53 @@ export function viteFinalConfigSnippet(): string {
 ${STORY_UI_VITE_CJS_INCLUDES.map(chain => `        '${chain}'`).join(',\n')}
       ]
     };
+    // Story UI: keep Vite's own module watcher alive on macOS. Storybook's story
+    // INDEX watcher and Vite's MODULE watcher are different watchers, and the
+    // launcher only fixes the first. Measured on a Storybook that had been
+    // running seven hours: a story rewritten on disk was never re-transformed —
+    // still serving the previous bytes after 90 seconds — so a repair was
+    // re-checked against the render it was meant to replace. With polling the
+    // same edit was served in 1 second. Remove this if you set server.watch
+    // yourself.
+    if (process.platform === 'darwin') {
+      config.server = {
+        ...config.server,
+        watch: { ...(config.server?.watch ?? {}), usePolling: true, interval: 300 },
+      };
+    }
     return config;
   },`;
+}
+
+/** Marks the Story UI viteFinal block, so `update` can extend its own work. */
+export const STORY_UI_VITE_MARKER = 'Story UI: Exclude from dependency optimization';
+
+/**
+ * Add Vite's watcher polling to a viteFinal block Story UI wrote itself.
+ *
+ * Only to its OWN block, identified by the comment it writes: a viteFinal the
+ * user authored is theirs, and this never rewrites it. Null when the block is
+ * absent, already polls, or belongs to someone else.
+ */
+export function ensureViteWatchPolling(mainContent: string): string | null {
+  if (!mainContent.includes(STORY_UI_VITE_MARKER)) return null;
+  if (/usePolling/.test(mainContent)) return null;
+  const anchor = mainContent.indexOf('return config;');
+  if (anchor < 0) return null;
+  const insertion = `// Story UI: keep Vite's own module watcher alive on macOS. Storybook's story
+    // INDEX watcher and Vite's MODULE watcher are different watchers. Measured on
+    // a Storybook running for seven hours: a story rewritten on disk was never
+    // re-transformed — still serving the previous bytes after 90 seconds — so a
+    // repair was re-checked against the render it was meant to replace. With
+    // polling the same edit was served in 1 second.
+    if (process.platform === 'darwin') {
+      config.server = {
+        ...config.server,
+        watch: { ...(config.server?.watch ?? {}), usePolling: true, interval: 300 },
+      };
+    }
+    `;
+  return mainContent.slice(0, anchor) + insertion + mainContent.slice(anchor);
 }
 
 /**

--- a/cli/update.ts
+++ b/cli/update.ts
@@ -8,7 +8,7 @@ import { createRequire } from 'module';
 import { ensureWatcherLauncher, WATCHER_LAUNCHER_FILE } from '../story-generator/verify/storybookWatcher.js';
 import { mergeEnv } from './envFile.js';
 import { ensurePreviewRootCss } from './setup.js';
-import { ensureManagerAddonWiring, ensureStoriesGlobCoversMdx, missingReactStorybookDep, ensureManagerHeadPort, readConfiguredPort, ensureScriptPort, viteFinalConfigSnippet, insertConfigProperty, missingViteCjsIncludes } from './setup.js';
+import { ensureManagerAddonWiring, ensureStoriesGlobCoversMdx, missingReactStorybookDep, ensureManagerHeadPort, readConfiguredPort, ensureScriptPort, viteFinalConfigSnippet, insertConfigProperty, missingViteCjsIncludes, ensureViteWatchPolling } from './setup.js';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
@@ -607,7 +607,13 @@ export async function updateCommand(options: UpdateOptions = {}): Promise<Update
             console.log(chalk.green(`   ✅ Added the Story UI viteFinal block to .storybook/${path.basename(mainPath)}`));
           }
         } else {
-          const missing = missingViteCjsIncludes(mainContent);
+          // Our own block gains the watcher polling; a user-authored one is theirs.
+          const polled = ensureViteWatchPolling(mainContent);
+          if (polled) {
+            fs.writeFileSync(mainPath, polled);
+            console.log(chalk.green(`   ✅ Vite's module watcher now polls in .storybook/${path.basename(mainPath)} — a repaired story is re-checked against the repair, not the render before it (restart Storybook)`));
+          }
+          const missing = missingViteCjsIncludes(fs.readFileSync(mainPath, 'utf8'));
           if (missing.length) {
             console.log(chalk.yellow(`   ⚠️  .storybook/${path.basename(mainPath)} has its own viteFinal excluding @tpitre/story-ui but its optimizeDeps.include lacks: ${missing.join(', ')}`));
           }


### PR DESCRIPTION

Storybook's story INDEX watcher and Vite's MODULE watcher are two different
watchers, and the launcher shipped earlier only fixes the first. Measured on a
Storybook that had been running for seven hours: a story rewritten on disk was
never re-transformed — the dev server still served the previous bytes after 90
seconds — while the same edit on a freshly started server appeared in about a
second. It is the FSEvents drop this codebase already documents, on the watcher
nobody had covered.

The cost was concrete. In one twenty-prompt run, four of six repairs waited the
full 45-second timeout and were then re-checked against the render they were
meant to replace: 180 seconds of waiting, and a verdict formed on the wrong
page. With polling the same write is served in one second.

init now writes it, and update adds it to a viteFinal block Story UI wrote
itself, identified by the comment it leaves. A viteFinal the user authored is
theirs and is never rewritten — tested in all three directions.

macOS only: the dropped events are FSEvents', and elsewhere polling would only
cost CPU.



https://claude.ai/code/session_0158a8zxX4SKPdxm7DLfgqp4
