### PR TITLE
fix(generator): let a gate retry correct the previous attempt

### DIFF
--- a/__tests__/loader-failure.test.ts
+++ b/__tests__/loader-failure.test.ts
@@ -129,3 +129,29 @@ describe('the prompt bounds scope instead of encouraging it', () => {
     expect(text).not.toMatch(/src=["']https:\/\/picsum/);
   });
 });
+
+describe('a gate retry corrects the previous attempt', () => {
+  it('treats the carried code as context, not as an edit to police', async () => {
+    /**
+     * The gate used to send only the findings, so a second attempt regenerated
+     * the whole story from the prompt — eight thousand tokens — and discarded
+     * whatever the repair pass had already improved.
+     *
+     * Carrying the previous code turns that into a correction. It must NOT
+     * turn on the edit-divergence guard: that guard exists to stop a
+     * conversational edit rewriting a page, and a gate retry is sometimes
+     * required to restructure precisely because the previous structure failed
+     * verification. Blocking it would leave the retry unable to make the fix
+     * it exists to make.
+     */
+    const source = await import('fs').then(fs =>
+      fs.readFileSync(new URL('../mcp-server/routes/generationCore.ts', import.meta.url), 'utf8'));
+    // The gate hands its attempt's code to the next one.
+    expect(source).toContain('gatePreviousCode: result.code');
+    // It becomes the baseline the prompt describes...
+    expect(source).toContain('previousCode = request.gatePreviousCode');
+    // ...and the divergence guard stands down for it, as it does for a
+    // placeholder baseline.
+    expect(source).toContain('!previousCodeIsFallback && !previousCodeIsGateRetry');
+  });
+});

--- a/mcp-server/routes/generationCore.ts
+++ b/mcp-server/routes/generationCore.ts
@@ -182,6 +182,18 @@ export interface GenerationRequest {
    * a "v2" beside the failed one.
    */
   regenerateOf?: { fileName: string; title: string; hash: string };
+  /**
+   * The code the previous gate attempt produced, carried into the retry.
+   *
+   * The gate used to send only the findings, so a second attempt regenerated
+   * the whole story from the prompt — eight thousand tokens — and discarded
+   * whatever the repair pass had already improved. With the previous code in
+   * hand the model can correct it instead of rebuilding it.
+   *
+   * It is CONTEXT, not an edit baseline: a retry is allowed to restructure,
+   * so the edit-divergence guard does not apply to it.
+   */
+  gatePreviousCode?: string;
 }
 
 export interface GenerationEvents {
@@ -365,6 +377,7 @@ async function runGatedGeneration(
       gateFeedback: gateFeedback(verdict),
       gateAttempt: attempt + 1,
       regenerateOf: { fileName: result.fileName, title: result.title, hash },
+      gatePreviousCode: result.code,
     };
     events.onProgress?.(11, 12, 'gate_retry',
       `Attempt ${attempt} failed verification (${verdict.reason.slice(0, 80)}) — generating again with the findings`);
@@ -996,6 +1009,8 @@ async function runStoryGenerationPipeline(
    * guard is skipped for exactly this baseline.
    */
   let previousCodeIsFallback = false;
+  /** The baseline is the last gate attempt: context for a correction, not an edit to police. */
+  let previousCodeIsGateRetry = false;
   /**
    * Props the user set by hand on this story. Told to the model, and
    * re-applied to whatever it returns — the model rewrites props as a matter
@@ -1063,6 +1078,11 @@ async function runStoryGenerationPipeline(
       logger.log(`📄 History had no version for ${fileName}; using the file on disk as the base for this edit`);
     }
 
+    if (!previousCode && request.gatePreviousCode) {
+      previousCode = request.gatePreviousCode;
+      previousCodeIsGateRetry = true;
+      logger.log('📄 Gate retry: correcting the previous attempt rather than regenerating from scratch');
+    }
     if (previousCode && isFallbackStoryCode(previousCode)) {
       previousCodeIsFallback = true;
       logger.log(
@@ -1463,7 +1483,7 @@ async function runStoryGenerationPipeline(
     // prop tweaks score well under 0.4.
     const CONVERSATIONAL_UPDATE_DIVERGENCE_LIMIT = 0.6;
     const editErrors: string[] = [];
-    if (previousCode && !previousCodeIsFallback) {
+    if (previousCode && !previousCodeIsFallback && !previousCodeIsGateRetry) {
       const { divergence, before, after } = editDivergence(previousCode, aiText);
       const limit = selection ? TARGETED_EDIT_DIVERGENCE_LIMIT : CONVERSATIONAL_UPDATE_DIVERGENCE_LIMIT;
       if (divergence > limit) {


### PR DESCRIPTION

When verification found a blocker the gate sent the findings and nothing else,
so the second attempt regenerated the whole story from the prompt — around
eight thousand tokens — and discarded whatever the repair pass had already
improved. The cause was small: a retry request carries regenerateOf but not
fileName, so the pipeline never classified it as having a baseline and
previousCode stayed undefined.

The retry now carries the attempt's code. The model sees what it produced, the
measurements that failed, and the full catalog, and can correct rather than
rebuild.

The code is CONTEXT, not an edit baseline. The edit-divergence guard exists to
stop a conversational edit quietly rewriting a page, and a gate retry is
sometimes required to restructure precisely because the previous structure
failed verification — so that guard stands down here, exactly as it already
does when the baseline is the placeholder a failed generation wrote.

Held back until now because the risk sat in the path that currently ships zero
stories with issues across three consecutive runs. Measuring both numbers
together: the tail, and that 0/20 still holds.



https://claude.ai/code/session_0158a8zxX4SKPdxm7DLfgqp4
