### PR TITLE
fix(generator): let the compiler decide which props are real

### DIFF
--- a/story-generator/knowledge/checkerProps.ts
+++ b/story-generator/knowledge/checkerProps.ts
@@ -70,6 +70,16 @@ export interface ResolvedComponent {
   /** Everything the compiler resolved, including the shared base. */
   total: number;
   /**
+   * Every attribute name the compiler resolved for this element.
+   *
+   * The authority on what the component accepts. Reading declarations
+   * syntactically can pick up members of a surrounding type map — MUI's
+   * OverridableTypeMap contributes `props` and `defaultComponent`, neither of
+   * which is a prop — and a catalog that lists those while claiming the list
+   * is COMPLETE is visibly wrong to anyone who knows the library.
+   */
+  resolvedNames: string[];
+  /**
    * `closed` — the compiler resolved a definite set, so anything outside it is
    * rejected. `open` — an index signature admits any prop. `unknown` — the
    * type resolved to any, or to nothing at all, which is what a type-only or
@@ -457,6 +467,7 @@ export function resolvePropsWithChecker(opts: {
     components.push({
       name,
       kind,
+      resolvedNames: [...r.symbols.keys()],
       ...(members?.length ? { members } : {}),
       own,
       total: r.symbols.size,

--- a/story-generator/knowledge/propExtractor.ts
+++ b/story-generator/knowledge/propExtractor.ts
@@ -1733,6 +1733,20 @@ async function readOnePackage(
           const prior = components[component.name];
           if (prior && prior.props.length) {
             const before = prior.props.length;
+            /**
+             * Where the compiler resolved a definite set, it is the authority.
+             *
+             * Reading declarations syntactically can pick up members of a
+             * surrounding type map: MUI's OverridableTypeMap contributes
+             * `props` and `defaultComponent`, and the catalog listed both for
+             * Stack while claiming the list was COMPLETE. A list that is
+             * visibly wrong is worse than a shorter one — a model that knows
+             * the library will trust its own memory over it.
+             */
+            if (component.verdict === 'closed' && component.resolvedNames.length) {
+              const real = new Set(component.resolvedNames);
+              prior.props = prior.props.filter(p => real.has(p.name));
+            }
             prior.props = mergeProps(prior.props, component.own);
             Object.assign(prior, closed);
             if (prior.props.length > before) filled++;


### PR DESCRIPTION

Reading the catalog entry the model actually receives — rather than the flag
that produces it — showed the completeness claim shipping alongside two props
that do not exist:

  Props — this is the COMPLETE list ... defaultComponent (RootComponent),
  props (AdditionalProps & StackOwnProps)

Neither is a prop of Stack. Both are members of MUI's OverridableTypeMap,
picked up by reading declarations syntactically. So the catalog asserted a list
was complete while that list was visibly wrong to anyone who knows the library
— and the one thing a model with a strong prior will not do is trust a source
it can see is wrong.

Where type resolution returned a definite set, that set is now the authority:
a syntactically-read prop the compiler does not resolve for the element is
dropped. MUI's Stack goes from ten entries to seven — children, classes,
direction, divider, spacing, sx, useFlexGap — which is exactly its API, and
the completeness claim becomes true.

Applied only where the verdict is closed, so nothing is dropped on a component
whose type the compiler could not pin down. Verified across fourteen
environments: no environment lost a component, and prop documentation held
(MUI 91%, Carbon 95%, Atlassian 89%).

This is the fifth intervention on MUI's undeclared-prop count and the first
that changes the DATA rather than the wording. Whether it moves the number is
the next measurement.



https://claude.ai/code/session_0158a8zxX4SKPdxm7DLfgqp4
