### PR TITLE
fix(generator): a grid of cards is not a row of controls

### DIFF
--- a/__tests__/layout-probe.test.ts
+++ b/__tests__/layout-probe.test.ts
@@ -327,6 +327,27 @@ describe.runIf(tooling)('layout probe — rhythm: rows line up', { retry: 2 }, (
     expect(hits[0].message).toContain('align-items: center');
   }, 30_000);
 
+  it('does not call controls in separate cards a row', async () => {
+    /**
+     * Three product cards side by side, one product name wrapping to a second
+     * line, so its "Add to cart" button sits 8px lower than its neighbours'.
+     * Grouping by geometry alone made those three buttons a row and told the
+     * composition to "put them in one row container with align-items: center"
+     * — which cannot be done to buttons in three different cards. The gate
+     * regenerated the story, the finding came back, and the run cost 354s.
+     *
+     * Cards of unequal height are a real defect and a different check reports
+     * them in terms a composition can act on. A row is something with one
+     * parent.
+     */
+    const card = (lines: string) =>
+      `<div style="display:flex;flex-direction:column;gap:8px;width:180px;padding:8px;border:1px solid #ccc">
+         <span style="font-size:12px">${lines}</span>${btn(36, 'Add to cart')}</div>`;
+    const r = await probe(`<div style="display:flex;gap:12px;align-items:flex-start">
+      ${card('Short name')}${card('A much longer product name that wraps onto two lines')}${card('Short name')}</div>`);
+    expect(r.problems.filter(p => p.kind === 'row_misaligned')).toHaveLength(0);
+  }, 30_000);
+
   it('passes the same row once every control shares a centre', async () => {
     const r = await probe(`<div style="display:flex;align-items:flex-end;gap:12px;padding:16px">
       ${field(36, 'Search')}${field(36, 'Status')}${btn()}</div>`);

--- a/story-generator/verify/probes/layout.ts
+++ b/story-generator/verify/probes/layout.ts
@@ -928,6 +928,42 @@ export async function runLayoutProbe(page: any, options: LayoutOptions = {}): Pr
       .filter(el => isVisible(el) && el.getBoundingClientRect().height > 0)
       .slice(0, 120);
 
+    /**
+     * Are these two controls in repeated cells of a collection?
+     *
+     * Grouping by geometry alone made a row out of the "Add to cart" buttons
+     * of three separate product cards: one product name wrapped to a second
+     * line, so its button sat 8px lower, and the check told the composition to
+     * "put them in one row container with align-items: center" — impossible for
+     * buttons in three different cards. The gate regenerated, the finding came
+     * back, and the run cost 354s.
+     *
+     * The signal is repetition. A card grid is sibling cells with the same tag
+     * and the same classes; a control row is heterogeneous — a labelled field
+     * beside a bare button. Requiring a shared PARENT was tried first and was
+     * too strict: it lost the real defect, where a field wraps its input and
+     * the button does not.
+     *
+     * Cards of unequal height are a genuine defect, and a different check
+     * reports them in terms a composition can act on.
+     */
+    const cellOf = (el: HTMLElement, stop: HTMLElement): HTMLElement | null => {
+      let node: HTMLElement | null = el;
+      while (node && node.parentElement && node.parentElement !== stop) node = node.parentElement;
+      return node && node.parentElement === stop ? node : null;
+    };
+    const repeatedCells = (a: HTMLElement, b: HTMLElement): boolean => {
+      let common: HTMLElement | null = a.parentElement;
+      while (common && !common.contains(b)) common = common.parentElement;
+      if (!common) return false;
+      const ca = cellOf(a, common);
+      const cb = cellOf(b, common);
+      if (!ca || !cb || ca === cb) return false;
+      // Same element type and same classes, and neither IS the control: a
+      // repeated cell, not a peer control.
+      return ca !== a && cb !== b && ca.tagName === cb.tagName && ca.className === cb.className;
+    };
+
     /** Controls that share a horizontal band and do not overlap horizontally. */
     const rows: HTMLElement[][] = [];
     for (const el of controls) {
@@ -938,7 +974,25 @@ export async function runLayoutProbe(page: any, options: LayoutOptions = {}): Pr
         const sameBand = overlap > Math.min(r.height, o.height) * 0.5;
         const sideBySide = r.left >= o.right - 1 || o.left >= r.right - 1;
         // A control nested inside another (a button in a combobox) is not a peer.
-        return sameBand && sideBySide && !el.contains(other) && !other.contains(el);
+        /**
+         * And a peer must share a parent.
+         *
+         * Grouping by geometry alone made a row out of controls in different
+         * containers: the "Add to cart" buttons of three separate product
+         * cards were reported as one row whose centres were 8px apart —
+         * because one product's name wrapped to a second line. The remedy this
+         * check prints is "put them in one row container with
+         * align-items: center", which cannot be done to buttons in three
+         * different cards, so the gate regenerated the story and the finding
+         * came back. Measured: 354s and one wasted regeneration.
+         *
+         * Cards of unequal height ARE a real defect, and a different check
+         * says so in terms a composition can act on — c06's "the three tier
+         * cards do not line up". This one is about a row, and a row is
+         * something with one parent.
+         */
+        return sameBand && sideBySide && !repeatedCells(el, other)
+          && !el.contains(other) && !other.contains(el);
       }));
       if (row) row.push(el); else rows.push([el]);
     }


### PR DESCRIPTION

The row-alignment check grouped controls by geometry alone, so the "Add to
cart" buttons of three separate product cards became one row. One product name
wrapped to a second line, its button sat 8px lower, and the check told the
composition to "put them in one row container with align-items: center" —
which cannot be done to buttons in three different cards. The gate regenerated
the story, the finding came back, and that prompt cost 354s and a wasted
regeneration.

The signal is repetition: a card grid is sibling cells with the same tag and
the same classes, while a control row is heterogeneous — a labelled field
beside a bare button. Requiring a shared parent was tried first and was too
strict: it lost the real defect, where a field wraps its input and the button
does not, and the existing test caught that immediately.

Cards of unequal height are a genuine defect and a different check already
reports them in terms a composition can act on — "the three tier cards do not
line up".

Second false positive found the same way as the first: by reading what the
story actually rendered instead of the finding's name.



https://claude.ai/code/session_0158a8zxX4SKPdxm7DLfgqp4
